### PR TITLE
SRC-2 Change "Panic" to "Revert" terminology

### DIFF
--- a/standards/src_2/README.md
+++ b/standards/src_2/README.md
@@ -69,14 +69,14 @@ Example:
 /// * [u64] - The number of hashes performed.
 ```
 
-#### - Panics
+#### - Reverts
 
 This section has a `h1` header.
-Lists the cases in which the function will panic starting with the `*` symbol. The list SHALL be in the order of occurrence within the function.
+Lists the cases in which the function will revert starting with the `*` symbol. The list SHALL be in the order of occurrence within the function.
 Example:
 
 ```rust
-/// # Panics
+/// # Reverts
 ///
 /// * When `argument_1` or `argument_2` are a zero [b256].
 ```
@@ -306,7 +306,7 @@ This standard will improve security by providing developers with relevant inform
 ///
 /// * [bool] - Determines whether `number` is or is not 5.
 ///
-/// # Panics
+/// # Reverts
 ///
 /// * When the sender is not the owner.
 ///


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Other (describe below)

## Changes

The following changes have been made:

- Changing the inline documentation title from "Panic" to "Revert" to move away from Rust conventions.
