### PR TITLE
Bump standards to forc v0.44

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.68.2
-  FORC_VERSION: 0.38.0
-  CORE_VERSION: 0.17.11
+  FORC_VERSION: 0.44.0
+  CORE_VERSION: 0.20.3
   PATH_TO_SCRIPTS: .github/scripts
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ use standard::src_20;
 > **NOTE** The SRC-20 standard is currently in draft. This cannot be imported until the standard is finalized. You may implement your own abi using the standard in order to prepare for the standard's release.
 
 > **Note**
-> All standards currently use `forc v0.38.0`.
+> All standards currently use `forc v0.44.0`.
 
 <!-- TODO:
 ## Contributing


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updated the repo to use forc v0.44 and fuel-core v0.20.3

## Notes

- Required for #13 
