### PR TITLE
Update SRC-5 Ownership standard file  to meet SRC-2 Inline Docs Standard

### DIFF
--- a/standards/src_5/src/src_5.sw
+++ b/standards/src_5/src/src_5.sw
@@ -38,15 +38,19 @@ pub struct Ownership {
 abi SRC_5 {
     /// Returns the owner.
     ///
-    /// ### Return Values
+    /// # Return Values
     ///
     /// * [State] - Represents the state of ownership for this contract.
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// fn foo() {
-    ///     let stored_owner = owner();
+    ///     match owner() {
+    ///         State::Uninitalized => log("The ownership is uninitalized"),
+    ///         State::Initialized(owner) => log("The ownership is initalized"),
+    ///         State::Revoked => log("The ownership is revoked"),
+    ///     }
     /// }
     /// ```
     #[storage(read)]


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- The inline documentation of the SRC-5 Ownership standard has been updated to meet the SRC-2 standard for inline documentation
