### PR TITLE
Update to use forc v0.46.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.68.2
-  FORC_VERSION: 0.44.0
+  RUST_VERSION: 1.71.1
+  FORC_VERSION: 0.46.0
   CORE_VERSION: 0.20.3
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.44.0" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.44.0-orange" />
+    <a href="https://crates.io/crates/forc/0.46.0" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.46.0-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-standards" />
@@ -63,7 +63,7 @@ use src_20::SRC20;
 ```
 
 > **Note**
-> All standards currently use `forc v0.44.0`.
+> All standards currently use `forc v0.46.0`.
 
 <!-- TODO:
 ## Contributing


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates CI to use forc v0.46.0

## Notes

- While this isn't required for any existing standards to compile but is required for SRC-7.
