### PR TITLE
Add SRC-5 Basic examples

### DIFF
--- a/examples/Forc.toml
+++ b/examples/Forc.toml
@@ -1,2 +1,7 @@
 [workspace]
-members = ["src_5/initialized_example", "src_5/uninitialized_example", "src_20/single_asset", "src_20/multi_asset"]
+members = [
+  "src_5/initialized_example",
+  "src_5/uninitialized_example",
+  "src_20/single_asset",
+  "src_20/multi_asset",
+]

--- a/examples/Forc.toml
+++ b/examples/Forc.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["src_20/single_asset", "src_20/multi_asset"]
+members = ["src_5/initialized_example", "src_5/uninitialized_example", "src_20/single_asset", "src_20/multi_asset"]

--- a/examples/src_5/initialized_example/Forc.toml
+++ b/examples/src_5/initialized_example/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "initialized_example.sw"
+license = "Apache-2.0"
+name = "initialized_src5_example"
+
+[dependencies]
+src_5 = { path = "../../../standards/src_5" }

--- a/examples/src_5/initialized_example/src/initialized_example.sw
+++ b/examples/src_5/initialized_example/src/initialized_example.sw
@@ -4,15 +4,40 @@ use src_5::{SRC_5, Ownership, State};
 use std::constants::ZERO_B256;
 
 configurable { 
-    // Replace ZERO_B256 with your address
+    /// The owner of this contract at deployment.
     INITIAL_OWNER: Identity = Identity::Address(Address::from(ZERO_B256)),
 }
 
 storage {
+    /// The owner in storage.
     owner: Ownership = Ownership { state: State::Initialized(INITIAL_OWNER) },
 }
 
 impl SRC_5 for Contract {
+    /// Returns the owner.
+    ///
+    /// # Return Values
+    ///
+    /// * [State] - Represents the state of ownership for this contract.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src_5::SRC_5;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let ownership_abi = abi(contract_id, SRC_5);
+    /// 
+    ///     match ownership_abi.owner() {
+    ///         State::Initialized(owner) => log("The ownership is initalized"),
+    ///         _ => log("This example will never reach this statement"),
+    ///     }
+    /// }
+    /// ```
     #[storage(read)]
     fn owner() -> State {
         storage.owner.read().state

--- a/examples/src_5/initialized_example/src/initialized_example.sw
+++ b/examples/src_5/initialized_example/src/initialized_example.sw
@@ -1,16 +1,18 @@
 contract;
 
-use src_5::{SRC_5, Ownership, State};
+use src_5::{Ownership, SRC_5, State};
 use std::constants::ZERO_B256;
 
-configurable { 
+configurable {
     /// The owner of this contract at deployment.
     INITIAL_OWNER: Identity = Identity::Address(Address::from(ZERO_B256)),
 }
 
 storage {
     /// The owner in storage.
-    owner: Ownership = Ownership { state: State::Initialized(INITIAL_OWNER) },
+    owner: Ownership = Ownership {
+        state: State::Initialized(INITIAL_OWNER),
+    },
 }
 
 impl SRC_5 for Contract {
@@ -31,7 +33,7 @@ impl SRC_5 for Contract {
     ///
     /// fn foo(contract_id: ContractId) {
     ///     let ownership_abi = abi(contract_id, SRC_5);
-    /// 
+    ///
     ///     match ownership_abi.owner() {
     ///         State::Initialized(owner) => log("The ownership is initalized"),
     ///         _ => log("This example will never reach this statement"),

--- a/examples/src_5/initialized_example/src/initialized_example.sw
+++ b/examples/src_5/initialized_example/src/initialized_example.sw
@@ -1,0 +1,20 @@
+contract;
+
+use src_5::{SRC_5, Ownership, State};
+use std::constants::ZERO_B256;
+
+configurable { 
+    // Replace ZERO_B256 with your address
+    INITIAL_OWNER: Identity = Identity::Address(Address::from(ZERO_B256)),
+}
+
+storage {
+    owner: Ownership = Ownership { state: State::Initialized(INITIAL_OWNER) },
+}
+
+impl SRC_5 for Contract {
+    #[storage(read)]
+    fn owner() -> State {
+        storage.owner.read().state
+    }
+}

--- a/examples/src_5/uninitialized_example/Forc.toml
+++ b/examples/src_5/uninitialized_example/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "uninitialized_example.sw"
+license = "Apache-2.0"
+name = "uninitialized_src5_example"
+
+[dependencies]
+src_5 = { path = "../../../standards/src_5" }

--- a/examples/src_5/uninitialized_example/src/uninitialized_example.sw
+++ b/examples/src_5/uninitialized_example/src/uninitialized_example.sw
@@ -1,11 +1,11 @@
 contract;
 
-use src_5::{SRC_5, Ownership, State};
+use src_5::{Ownership, SRC_5, State};
 
 storage {
     /// The owner in storage.
-    owner: Ownership = Ownership { 
-        state: State::Uninitialized
+    owner: Ownership = Ownership {
+        state: State::Uninitialized,
     },
 }
 
@@ -27,7 +27,7 @@ impl SRC_5 for Contract {
     ///
     /// fn foo(contract_id: ContractId) {
     ///     let ownership_abi = abi(contract_id, SRC_5);
-    /// 
+    ///
     ///     match ownership_abi.owner() {
     ///         State::Uninitalized => log("The ownership is uninitalized"),
     ///         _ => log("This example will never reach this statement"),

--- a/examples/src_5/uninitialized_example/src/uninitialized_example.sw
+++ b/examples/src_5/uninitialized_example/src/uninitialized_example.sw
@@ -1,0 +1,16 @@
+contract;
+
+use src_5::{SRC_5, Ownership, State};
+
+storage {
+    owner: Ownership = Ownership { 
+        state: State::Uninitialized
+    },
+}
+
+impl SRC_5 for Contract {
+    #[storage(read)]
+    fn owner() -> State {
+        storage.owner.read().state
+    }
+}

--- a/examples/src_5/uninitialized_example/src/uninitialized_example.sw
+++ b/examples/src_5/uninitialized_example/src/uninitialized_example.sw
@@ -3,12 +3,37 @@ contract;
 use src_5::{SRC_5, Ownership, State};
 
 storage {
+    /// The owner in storage.
     owner: Ownership = Ownership { 
         state: State::Uninitialized
     },
 }
 
 impl SRC_5 for Contract {
+    /// Returns the owner.
+    ///
+    /// # Return Values
+    ///
+    /// * [State] - Represents the state of ownership for this contract.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src_5::SRC_5;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let ownership_abi = abi(contract_id, SRC_5);
+    /// 
+    ///     match ownership_abi.owner() {
+    ///         State::Uninitalized => log("The ownership is uninitalized"),
+    ///         _ => log("This example will never reach this statement"),
+    ///     }
+    /// }
+    /// ```
     #[storage(read)]
     fn owner() -> State {
         storage.owner.read().state


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature
- Documentation

## Changes

The following changes have been made:

- Adds an example of the SRC-5 standard implemented in the `Initialized` state
- Adds an example of the SRC-5 standard implemented in the `Uninitialized` state

## Related Issues

Completes SRC-5 task of #31 
