### PR TITLE
Add SRC3 Examples to workspace

### DIFF
--- a/examples/Forc.toml
+++ b/examples/Forc.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+  "src_3/single_asset",
+  "src_3/multi_asset",
   "src_5/initialized_example",
   "src_5/uninitialized_example",
   "src_20/single_asset",


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix

## Changes

The following changes have been made:

- SRC-3 example is missing from the examples workspace file.
