### PR TITLE
Remove `Ownerhship` struct and change `SRC_5` abi to `SRC5` 

### DIFF
--- a/examples/src_5/initialized_example/src/initialized_example.sw
+++ b/examples/src_5/initialized_example/src/initialized_example.sw
@@ -1,6 +1,6 @@
 contract;
 
-use src_5::{Ownership, SRC_5, State};
+use src_5::{SRC5, State};
 use std::constants::ZERO_B256;
 
 configurable {
@@ -10,12 +10,10 @@ configurable {
 
 storage {
     /// The owner in storage.
-    owner: Ownership = Ownership {
-        state: State::Initialized(INITIAL_OWNER),
-    },
+    owner: State = State::Initialized(INITIAL_OWNER),
 }
 
-impl SRC_5 for Contract {
+impl SRC5 for Contract {
     /// Returns the owner.
     ///
     /// # Return Values
@@ -42,6 +40,6 @@ impl SRC_5 for Contract {
     /// ```
     #[storage(read)]
     fn owner() -> State {
-        storage.owner.read().state
+        storage.owner.read()
     }
 }

--- a/examples/src_5/uninitialized_example/src/uninitialized_example.sw
+++ b/examples/src_5/uninitialized_example/src/uninitialized_example.sw
@@ -1,15 +1,13 @@
 contract;
 
-use src_5::{Ownership, SRC_5, State};
+use src_5::{SRC5, State};
 
 storage {
     /// The owner in storage.
-    owner: Ownership = Ownership {
-        state: State::Uninitialized,
-    },
+    owner: State = State::Uninitialized,
 }
 
-impl SRC_5 for Contract {
+impl SRC5 for Contract {
     /// Returns the owner.
     ///
     /// # Return Values
@@ -36,6 +34,6 @@ impl SRC_5 for Contract {
     /// ```
     #[storage(read)]
     fn owner() -> State {
-        storage.owner.read().state
+        storage.owner.read()
     }
 }

--- a/standards/src_5/README.md
+++ b/standards/src_5/README.md
@@ -81,7 +81,7 @@ use std::constants::ZERO_B256;
 use standards::src_5::*;
 
 storage {
-    owner: Ownership = Ownership::initialized(Identity::Address(Address::from(ZERO_B256))),
+    owner: State = Identity::Address(Address::from(ZERO_B256)),
 }
 
 impl SRC_5 for MyContract {

--- a/standards/src_5/src/src_5.sw
+++ b/standards/src_5/src/src_5.sw
@@ -29,13 +29,7 @@ pub enum AccessError {
     NotOwner: (),
 }
 
-/// Contains the ownership state.
-pub struct Ownership {
-    /// Represents the state of ownership.
-    state: State,
-}
-
-abi SRC_5 {
+abi SRC5 {
     /// Returns the owner.
     ///
     /// # Return Values


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- The abi `SRC_5` has been changed to `SRC5` to follow the same syntax as all other standards.
- The `Ownership` struct has been removed. This is NOT part of the standard and should be left for self-implementation in either a library or by the developer. As a result, the following changes have been made in the examples:
```sway
storage {
    /// The owner in storage.
    owner: Ownership = Ownership {
        state: State::Initialized(INITIAL_OWNER),
    },
}
```
Is now 
```sway
storage {
    /// The owner in storage.
    owner: State = State::Initialized(INITIAL_OWNER),
}
```

## Notes

- This is a breaking change to any implementations that use the `Ownership` struct, but the underlying standard remains the same.