### PR TITLE
docs: Removing tags in readme until fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you don't find what you're looking for, feel free to create an issue and prop
 To import a standard the following should be added to the project's `Forc.toml` file under `[dependencies]` with the most recent release:
 
 ```rust
-standard = { git = "https://github.com/FuelLabs/sway-standards" }
+standard = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.0" }
 ```
 
 You may then import your desired standard in your Sway Smart Contract as so:
@@ -57,7 +57,7 @@ use standard::<standard_abi>;
 For example, to import the SRC-20 Token Standard use the following statements in your `Forc.toml` and Sway Smart Contract file respectively:
 
 ```rust
-src20 = { git = "https://github.com/FuelLabs/sway-standards" }
+src20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.3.0"}
 ```
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you don't find what you're looking for, feel free to create an issue and prop
 To import a standard the following should be added to the project's `Forc.toml` file under `[dependencies]` with the most recent release:
 
 ```rust
-standard = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.0" }
+standard = { git = "https://github.com/FuelLabs/sway-standards" }
 ```
 
 You may then import your desired standard in your Sway Smart Contract as so:
@@ -57,7 +57,7 @@ use standard::<standard_abi>;
 For example, to import the SRC-20 Token Standard use the following statements in your `Forc.toml` and Sway Smart Contract file respectively:
 
 ```rust
-src20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.1" }
+src20 = { git = "https://github.com/FuelLabs/sway-standards" }
 ```
 
 ```rust


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

Removing tags in the readme until fix

## Notes

Issue reported in the forum post [here](https://forum.fuel.network/t/sway-token-standarts-documentation/3896)

## Related Issues

Closes #49
