### PR TITLE
hotfix: Add `#[payable]` attribute to vault `deposit()` and `withdraw()` functions

### DIFF
--- a/examples/src6-vault/multi_token_vault/src/main.sw
+++ b/examples/src6-vault/multi_token_vault/src/main.sw
@@ -40,6 +40,7 @@ storage {
 }
 
 impl SRC6 for Contract {
+    #[payable]
     #[storage(read, write)]
     fn deposit(receiver: Identity, vault_sub_id: SubId) -> u64 {
         let asset_amount = msg_amount();
@@ -76,6 +77,7 @@ impl SRC6 for Contract {
         shares
     }
 
+    #[payable]
     #[storage(read, write)]
     fn withdraw(
         receiver: Identity,

--- a/examples/src6-vault/single_token_single_sub_vault/src/main.sw
+++ b/examples/src6-vault/single_token_single_sub_vault/src/main.sw
@@ -37,6 +37,7 @@ storage {
 }
 
 impl SRC6 for Contract {
+    #[payable]
     #[storage(read, write)]
     fn deposit(receiver: Identity, vault_sub_id: SubId) -> u64 {
         require(vault_sub_id == ACCEPTED_SUB_VAULT, "INVALID_vault_sub_id");
@@ -69,6 +70,7 @@ impl SRC6 for Contract {
         shares
     }
 
+    #[payable]
     #[storage(read, write)]
     fn withdraw(
         receiver: Identity,

--- a/examples/src6-vault/single_token_vault/src/main.sw
+++ b/examples/src6-vault/single_token_vault/src/main.sw
@@ -46,6 +46,7 @@ configurable {
 }
 
 impl SRC6 for Contract {
+    #[payable]
     #[storage(read, write)]
     fn deposit(receiver: Identity, vault_sub_id: SubId) -> u64 {
         let asset_amount = msg_amount();
@@ -83,6 +84,7 @@ impl SRC6 for Contract {
         shares
     }
 
+    #[payable]
     #[storage(read, write)]
     fn withdraw(
         receiver: Identity,

--- a/standards/src6-vault/README.md
+++ b/standards/src6-vault/README.md
@@ -153,9 +153,11 @@ Incorrect implementation of token vaults could allow attackers to steal underlyi
 
 ```sway
 abi SRC6 {
+    #[payable]
     #[storage(read, write)]
     fn deposit(receiver: Identity, vault_sub_id: SubId) -> u64;
 
+    #[payable]
     #[storage(read, write)]
     fn withdraw(receiver: Identity, underlying_asset: AssetId, vault_sub_id: SubId) -> u64;
 

--- a/standards/src6-vault/src/src6.sw
+++ b/standards/src6-vault/src/src6.sw
@@ -53,6 +53,7 @@ abi SRC6 {
     /// * If the asset is not supported by the contract.
     /// * If the amount of assets forwarded to the contract is zero.
     /// * The user crosses any global or user specific deposit limits.
+    #[payable]
     #[storage(read, write)]
     fn deposit(receiver: Identity, vault_sub_id: SubId) -> u64;
 
@@ -78,6 +79,7 @@ abi SRC6 {
     /// * If the amount of shares is zero.
     /// * If the transferred shares do not corresspond to the given asset.
     /// * The user crosses any global or user specific withdrawal limits.
+    #[payable]
     #[storage(read, write)]
     fn withdraw(
         receiver: Identity,


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix

## Changes

The following changes have been made:

- Added the `#[payable]` attribute to the vault's `deposit()` and `withdraw()` functions

## Notes

- The `SRC6` abi does not currently allow for the SRC-6 Standard implementation