### PR TITLE
Bump standards to forc v0.49.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.73.0
-  FORC_VERSION: 0.48.1
-  CORE_VERSION: 0.20.8
+  FORC_VERSION: 0.49.0
+  CORE_VERSION: 0.22.0
   PATH_TO_SCRIPTS: .github/scripts
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.73.0
-  FORC_VERSION: 0.49.0
+  FORC_VERSION: 0.49.1
   CORE_VERSION: 0.22.0
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.48.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.48.1-orange" />
+    <a href="https://crates.io/crates/forc/0.49.0" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.49.0-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-standards" />
@@ -71,7 +71,7 @@ use standard::<standard_abi>;
 For example, to import the SRC-20 Native Asset Standard use the following statements in your `Forc.toml` and Sway Smart Contract file respectively:
 
 ```rust
-src20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.3.0" }
+src20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.0" }
 ```
 
 ```rust
@@ -137,7 +137,7 @@ Example of the SRC-7 implementation where metadata exists for only a single asse
 Example of the SRC-7 implementation where metadata exists for multiple assets with differing `SubId`s.
 
 > **Note**
-> All standards currently use `forc v0.48.1`.
+> All standards currently use `forc v0.49.0`.
 
 <!-- TODO:
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.49.0" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.49.0-orange" />
+    <a href="https://crates.io/crates/forc/0.49.1" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.49.1-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-standards" />
@@ -137,7 +137,7 @@ Example of the SRC-7 implementation where metadata exists for only a single asse
 Example of the SRC-7 implementation where metadata exists for multiple assets with differing `SubId`s.
 
 > **Note**
-> All standards currently use `forc v0.49.0`.
+> All standards currently use `forc v0.49.1`.
 
 <!-- TODO:
 ## Contributing

--- a/examples/src3-mint-burn/multi_asset/src/multi_asset.sw
+++ b/examples/src3-mint-burn/multi_asset/src/multi_asset.sw
@@ -3,6 +3,10 @@ contract;
 use src3::SRC3;
 use src20::SRC20;
 use std::{
+    asset::{
+        burn,
+        mint_to,
+    },
     call_frames::{
         contract_id,
         msg_asset_id,
@@ -11,10 +15,6 @@ use std::{
     hash::Hash,
     storage::storage_string::*,
     string::String,
-    token::{
-        burn,
-        mint_to,
-    },
 };
 
 // In this example, all assets minted from this contract have the same decimals, name, and symbol
@@ -67,9 +67,7 @@ impl SRC3 for Contract {
         let asset_supply = storage.total_supply.get(asset_id).try_read();
         match asset_supply {
             None => {
-                storage
-                    .total_assets
-                    .write(storage.total_assets.read() + 1)
+                storage.total_assets.write(storage.total_assets.read() + 1)
             },
             _ => {},
         }

--- a/examples/src3-mint-burn/single_asset/src/single_asset.sw
+++ b/examples/src3-mint-burn/single_asset/src/single_asset.sw
@@ -3,6 +3,10 @@ contract;
 use src3::SRC3;
 use src20::SRC20;
 use std::{
+    asset::{
+        burn,
+        mint_to,
+    },
     call_frames::{
         contract_id,
         msg_asset_id,
@@ -10,10 +14,6 @@ use std::{
     constants::DEFAULT_SUB_ID,
     context::msg_amount,
     string::String,
-    token::{
-        burn,
-        mint_to,
-    },
 };
 
 configurable {

--- a/examples/src6-vault/multi_token_vault/src/main.sw
+++ b/examples/src6-vault/multi_token_vault/src/main.sw
@@ -61,8 +61,7 @@ impl SRC6 for Contract {
             );
 
         let mut vault_info = storage.vault_info.get(share_asset).read();
-        vault_info.managed_assets = vault_info
-            .managed_assets + asset_amount;
+        vault_info.managed_assets = vault_info.managed_assets + asset_amount;
         storage.vault_info.insert(share_asset, vault_info);
 
         log(Deposit {

--- a/examples/src6-vault/single_token_vault/src/main.sw
+++ b/examples/src6-vault/single_token_vault/src/main.sw
@@ -68,8 +68,7 @@ impl SRC6 for Contract {
             );
 
         let mut vault_info = storage.vault_info.get(share_asset).read();
-        vault_info.managed_assets = vault_info
-            .managed_assets + asset_amount;
+        vault_info.managed_assets = vault_info.managed_assets + asset_amount;
         storage.vault_info.insert(share_asset, vault_info);
 
         log(Deposit {


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Bumps Repository to forc v0.49.0 and fuel-core v0.22.0