### PR TITLE
Bump standards to forc v0.50

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.73.0
-  FORC_VERSION: 0.49.1
+  RUST_VERSION: 1.75.0
+  FORC_VERSION: 0.50.0
   CORE_VERSION: 0.22.0
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/standards/src10-native-bridge/src/src10.sw
+++ b/standards/src10-native-bridge/src/src10.sw
@@ -3,17 +3,17 @@ library;
 /// Enscapsultes metadata sent between the canonical chain and Fuel.
 struct MessageData {
     /// The number of tokens.
-    amount: b256,
+    pub amount: b256,
     /// The user's address on the canonical chain.
-    from: b256,
+    pub from: b256,
     /// The number of deposit messages.
-    len: u16,
+    pub len: u16,
     /// The bridging target destination on the Fuel chain.
-    to: Identity,
+    pub to: Identity,
     /// The bridged token's address on the canonical chain.
-    token_address: b256,
+    pub token_address: b256,
     /// The token's ID on the canonical chain.
-    token_id: b256,
+    pub token_id: b256,
 }
 
 abi SRC10 {

--- a/standards/src6-vault/src/src6.sw
+++ b/standards/src6-vault/src/src6.sw
@@ -3,33 +3,33 @@ library;
 /// Event logged when a deposit is made.
 pub struct Deposit {
     /// The caller of the deposit function.
-    caller: Identity,
+    pub caller: Identity,
     /// The receiver of the deposit.
-    receiver: Identity,
+    pub receiver: Identity,
     /// The asset being deposited.
-    underlying_asset: AssetId,
+    pub underlying_asset: AssetId,
     /// The SubId of the vault.
-    vault_sub_id: SubId,
+    pub vault_sub_id: SubId,
     /// The amount of assets being deposited.
-    deposited_amount: u64,
+    pub deposited_amount: u64,
     /// The amount of shares being minted.
-    minted_shares: u64,
+    pub minted_shares: u64,
 }
 
 /// Event logged when a withdrawal is made.
 pub struct Withdraw {
     /// The caller of the withdrawal function.
-    caller: Identity,
+    pub caller: Identity,
     /// The receiver of the withdrawal.
-    receiver: Identity,
+    pub receiver: Identity,
     /// The asset being withdrawn.
-    underlying_asset: AssetId,
+    pub underlying_asset: AssetId,
     /// The SubId of the vault.
-    vault_sub_id: SubId,
+    pub vault_sub_id: SubId,
     /// The amount of assets being withdrawn.
-    withdrawn_amount: u64,
+    pub withdrawn_amount: u64,
     /// The amount of shares being burned.
-    burned_shares: u64,
+    pub burned_shares: u64,
 }
 
 abi SRC6 {


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix

## Changes

The following changes have been made:

- Updates CI to forc v0.50.0
- Struct fields in the SRC-6 standard are now public
- Struct fields in the SRC-10 standard are now public

## Notes

- In some cases such as logging, private fields cannot be used.