### PR TITLE
Remove duplicate adjustment of total_supply in SRC6 examples

### DIFF
--- a/examples/src6-vault/multi_token_vault/src/main.sw
+++ b/examples/src6-vault/multi_token_vault/src/main.sw
@@ -50,15 +50,6 @@ impl SRC6 for Contract {
         let (shares, share_asset, share_asset_vault_sub_id) = preview_deposit(underlying_asset, vault_sub_id, asset_amount);
 
         _mint(receiver, share_asset, share_asset_vault_sub_id, shares);
-        storage
-            .total_supply
-            .insert(
-                share_asset,
-                storage
-                    .total_supply
-                    .get(share_asset)
-                    .read() + shares,
-            );
 
         let mut vault_info = storage.vault_info.get(share_asset).read();
         vault_info.managed_assets = vault_info.managed_assets + asset_amount;
@@ -92,15 +83,6 @@ impl SRC6 for Contract {
         let assets = preview_withdraw(share_asset_id, shares);
 
         _burn(share_asset_id, share_asset_vault_sub_id, shares);
-        storage
-            .total_supply
-            .insert(
-                share_asset_id,
-                storage
-                    .total_supply
-                    .get(share_asset_id)
-                    .read() - shares,
-            );
 
         transfer(receiver, underlying_asset, assets);
 

--- a/examples/src6-vault/single_token_single_sub_vault/src/main.sw
+++ b/examples/src6-vault/single_token_single_sub_vault/src/main.sw
@@ -50,9 +50,6 @@ impl SRC6 for Contract {
         let shares = preview_deposit(asset_amount);
 
         _mint(receiver, shares);
-        storage
-            .total_supply
-            .write(storage.total_supply.read() + shares);
 
         storage
             .managed_assets
@@ -89,9 +86,6 @@ impl SRC6 for Contract {
         let assets = preview_withdraw(shares);
 
         _burn(share_asset_id, shares);
-        storage
-            .total_supply
-            .write(storage.total_supply.read() - shares);
 
         transfer(receiver, underlying_asset, assets);
 
@@ -150,7 +144,11 @@ impl SRC20 for Contract {
 
     #[storage(read)]
     fn total_supply(asset: AssetId) -> Option<u64> {
-        Some(storage.total_supply.read())
+        if asset == vault_assetid() {
+            Some(storage.total_supply.read())
+        } else {
+            None
+        }
     }
 
     #[storage(read)]

--- a/examples/src6-vault/single_token_vault/src/main.sw
+++ b/examples/src6-vault/single_token_vault/src/main.sw
@@ -57,15 +57,6 @@ impl SRC6 for Contract {
         require(asset_amount != 0, "ZERO_ASSETS");
 
         _mint(receiver, share_asset, share_asset_vault_sub_id, shares);
-        storage
-            .total_supply
-            .insert(
-                share_asset,
-                storage
-                    .total_supply
-                    .get(share_asset)
-                    .read() + shares,
-            );
 
         let mut vault_info = storage.vault_info.get(share_asset).read();
         vault_info.managed_assets = vault_info.managed_assets + asset_amount;
@@ -99,16 +90,7 @@ impl SRC6 for Contract {
         let assets = preview_withdraw(share_asset_id, shares);
 
         _burn(share_asset_id, share_asset_vault_sub_id, shares);
-        storage
-            .total_supply
-            .insert(
-                share_asset_id,
-                storage
-                    .total_supply
-                    .get(share_asset_id)
-                    .read() - shares,
-            );
-
+        
         transfer(receiver, underlying_asset, assets);
 
         log(Withdraw {

--- a/examples/src6-vault/single_token_vault/src/main.sw
+++ b/examples/src6-vault/single_token_vault/src/main.sw
@@ -90,7 +90,7 @@ impl SRC6 for Contract {
         let assets = preview_withdraw(share_asset_id, shares);
 
         _burn(share_asset_id, share_asset_vault_sub_id, shares);
-        
+
         transfer(receiver, underlying_asset, assets);
 
         log(Withdraw {


### PR DESCRIPTION
## Type of change

- Bug fix

## Changes

The following changes have been made:

- Duplicate total supply adjustments have been removed from the src6 examples
- The return for the total supply in single token single subvault has been fixed to return None if the wrong assetid is passed in as the parameter.

## Notes

- Note 1

## Related Issues

Closes #60 

