### PR TITLE
Bump to forc v0.52.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.75.0
-  FORC_VERSION: 0.50.0
+  FORC_VERSION: 0.52.1
   CORE_VERSION: 0.22.0
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Example of the SRC-7 implementation where metadata exists for only a single asse
 Example of the SRC-7 implementation where metadata exists for multiple assets with differing `SubId`s.
 
 > **Note**
-> All standards currently use `forc v0.50.0`.
+> All standards currently use `forc v0.52.1`.
 
 <!-- TODO:
 ## Contributing


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Bumps the repo to the latest version of forc