### PR TITLE
Hotfix: Add payable attribute to SRC3 burn function

### DIFF
--- a/SRCs/src-3.md
+++ b/SRCs/src-3.md
@@ -56,7 +56,10 @@ The burn function may also introduce a security consideration if the total suppl
 
 ```rust
 abi MySRC3Asset {
+    #[storage(read, write)]
     fn mint(recipient: Identity, vault_sub_id: SubId, amount: u64);
+    #[payable]
+    #[storage(read, write)]
     fn burn(vault_sub_id: SubId, amount: u64);
 }
 ```

--- a/examples/src3-mint-burn/multi_asset/src/multi_asset.sw
+++ b/examples/src3-mint-burn/multi_asset/src/multi_asset.sw
@@ -110,6 +110,7 @@ impl SRC3 for Contract {
     ///     }.burn(DEFAULT_SUB_ID, 100);
     /// }
     /// ```
+    #[payable]
     #[storage(read, write)]
     fn burn(sub_id: SubId, amount: u64) {
         let asset_id = AssetId::new(contract_id(), sub_id);

--- a/examples/src3-mint-burn/single_asset/src/single_asset.sw
+++ b/examples/src3-mint-burn/single_asset/src/single_asset.sw
@@ -102,6 +102,7 @@ impl SRC3 for Contract {
     ///     }.burn(DEFAULT_SUB_ID, 100);
     /// }
     /// ```
+    #[payable]
     #[storage(read, write)]
     fn burn(sub_id: SubId, amount: u64) {
         require(sub_id == DEFAULT_SUB_ID, "Incorrect Sub Id");

--- a/standards/src/src3.sw
+++ b/standards/src/src3.sw
@@ -48,6 +48,7 @@ abi SRC3 {
     ///     }.burn(ZERO_B256, 100);
     /// }
     /// ```
+    #[payable]
     #[storage(read, write)]
     fn burn(vault_sub_id: SubId, amount: u64);
 }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix

## Changes

The following changes have been made:

- The `burn()` function on the SRC3 standard does not have the `#[payable]` attribute. This means any use of the SDK to call the burn function and forwarding assets will not work.