### PR TITLE
Update to forc v0.55.0, fuel-core v0.24.2, and Rust v1.77.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.75.0
-  FORC_VERSION: 0.53.0
-  CORE_VERSION: 0.23.0
+  RUST_VERSION: 1.77.2
+  FORC_VERSION: 0.55.0
+  CORE_VERSION: 0.24.2
   PATH_TO_SCRIPTS: .github/scripts
 
 jobs:

--- a/examples/src20-native-asset/single_asset/src/single_asset.sw
+++ b/examples/src20-native-asset/single_asset/src/single_asset.sw
@@ -1,7 +1,7 @@
 contract;
 
 use standards::src20::SRC20;
-use std::{call_frames::contract_id, string::String};
+use std::string::String;
 
 configurable {
     /// The total supply of coins for the asset minted by this contract.

--- a/examples/src3-mint-burn/multi_asset/src/multi_asset.sw
+++ b/examples/src3-mint-burn/multi_asset/src/multi_asset.sw
@@ -6,10 +6,7 @@ use std::{
         burn,
         mint_to,
     },
-    call_frames::{
-        contract_id,
-        msg_asset_id,
-    },
+    call_frames::msg_asset_id,
     context::msg_amount,
     hash::Hash,
     storage::storage_string::*,
@@ -60,7 +57,7 @@ impl SRC3 for Contract {
     /// ```
     #[storage(read, write)]
     fn mint(recipient: Identity, sub_id: SubId, amount: u64) {
-        let asset_id = AssetId::new(contract_id(), sub_id);
+        let asset_id = AssetId::new(ContractId::this(), sub_id);
 
         // If this SubId is new, increment the total number of distinguishable assets this contract has minted.
         let asset_supply = storage.total_supply.get(asset_id).try_read();
@@ -113,7 +110,7 @@ impl SRC3 for Contract {
     #[payable]
     #[storage(read, write)]
     fn burn(sub_id: SubId, amount: u64) {
-        let asset_id = AssetId::new(contract_id(), sub_id);
+        let asset_id = AssetId::new(ContractId::this(), sub_id);
         require(msg_amount() == amount, "Incorrect amount provided");
         require(msg_asset_id() == asset_id, "Incorrect asset provided");
 

--- a/examples/src3-mint-burn/single_asset/src/single_asset.sw
+++ b/examples/src3-mint-burn/single_asset/src/single_asset.sw
@@ -6,10 +6,7 @@ use std::{
         burn,
         mint_to,
     },
-    call_frames::{
-        contract_id,
-        msg_asset_id,
-    },
+    call_frames::msg_asset_id,
     constants::DEFAULT_SUB_ID,
     context::msg_amount,
     string::String,

--- a/examples/src6-vault/single_asset_single_sub_vault/src/main.sw
+++ b/examples/src6-vault/single_asset_single_sub_vault/src/main.sw
@@ -3,10 +3,7 @@ contract;
 use std::{
     asset::transfer,
     call_frames::msg_asset_id,
-    constants::{
-        BASE_ASSET_ID,
-        ZERO_B256,
-    },
+    constants::ZERO_B256,
     context::msg_amount,
     hash::{
         Hash,
@@ -19,8 +16,6 @@ use std::{
 use standards::{src20::SRC20, src6::{Deposit, SRC6, Withdraw}};
 
 configurable {
-    /// The only asset that can be deposited and withdrawn from this vault.
-    ACCEPTED_ASSET: AssetId = BASE_ASSET_ID,
     /// The only sub vault that can be deposited and withdrawn from this vault.
     ACCEPTED_SUB_VAULT: SubId = ZERO_B256,
     PRE_CALCULATED_SHARE_VAULT_SUB_ID: SubId = 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b,
@@ -42,7 +37,7 @@ impl SRC6 for Contract {
         require(vault_sub_id == ACCEPTED_SUB_VAULT, "INVALID_vault_sub_id");
 
         let underlying_asset = msg_asset_id();
-        require(underlying_asset == ACCEPTED_ASSET, "INVALID_ASSET_ID");
+        require(underlying_asset == AssetId::base(), "INVALID_ASSET_ID");
 
         let asset_amount = msg_amount();
         require(asset_amount != 0, "ZERO_ASSETS");
@@ -73,7 +68,7 @@ impl SRC6 for Contract {
         underlying_asset: AssetId,
         vault_sub_id: SubId,
     ) -> u64 {
-        require(underlying_asset == ACCEPTED_ASSET, "INVALID_ASSET_ID");
+        require(underlying_asset == AssetId::base(), "INVALID_ASSET_ID");
         require(vault_sub_id == ACCEPTED_SUB_VAULT, "INVALID_vault_sub_id");
 
         let shares = msg_amount();
@@ -102,7 +97,7 @@ impl SRC6 for Contract {
 
     #[storage(read)]
     fn managed_assets(underlying_asset: AssetId, vault_sub_id: SubId) -> u64 {
-        if underlying_asset == ACCEPTED_ASSET && vault_sub_id == ACCEPTED_SUB_VAULT {
+        if underlying_asset == AssetId::base() && vault_sub_id == ACCEPTED_SUB_VAULT {
             // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
             storage.managed_assets.read()
         } else {
@@ -116,7 +111,7 @@ impl SRC6 for Contract {
         underlying_asset: AssetId,
         vault_sub_id: SubId,
     ) -> Option<u64> {
-        if underlying_asset == ACCEPTED_ASSET {
+        if underlying_asset == AssetId::base() {
             // This is the max value of u64 minus the current managed_assets. Ensures that the sum will always be lower than u64::MAX.
             Some(u64::max() - storage.managed_assets.read())
         } else {
@@ -126,7 +121,7 @@ impl SRC6 for Contract {
 
     #[storage(read)]
     fn max_withdrawable(underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64> {
-        if underlying_asset == ACCEPTED_ASSET {
+        if underlying_asset == AssetId::base() {
             // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
             Some(storage.managed_assets.read())
         } else {

--- a/examples/src6-vault/single_asset_vault/src/main.sw
+++ b/examples/src6-vault/single_asset_vault/src/main.sw
@@ -3,7 +3,6 @@ contract;
 use std::{
     asset::transfer,
     call_frames::msg_asset_id,
-    constants::BASE_ASSET_ID,
     context::msg_amount,
     hash::{
         Hash,
@@ -39,11 +38,6 @@ storage {
     decimals: StorageMap<AssetId, u8> = StorageMap {},
 }
 
-configurable {
-    /// The only asset that can be deposited and withdrawn from this vault.
-    ACCEPTED_ASSET: AssetId = BASE_ASSET_ID,
-}
-
 impl SRC6 for Contract {
     #[payable]
     #[storage(read, write)]
@@ -51,7 +45,7 @@ impl SRC6 for Contract {
         let asset_amount = msg_amount();
         let underlying_asset = msg_asset_id();
 
-        require(underlying_asset == ACCEPTED_ASSET, "INVALID_ASSET_ID");
+        require(underlying_asset == AssetId::base(), "INVALID_ASSET_ID");
         let (shares, share_asset, share_asset_vault_sub_id) = preview_deposit(underlying_asset, vault_sub_id, asset_amount);
         require(asset_amount != 0, "ZERO_ASSETS");
 
@@ -106,7 +100,7 @@ impl SRC6 for Contract {
 
     #[storage(read)]
     fn managed_assets(underlying_asset: AssetId, vault_sub_id: SubId) -> u64 {
-        if underlying_asset == ACCEPTED_ASSET {
+        if underlying_asset == AssetId::base() {
             let vault_share_asset = vault_asset_id(underlying_asset, vault_sub_id).0;
             // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
             managed_assets(vault_share_asset)
@@ -121,7 +115,7 @@ impl SRC6 for Contract {
         underlying_asset: AssetId,
         vault_sub_id: SubId,
     ) -> Option<u64> {
-        if underlying_asset == ACCEPTED_ASSET {
+        if underlying_asset == AssetId::base() {
             // This is the max value of u64 minus the current managed_assets. Ensures that the sum will always be lower than u64::MAX.
             Some(u64::max() - managed_assets(underlying_asset))
         } else {
@@ -131,7 +125,7 @@ impl SRC6 for Contract {
 
     #[storage(read)]
     fn max_withdrawable(underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64> {
-        if underlying_asset == ACCEPTED_ASSET {
+        if underlying_asset == AssetId::base() {
             // In this implementation total_assets and max_withdrawable are the same. However in case of lending out of assets, total_assets should be greater than max_withdrawable.
             Some(managed_assets(underlying_asset))
         } else {

--- a/examples/src7-metadata/multi_asset/src/multi_asset.sw
+++ b/examples/src7-metadata/multi_asset/src/multi_asset.sw
@@ -2,7 +2,7 @@ contract;
 
 use standards::{src20::SRC20, src7::{Metadata, SRC7}};
 
-use std::{call_frames::contract_id, hash::Hash, storage::storage_string::*, string::String};
+use std::{hash::Hash, storage::storage_string::*, string::String};
 
 // In this example, all assets minted from this contract have the same decimals, name, and symbol
 configurable {

--- a/examples/src7-metadata/single_asset/src/single_asset.sw
+++ b/examples/src7-metadata/single_asset/src/single_asset.sw
@@ -2,7 +2,7 @@ contract;
 
 use standards::{src20::SRC20, src7::{Metadata, SRC7}};
 
-use std::{call_frames::contract_id, string::String};
+use std::string::String;
 
 configurable {
     /// The total supply of coins for the asset minted by this contract.


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates to the latest version of forc v0.55.0
- Updates to the latest version of fuel-core v0.24.2
- Updates to the latest version of Rust v1.77.2
- Removes `ACCEPTED_ASSET` configurable in favor of `AssetId::base()` in vault examples
