### PR TITLE
docs: improve SRC-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you don't find what you're looking for, feel free to create an issue and prop
 ### Native Assets
 
 - [SRC-20; Native Asset Standard](./SRCs/src-20.md) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
-- [SRC-3; Mint and Burn](./SRCs/src-3.md) is used to enable mint and burn functionality for Native Assets.
+- [SRC-3; Mint and Burn](./SRCs/src-3.md) is used to enable mint and burn functionality for fungible assets.
 - [SRC-7; Arbitrary Asset Metadata Standard](./SRCs/src-7.md) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
 - [SRC-9; Metadata Keys Standard](./SRCs/src-9.md) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
 - [SRC-6; Vault Standard](./SRCs/src-6.md) defines the implementation of a standard API for asset vaults developed in Sway.

--- a/SRCs/src-3.md
+++ b/SRCs/src-3.md
@@ -1,6 +1,6 @@
 # Abstract
 
-The following standard enables the minting and burning of native assets for any fungible assets within the Sway Language. It seeks to define mint and burn functions defined separately from the [SRC-20](./src-20.md) standard. Any contract that implements the SRC-3 standard MUST implement the [SRC-20](./src-20.md) standard.
+The following standard enables the minting and burning of native assets for any fungible assets within the Sway Language. It seeks to define mint and burn functions defined separately from the [SRC-20](./src-20.md) standard.
 
 # Motivation
 
@@ -16,27 +16,27 @@ Minting and burning were initially added to the [SRC-20](./src-20.md) standard.
 
 The following functions MUST be implemented to follow the SRC-3 standard:
 
-### `fn mint(recipient: Identity, vault_sub_id: SubId, amount: u64)`
+### `fn mint(recipient: Identity, sub_id: SubId, amount: u64)`
 
-This function MUST mint `amount` coins with sub-identifier `vault_sub_id` and transfer them to the `recipient`. 
+This function MUST mint `amount` coins with sub-identifier `sub_id` and transfer them to the `recipient`. 
 This function MAY contain arbitrary conditions for minting, and revert if those conditions are not met.
 
 ##### Arguments
 
 * `recipient` - The `Identity` to which the newly minted asset is transferred to.
-* `vault_sub_id` - The sub-identifier of the asset to mint.
+* `sub_id` - The sub-identifier of the asset to mint.
 * `amount` - The quantity of coins to mint.
 
-### `fn burn(vault_sub_id: SubId, amount: u64)`
+### `fn burn(sub_id: SubId, amount: u64)`
 
-This function MUST burn `amount` coins with the sub-identifier `vault_sub_id` and MUST ensure the `AssetId` of the asset is the sha-256 hash of `(ContractId, SubId)` for the implementing contract. 
+This function MUST burn `amount` coins with the sub-identifier `sub_id` and MUST ensure the `AssetId` of the asset is the sha-256 hash of `(ContractId, SubId)` for the implementing contract. 
 This function MUST ensure at least `amount` coins have been transferred to the implementing contract. 
 This function MUST update the total supply defined in the [SRC-20](./src-20.md) standard. 
 This function MAY contain arbitrary conditions for burning, and revert if those conditions are not met.
 
 ##### Arguments
 
-* `vault_sub_id` - The sub-identifier of the asset to burn.
+* `sub_id` - The sub-identifier of the asset to burn.
 * `amount` - The quantity of coins to burn.
 
 # Rationale
@@ -57,10 +57,10 @@ The burn function may also introduce a security consideration if the total suppl
 ```rust
 abi MySRC3Asset {
     #[storage(read, write)]
-    fn mint(recipient: Identity, vault_sub_id: SubId, amount: u64);
+    fn mint(recipient: Identity, sub_id: SubId, amount: u64);
     #[payable]
     #[storage(read, write)]
-    fn burn(vault_sub_id: SubId, amount: u64);
+    fn burn(sub_id: SubId, amount: u64);
 }
 ```
 


### PR DESCRIPTION
## Type of change

- Improvement

## Changes

Correct contradictory documentation about SRC-3.

## Notes

If SRC-3 has been separated from SRC-20 to allow for the minting and burning of all fungible assets, then it doesn't make sense to require SRC-3 implementors to also implement SRC-20.

Related: https://forum.fuel.network/t/understanding-src-3-mint-and-burn/5282