### PR TITLE
change vault_sub_id back to sub_id SRC-3

### DIFF
--- a/SRCs/src-3.md
+++ b/SRCs/src-3.md
@@ -16,27 +16,27 @@ Minting and burning were initially added to the [SRC-20](./src-20.md) standard.
 
 The following functions MUST be implemented to follow the SRC-3 standard:
 
-### `fn mint(recipient: Identity, vault_sub_id: SubId, amount: u64)`
+### `fn mint(recipient: Identity, sub_id: SubId, amount: u64)`
 
-This function MUST mint `amount` coins with sub-identifier `vault_sub_id` and transfer them to the `recipient`. 
+This function MUST mint `amount` coins with sub-identifier `sub_id` and transfer them to the `recipient`. 
 This function MAY contain arbitrary conditions for minting, and revert if those conditions are not met.
 
 ##### Arguments
 
 * `recipient` - The `Identity` to which the newly minted asset is transferred to.
-* `vault_sub_id` - The sub-identifier of the asset to mint.
+* `sub_id` - The sub-identifier of the asset to mint.
 * `amount` - The quantity of coins to mint.
 
-### `fn burn(vault_sub_id: SubId, amount: u64)`
+### `fn burn(sub_id: SubId, amount: u64)`
 
-This function MUST burn `amount` coins with the sub-identifier `vault_sub_id` and MUST ensure the `AssetId` of the asset is the sha-256 hash of `(ContractId, SubId)` for the implementing contract. 
+This function MUST burn `amount` coins with the sub-identifier `sub_id` and MUST ensure the `AssetId` of the asset is the sha-256 hash of `(ContractId, SubId)` for the implementing contract. 
 This function MUST ensure at least `amount` coins have been transferred to the implementing contract. 
 This function MUST update the total supply defined in the [SRC-20](./src-20.md) standard. 
 This function MAY contain arbitrary conditions for burning, and revert if those conditions are not met.
 
 ##### Arguments
 
-* `vault_sub_id` - The sub-identifier of the asset to burn.
+* `sub_id` - The sub-identifier of the asset to burn.
 * `amount` - The quantity of coins to burn.
 
 # Rationale
@@ -57,10 +57,10 @@ The burn function may also introduce a security consideration if the total suppl
 ```rust
 abi MySRC3Asset {
     #[storage(read, write)]
-    fn mint(recipient: Identity, vault_sub_id: SubId, amount: u64);
+    fn mint(recipient: Identity, sub_id: SubId, amount: u64);
     #[payable]
     #[storage(read, write)]
-    fn burn(vault_sub_id: SubId, amount: u64);
+    fn burn(sub_id: SubId, amount: u64);
 }
 ```
 

--- a/standards/src/src3.sw
+++ b/standards/src/src3.sw
@@ -1,12 +1,12 @@
 library;
 
 abi SRC3 {
-    /// Mints new assets using the `vault_sub_id` sub-identifier.
+    /// Mints new assets using the `sub_id` sub-identifier.
     ///
     /// # Arguments
     ///
     /// * `recipient`: [Identity] - The user to which the newly minted asset is transferred to.
-    /// * `vault_sub_id`: [SubId] - The sub-identifier of the newly minted asset.
+    /// * `sub_id`: [SubId] - The sub-identifier of the newly minted asset.
     /// * `amount`: [u64] - The quantity of coins to mint.
     ///
     /// # Examples
@@ -20,18 +20,18 @@ abi SRC3 {
     /// }
     /// ```
     #[storage(read, write)]
-    fn mint(recipient: Identity, vault_sub_id: SubId, amount: u64);
+    fn mint(recipient: Identity, sub_id: SubId, amount: u64);
 
-    /// Burns assets sent with the given `vault_sub_id`.
+    /// Burns assets sent with the given `sub_id`.
     ///
     /// # Additional Information
     ///
     /// NOTE: The sha-256 hash of `(ContractId, SubId)` must match the `AssetId` where `ContractId` is the id of
-    /// the implementing contract and `SubId` is the given `vault_sub_id` argument.
+    /// the implementing contract and `SubId` is the given `sub_id` argument.
     ///
     /// # Arguments
     ///
-    /// * `vault_sub_id`: [SubId] - The sub-identifier of the asset to burn.
+    /// * `sub_id`: [SubId] - The sub-identifier of the asset to burn.
     /// * `amount`: [u64] - The quantity of coins to burn.
     ///
     /// # Examples
@@ -50,5 +50,5 @@ abi SRC3 {
     /// ```
     #[payable]
     #[storage(read, write)]
-    fn burn(vault_sub_id: SubId, amount: u64);
+    fn burn(sub_id: SubId, amount: u64);
 }


### PR DESCRIPTION
## Type of change
- Bug fix
- Documentation


## Changes

The following changes have been made:

- All cases of `vault_sub_id` have been changed back to `sub_id`

## Notes

All instances of `sub_id` were changed to `vault_sub_id` in this commit, this was intended to be limited to the vault contract files but was accidentally applied to the src3 standard files aswell.
https://github.com/FuelLabs/sway-standards/commit/e34bf5646017a82819a78cf3c421ebebcf7f4219
Changes slipped through the reviews in https://github.com/FuelLabs/sway-standards/pull/24

