### PR TITLE
docs: improve SRC-20

### DIFF
--- a/SRCs/src-20.md
+++ b/SRCs/src-20.md
@@ -47,7 +47,7 @@ This function must return the symbol of the asset, such as “ETH”. This funct
 
 This function must return the number of decimals the asset uses - e.g. 8, which means to divide the coin amount by 100000000 to get its user representation. This function MUST return `Some` for any assets minted by the contract.
 
-## Non-Fungible Asset Restrictions 
+## Non-Fungible Asset Restrictions
 
 Non-Fungible Tokens (NFT) or Non-Fungible Assets on Fuel are Native Assets and thus follow the same standard as Fungible Native Assets with some restrictions. For a Native Asset on Fuel to be deemed an NFT, the following must be applied:
 
@@ -56,9 +56,9 @@ Non-Fungible Tokens (NFT) or Non-Fungible Assets on Fuel are Native Assets and t
 
 # Rationale
 
-As the SRC-20 Native Asset Standard leverages Native Assets on Fuel, we do not require the implementation of certain functions such as transfer or approval. This is done directly within the FuelVM and there is no smart contract that requires updating of balances. As Fuel is UTXO based, any transfer events may be indexed on transaction receipts. 
+As the SRC-20 Native Asset Standard leverages Native Assets on Fuel, we do not require the implementation of certain functions such as transfer or approval. This is done directly within the FuelVM and there is no smart contract that requires updating of balances. As Fuel is UTXO based, any transfer events may be indexed on transaction receipts.
 
-Following this, we have omitted the inclusion of any transfer functions or events. The provided specification outlines only the required functions and events to implement fully functional native assets on the Fuel Network. Additional functionality and properties may be added as needed.
+Following this, we have omitted the inclusion of any transfer functions or events. The provided specification outlines only the functions necessary to implement fully functional native assets on the Fuel Network. Additional functionality and properties may be added as needed.
 
 # Backwards Compatibility
 
@@ -87,7 +87,7 @@ abi MyAsset {
 
 # Example Implementation
 
-## [Single Native Assset](../examples/src20-native-asset/multi_asset/src/multi_asset.sw)
+## [Single Native Asset](../examples/src20-native-asset/multi_asset/src/multi_asset.sw)
 
 Example of the SRC-20 implementation where a contract contains a single asset with one `SubId`. This implementation is recommended for users that intend to deploy a single asset with their contract.
 


### PR DESCRIPTION
## Type of change

- Improvement

## Changes

The following changes have been made:

- Fix typo
- Remove extra whitespaces
- Remove the note about "events" because no events are defined in the SRC-20 standard