### PR TITLE
Bugfixes: struct syntax, ptr(), and base_asset_id() method usage

### DIFF
--- a/examples/src12-contract-factory/with_configurables/src/utils.sw
+++ b/examples/src12-contract-factory/with_configurables/src/utils.sw
@@ -119,6 +119,7 @@ pub fn _swap_configurables(
 
         // Overwrite the configurable data into the bytecode
         data
+            .buf
             .ptr()
             .copy_bytes_to(bytecode.ptr().add::<u8>(offset), data.len());
 

--- a/examples/src6-vault/single_asset_single_sub_vault/src/main.sw
+++ b/examples/src6-vault/single_asset_single_sub_vault/src/main.sw
@@ -37,7 +37,7 @@ impl SRC6 for Contract {
         require(vault_sub_id == ACCEPTED_SUB_VAULT, "INVALID_vault_sub_id");
 
         let underlying_asset = msg_asset_id();
-        require(underlying_asset == AssetId::base(), "INVALID_ASSET_ID");
+        require(underlying_asset == AssetId::base_asset_id(), "INVALID_ASSET_ID");
 
         let asset_amount = msg_amount();
         require(asset_amount != 0, "ZERO_ASSETS");
@@ -68,7 +68,7 @@ impl SRC6 for Contract {
         underlying_asset: AssetId,
         vault_sub_id: SubId,
     ) -> u64 {
-        require(underlying_asset == AssetId::base(), "INVALID_ASSET_ID");
+        require(underlying_asset == AssetId::base_asset_id(), "INVALID_ASSET_ID");
         require(vault_sub_id == ACCEPTED_SUB_VAULT, "INVALID_vault_sub_id");
 
         let shares = msg_amount();
@@ -97,7 +97,7 @@ impl SRC6 for Contract {
 
     #[storage(read)]
     fn managed_assets(underlying_asset: AssetId, vault_sub_id: SubId) -> u64 {
-        if underlying_asset == AssetId::base() && vault_sub_id == ACCEPTED_SUB_VAULT {
+        if underlying_asset == AssetId::base_asset_id() && vault_sub_id == ACCEPTED_SUB_VAULT {
             // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
             storage.managed_assets.read()
         } else {
@@ -111,7 +111,7 @@ impl SRC6 for Contract {
         underlying_asset: AssetId,
         vault_sub_id: SubId,
     ) -> Option<u64> {
-        if underlying_asset == AssetId::base() {
+        if underlying_asset == AssetId::base_asset_id() {
             // This is the max value of u64 minus the current managed_assets. Ensures that the sum will always be lower than u64::MAX.
             Some(u64::max() - storage.managed_assets.read())
         } else {
@@ -121,7 +121,7 @@ impl SRC6 for Contract {
 
     #[storage(read)]
     fn max_withdrawable(underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64> {
-        if underlying_asset == AssetId::base() {
+        if underlying_asset == AssetId::base_asset_id() {
             // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
             Some(storage.managed_assets.read())
         } else {

--- a/examples/src6-vault/single_asset_vault/src/main.sw
+++ b/examples/src6-vault/single_asset_vault/src/main.sw
@@ -45,7 +45,7 @@ impl SRC6 for Contract {
         let asset_amount = msg_amount();
         let underlying_asset = msg_asset_id();
 
-        require(underlying_asset == AssetId::base(), "INVALID_ASSET_ID");
+        require(underlying_asset == AssetId::base_asset_id(), "INVALID_ASSET_ID");
         let (shares, share_asset, share_asset_vault_sub_id) = preview_deposit(underlying_asset, vault_sub_id, asset_amount);
         require(asset_amount != 0, "ZERO_ASSETS");
 
@@ -100,7 +100,7 @@ impl SRC6 for Contract {
 
     #[storage(read)]
     fn managed_assets(underlying_asset: AssetId, vault_sub_id: SubId) -> u64 {
-        if underlying_asset == AssetId::base() {
+        if underlying_asset == AssetId::base_asset_id() {
             let vault_share_asset = vault_asset_id(underlying_asset, vault_sub_id).0;
             // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
             managed_assets(vault_share_asset)
@@ -115,7 +115,7 @@ impl SRC6 for Contract {
         underlying_asset: AssetId,
         vault_sub_id: SubId,
     ) -> Option<u64> {
-        if underlying_asset == AssetId::base() {
+        if underlying_asset == AssetId::base_asset_id() {
             // This is the max value of u64 minus the current managed_assets. Ensures that the sum will always be lower than u64::MAX.
             Some(u64::max() - managed_assets(underlying_asset))
         } else {
@@ -125,7 +125,7 @@ impl SRC6 for Contract {
 
     #[storage(read)]
     fn max_withdrawable(underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64> {
-        if underlying_asset == AssetId::base() {
+        if underlying_asset == AssetId::base_asset_id() {
             // In this implementation total_assets and max_withdrawable are the same. However in case of lending out of assets, total_assets should be greater than max_withdrawable.
             Some(managed_assets(underlying_asset))
         } else {

--- a/standards/src/src10.sw
+++ b/standards/src/src10.sw
@@ -13,32 +13,32 @@ pub enum DepositType {
 }
 
 /// Enscapsultes metadata sent between the canonical chain and Fuel when a deposit is made.
-struct DepositMessage {
+pub struct DepositMessage {
     /// The number of tokens.
-    pub amount: b256,
+    amount: b256,
     /// The user's address on the canonical chain.
-    pub from: b256,
+    from: b256,
     /// The bridging target destination on the Fuel chain.
-    pub to: Identity,
+    to: Identity,
     /// The bridged token's address on the canonical chain.
-    pub token_address: b256,
+    token_address: b256,
     /// The token's ID on the canonical chain.
-    pub token_id: b256,
+    token_id: b256,
     /// The decimals of the token.
-    pub decimals: u8,
+    decimals: u8,
     /// The type of deposit made.
-    pub deposit_type: DepositType,
+    deposit_type: DepositType,
 }
 
 pub struct MetadataMessage {
     /// The bridged token's address on the canonical chain.
-    pub token_address: b256,
+    token_address: b256,
     /// The token's ID on the canonical chain.
-    pub token_id: b256,
+    token_id: b256,
     /// The bridged token's name on the canonical chain.
-    pub name: String,
+    name: String,
     /// The bridged token's symbol on the canonical chain.
-    pub symbol: String,
+    symbol: String,
 }
 
 abi SRC10 {

--- a/standards/src/src11.sw
+++ b/standards/src/src11.sw
@@ -5,35 +5,35 @@ use std::string::String;
 /// Contact Information to report bugs to.
 pub struct SecurityInformation {
     /// Name of the project.
-    pub name: String,
+    name: String,
     /// Website URL of the project.
-    pub project_url: Option<String>,
+    project_url: Option<String>,
     /// List of contact information to contact developers of the project.
     /// Should be in the format <contact_type>:<contact_information>.
     /// You should include contact types that will not change over time.
-    pub contact_information: Vec<String>,
+    contact_information: Vec<String>,
     /// Text describing the project's security policy, or a link to it.
     /// This should describe what kind of bounties your project offers and the terms under which you offer them.
-    pub policy: String,
+    policy: String,
     /// A list of preferred languages (ISO 639-1).
-    pub preferred_languages: Option<Vec<String>>,
+    preferred_languages: Option<Vec<String>>,
     /// A PGP public key block (or similar) or a link to one.
-    pub encryption: Option<String>,
+    encryption: Option<String>,
     /// A URL to the project's source code.
-    pub source_code: Option<String>,
+    source_code: Option<String>,
     /// The release identifier of this build, ideally corresponding to a tag on git that can be rebuilt to reproduce the same binary.
     /// 3rd party build verification tools will use this tag to identify a matching github release.
-    pub source_release: Option<String>,
+    source_release: Option<String>,
     /// The revision identifier of this build, usually a git commit hash that can be rebuilt to reproduce the same binary.
     /// 3rd party build verification tools will use this tag to identify a matching github release.
-    pub source_revision: Option<String>,
+    source_revision: Option<String>,
     /// A list of people or entities that audited this smart contract, or links to pages where audit reports are hosted.
     /// Note that this field is self-reported by the author of the program and might not be accurate.
-    pub auditors: Option<Vec<String>>,
+    auditors: Option<Vec<String>>,
     /// Text containing acknowledgments to security researchers who have previously found vulnerabilities in the project, or a link to it.
-    pub acknowledgments: Option<String>,
+    acknowledgments: Option<String>,
     /// Text containing any additional information you want to provide, or a link to it.
-    pub additional_information: Option<String>,
+    additional_information: Option<String>,
 }
 
 abi SRC11 {

--- a/standards/src/src12.sw
+++ b/standards/src/src12.sw
@@ -1,6 +1,6 @@
 library;
 
-use std::{alloc::alloc_bytes, bytes::Bytes, hash::{Hash, Hasher}, vec::*};
+use std::{alloc::alloc_bytes, bytes::Bytes, hash::{Hash, Hasher}};
 
 pub type BytecodeRoot = b256;
 pub type ContractConfigurables = Vec<(u64, Vec<u8>)>;

--- a/standards/src/src12.sw
+++ b/standards/src/src12.sw
@@ -1,6 +1,6 @@
 library;
 
-use std::{alloc::alloc_bytes, bytes::Bytes, hash::{Hash, Hasher}};
+use std::{alloc::alloc_bytes, bytes::Bytes, hash::{Hash, Hasher}, vec::*};
 
 pub type BytecodeRoot = b256;
 pub type ContractConfigurables = Vec<(u64, Vec<u8>)>;
@@ -120,7 +120,7 @@ impl Hash for ContractConfigurables {
 
             // Overwrite the configurable data into the buffer
             offset_ptr.copy_bytes_to(buffer, 4);
-            data.ptr().copy_bytes_to(buffer.add::<u8>(4), data.len());
+            data.buf.ptr().copy_bytes_to(buffer.add::<u8>(4), data.len());
 
             state.write(Bytes::from(raw_slice::from_parts::<u8>(buffer, data.len() + 4)));
             configurable_iterator += 1;

--- a/standards/src/src6.sw
+++ b/standards/src/src6.sw
@@ -3,33 +3,33 @@ library;
 /// Event logged when a deposit is made.
 pub struct Deposit {
     /// The caller of the deposit function.
-    pub caller: Identity,
+    caller: Identity,
     /// The receiver of the deposit.
-    pub receiver: Identity,
+    receiver: Identity,
     /// The asset being deposited.
-    pub underlying_asset: AssetId,
+    underlying_asset: AssetId,
     /// The SubId of the vault.
-    pub vault_sub_id: SubId,
+    vault_sub_id: SubId,
     /// The amount of assets being deposited.
-    pub deposited_amount: u64,
+    deposited_amount: u64,
     /// The amount of shares being minted.
-    pub minted_shares: u64,
+    minted_shares: u64,
 }
 
 /// Event logged when a withdrawal is made.
 pub struct Withdraw {
     /// The caller of the withdrawal function.
-    pub caller: Identity,
+    caller: Identity,
     /// The receiver of the withdrawal.
-    pub receiver: Identity,
+    receiver: Identity,
     /// The asset being withdrawn.
-    pub underlying_asset: AssetId,
+    underlying_asset: AssetId,
     /// The SubId of the vault.
-    pub vault_sub_id: SubId,
+    vault_sub_id: SubId,
     /// The amount of assets being withdrawn.
-    pub withdrawn_amount: u64,
+    withdrawn_amount: u64,
     /// The amount of shares being burned.
-    pub burned_shares: u64,
+    burned_shares: u64,
 }
 
 abi SRC6 {


### PR DESCRIPTION
## Type of change

- Bug fixes.

## Motivation

- Running `forc build` in both `examples` and `standards` throws errors.

## Changes

The following changes have been made:

- Removed `pub` definition from inside the structs in `standards/src`.
- Updated line 123 in `standards/src/src12.sw`  to access the `ptr()` method for a vector. 
- Replaced `base()` with `base_asset_id()` in  `examples/src6-vault`.

## Notes

- Consult the [Sway docs](https://docs.fuel.network/docs/fuels-ts/types/structs/#structs) for context regarding defining custom structs.
- Consult this section of the [Sway std library](https://github.com/FuelLabs/sway/blob/v0.49.3/sway-lib-std/src/vec.sw) for context regarding accessing the `ptr()` method.
- Consult this section of the [Sway std library](https://github.com/FuelLabs/sway/blob/0dc6570377ee9c4a6359ade597fa27351e02a728/sway-lib-std/src/asset_id.sw#L179) for context regarding accessing the `base_asset_id()` method.
