### PR TITLE
docs: SRC-14 grammar and example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you don't find what you're looking for, feel free to create an issue and prop
 ### Contracts
 
 - [SRC-12; Contract Factory](./SRCs/src-12.md) defines the implementation of a standard API for contract factories.
+- [SRC-14; Simple Upgradable Proxies](./SRCs/src-14.md) defines the implementation of a standard API for simple upgradable proxies.
 
 ### Bridge
 
@@ -148,6 +149,16 @@ Example of the SRC-12 implementation where contract deployments contain configur
 ##### [Without Configurables](./examples/src12-contract-factory/without_configurables/src/without_configurables.sw)
 
 Example of the SRC-12 implementation where all contract deployments are identical and thus have the same bytecode and root.
+
+#### SRC-14; Simple Upgradable Proxies Standard Examples
+
+##### [Minimal](./examples/src14-simple-proxy/minimal/src/minimal.sw)
+
+Example of a minimal SRC-14 implementation with no access control.
+
+##### [Owned Proxy](./examples/src14-simple-proxy/owned/src/owned.sw)
+
+Example of a SRC-14 implementation that also implements [SRC-5](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-5.md).
 
 > **Note**
 > All standards currently use `forc v0.59.0`.

--- a/SRCs/src-14.md
+++ b/SRCs/src-14.md
@@ -6,7 +6,7 @@ The following proposes a standard for simple upgradable proxies.
 
 ## Motivation
 
-We seek to standardize proxy implementation to improve developer experience and enable tooling to automatically deploy or update proxies as needed.
+We seek to standardize a proxy implementation to improve developer experience and enable tooling to automatically deploy or update proxies as needed.
 
 ## Prior Art
 
@@ -71,10 +71,10 @@ abi SRC14 {
 
 ## Example Implementation
 
-### [Minimal Proxy](../examples/examples/src14-simple-proxy/owned/src/minimal.sw)
+### [Minimal Proxy](../examples/src14-simple-proxy/owned/src/minimal.sw)
 
 Example of a minimal SRC-14 implementation with no access control.
 
-### [Owned Proxy](../examples/examples/src14-simple-proxy/owned/src/owned.sw)
+### [Owned Proxy](../examples/src14-simple-proxy/owned/src/owned.sw)
 
 Example of a SRC-14 implementation that also implements [SRC-5](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-5.md).

--- a/SRCs/src-14.md
+++ b/SRCs/src-14.md
@@ -71,7 +71,7 @@ abi SRC14 {
 
 ## Example Implementation
 
-### [Minimal Proxy](../examples/src14-simple-proxy/owned/src/minimal.sw)
+### [Minimal Proxy](../examples/src14-simple-proxy/minimal/src/minimal.sw)
 
 Example of a minimal SRC-14 implementation with no access control.
 


### PR DESCRIPTION
## Type of change

- Documentation

## Changes

The following changes have been made:

In `src-14.md`:
- Grammar fixed in `Motiviation`
- example links fixed


## Related Issues

Closes #98 
