### PR TITLE
Fix forc versions in README for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.59.0" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.59.0-orange" />
+    <a href="https://crates.io/crates/forc/0.60.0" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.60.0-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-standards" />
@@ -150,7 +150,7 @@ Example of the SRC-12 implementation where contract deployments contain configur
 Example of the SRC-12 implementation where all contract deployments are identical and thus have the same bytecode and root.
 
 > **Note**
-> All standards currently use `forc v0.59.0`.
+> All standards currently use `forc v0.60.0`.
 
 <!-- TODO:
 ## Contributing


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Docs fix

## Changes

The following changes have been made:

- Updates the version of forc in the README from v0.59.0 to v0.60.0

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
