### PR TITLE
Update links to use docs hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,29 +35,30 @@ If you don't find what you're looking for, feel free to create an issue and prop
 
 ### Native Assets
 
-- [SRC-20; Native Asset Standard](./docs/src/src-20-native-asset.md) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
-- [SRC-3; Mint and Burn](./docs/src/src-3-minting-and-burning.md) is used to enable mint and burn functionality for fungible assets.
-- [SRC-7; Arbitrary Asset Metadata Standard](./docs/src/src-7-asset-metadata.md) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
-- [SRC-9; Metadata Keys Standard](./docs/src/src-9-metadata-keys.md) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
-- [SRC-6; Vault Standard](./docs/src/src-6-vault.md) defines the implementation of a standard API for asset vaults developed in Sway.
+- [SRC-20; Native Asset Standard](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
+- [SRC-3; Mint and Burn](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) is used to enable mint and burn functionality for fungible assets.
+- [SRC-7; Arbitrary Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
+- [SRC-9; Metadata Keys Standard](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
+- [SRC-6; Vault Standard](https://docs.fuel.network/docs/sway-standards/src-6-vault/) defines the implementation of a standard API for asset vaults developed in Sway.
+- [SRC-13; Soulbound Address](https://docs.fuel.network/docs/sway-standards/src-13-soulbound-address/) provides a predicate interface to lock [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) as soulbound.
 
 ### Access Control
 
-- [SRC-5; Ownership Standard](./docs/src/src-5-ownership.md) is used to restrict function calls to admin users in contracts.
+- [SRC-5; Ownership Standard](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) is used to restrict function calls to admin users in contracts.
 
 ### Contracts
 
-- [SRC-12; Contract Factory](./docs/src/src-12-contract-factory.md) defines the implementation of a standard API for contract factories.
-- [SRC-14; Simple Upgradable Proxies](./docs/src/src-14-simple-upgradeable-proxies.md) defines the implementation of a standard API for simple upgradable proxies.
+- [SRC-12; Contract Factory](https://docs.fuel.network/docs/sway-standards/src-12-contract-factory/) defines the implementation of a standard API for contract factories.
+- [SRC-14; Simple Upgradable Proxies](https://docs.fuel.network/docs/sway-standards/src-14-simple-upgradeable-proxies/) defines the implementation of a standard API for simple upgradable proxies.
 
 ### Bridge
 
-- [SRC-8; Bridged Asset](./docs/src/src-8-bridged-asset.md) defines the metadata required for an asset bridged to the Fuel Network.
-- [SRC-10; Native Bridge Standard](./docs/src/src-10-native-bridge.md) defines the standard API for the Native Bridge between the Fuel Chain and the canonical base chain.
+- [SRC-8; Bridged Asset](https://docs.fuel.network/docs/sway-standards/src-8-bridged-asset/) defines the metadata required for an asset bridged to the Fuel Network.
+- [SRC-10; Native Bridge Standard](https://docs.fuel.network/docs/sway-standards/src-10-native-bridge/) defines the standard API for the Native Bridge between the Fuel Chain and the canonical base chain.
 
 ### Documentation
 
-- [SRC-2; Inline Documentation](./docs/src/src-2-inline-documentation.md) defines how to document your Sway files.
+- [SRC-2; Inline Documentation](https://docs.fuel.network/docs/sway-standards/src-2-inline-documentation/) defines how to document your Sway files.
 
 ## Using a standard
 
@@ -158,7 +159,7 @@ Example of a minimal SRC-14 implementation with no access control.
 
 ##### [Owned Proxy](./examples/src14-simple-proxy/owned/src/owned.sw)
 
-Example of a SRC-14 implementation that also implements [SRC-5](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-5.md).
+Example of a SRC-14 implementation that also implements [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/).
 
 > **Note**
 > All standards currently use `forc v0.60.0`.

--- a/docs/src/src-2-inline-documentation.md
+++ b/docs/src/src-2-inline-documentation.md
@@ -8,7 +8,7 @@ The standard seeks to provide a better developer experience using Fuel's tooling
 
 ## Prior Art
 
-A number of pre-existing functions in the [sway standard library](https://github.com/FuelLabs/sway/tree/master/sway-lib-std), [sway-applications](https://github.com/FuelLabs/sway-applications), and [sway-libs](https://github.com/FuelLabs/sway-libs) repositories have inline documentation. The inline documentation for these is already compatible with Fuel's VS Code extension. These however do not all follow the same structure and outline.
+A number of pre-existing functions in the [sway standard library](https://fuellabs.github.io/sway/master/std/), [sway-applications](https://github.com/FuelLabs/sway-applications), and [sway-libs](https://docs.fuel.network/docs/sway-libs/) repositories have inline documentation. The inline documentation for these is already compatible with Fuel's VS Code extension. These however do not all follow the same structure and outline.
 
 ## Specification
 

--- a/docs/src/src-5-ownership.md
+++ b/docs/src/src-5-ownership.md
@@ -8,7 +8,7 @@ The standard seeks to provide a method for restricting access to particular user
 
 ## Prior Art
 
-The [sway-libs](https://github.com/FuelLabs/sway-libs) repository contains a pre-existing Ownership library.
+The [sway-libs](https://docs.fuel.network/docs/sway-libs/ownership/) repository contains a pre-existing Ownership library.
 
 Ownership libraries exist for other ecosystems such as OpenZeppelin's [Ownership library](https://docs.openzeppelin.com/contracts/2.x/api/ownership).
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)
- Documentation

## Changes

The following changes have been made:

- Replaces all instances of links that point to a file with a link to the corresponding docs hub section

## Notes

- Now that the Sway-Standards and Sway-Standards are included in the docs hub, all links should point to it.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
