### PR TITLE
Add `proxy_owner()` function to the SRC-14 standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,17 @@ Description of the upcoming release here.
 
 ### Added
 
-- Something new here 1
+- [#107](https://github.com/FuelLabs/sway-standards/pull/107) Adds the `proxy_owner()` function to the SRC-14 standard.
 - Something new here 2
 
 ### Changed
 
-- [#107](https://github.com/FuelLabs/sway-standards/pull/107) Add `proxy_owner()` function to the SRC-14 standard.
+- Something changed here 1
+- Something changed here 2
 
 ### Fixed
 
-- Some fix here 1
-- Some fix here 2
+- [#107](https://github.com/FuelLabs/sway-standards/pull/107) resolves the conflict when SRC-5's `owner()` function is used in both the proxy and target contract in the SRC-14 standard.
 
 #### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ Description of the upcoming release here.
 
 ### Changed
 
-- Something changed here 1
-- Something changed here 2
+- [#107](https://github.com/FuelLabs/sway-standards/pull/107) Add `proxy_owner()` function to the SRC-14 standard.
 
 ### Fixed
 

--- a/docs/src/src-14-simple-upgradeable-proxies.md
+++ b/docs/src/src-14-simple-upgradeable-proxies.md
@@ -41,6 +41,14 @@ The following functions MUST be implemented by a proxy contract to follow the SR
 If a valid call is made to this function it MUST change the target address of the proxy to `new_target`.
 This method SHOULD implement access controls such that the target can only be changed by a user that possesses the right permissions (typically the proxy owner).
 
+### Optional Public Functions
+
+The following functions are RECOMMENDED to be implemented by a proxy contract to follow the SRC-14 standard:
+
+#### `fn proxy_owner() -> State;`
+
+This function SHALL return the current state of ownership for the proxy contract where the `State` is either `Uninitialized`, `Initialized`, or `Revoked`. `State` is defined in the [SRC-5; Ownership Standard](./src-5-ownership.md).
+
 ## Rationale
 
 This standard is meant to provide simple upgradeability, it is deliberately minimalistic and does not provide the level of functionality of diamonds.
@@ -57,14 +65,19 @@ As it is the first attempt to standardize proxy implementation, we do not consid
 ## Security Considerations
 
 Permissioning proxy target changes is the primary consideration here.
-This standard is not opinionated about means of achieving this, use of [SRC-5](./src-5-ownership.md) is recommended.
+Use of the [SRC-5; Ownership Standard](./src-5-ownership.md) is discouraged. If both the target and proxy contracts implement the [SRC-5](./src-5-ownership.md) standard, the `owner()` function in the target contract is unreachable through the proxy contract. Use of the `proxy_owner()` function in the proxy contract should be used instead.
 
 ## Example ABI
 
 ```sway
 abi SRC14 {
-    #[storage(write)]
+    #[storage(read, write)]
     fn set_proxy_target(new_target: ContractId);
+}
+
+abi SRC14Extension {
+    #[storage(read)]
+    fn proxy_owner() -> State;
 }
 ```
 
@@ -80,7 +93,7 @@ Example of a minimal SRC-14 implementation with no access control.
 
 ### Owned Proxy
 
-Example of a SRC-14 implementation that also implements [SRC-5](./src-5-ownership.md).
+Example of a SRC-14 implementation that also implements `proxy_owner()`.
 
 ```sway
 {{#include ../../examples/src14-simple-proxy/owned/src/owned.sw}}

--- a/examples/src14-simple-proxy/minimal/src/minimal.sw
+++ b/examples/src14-simple-proxy/minimal/src/minimal.sw
@@ -1,18 +1,17 @@
 contract;
 
 use std::execution::run_external;
-use std::constants::ZERO_B256;
 use standards::src14::SRC14;
 
 // use sha256("storage_SRC14") as base to avoid collisions
 #[namespace(SRC14)]
 storage {
     // target is at sha256("storage_SRC14_0")
-    target: ContractId = ContractId::from(ZERO_B256),
+    target: ContractId = ContractId::zero(),
 }
 
 impl SRC14 for Contract {
-    #[storage(write)]
+    #[storage(read, write)]
     fn set_proxy_target(new_target: ContractId) {
         storage.target.write(new_target);
     }

--- a/examples/src14-simple-proxy/owned/src/owned.sw
+++ b/examples/src14-simple-proxy/owned/src/owned.sw
@@ -1,33 +1,32 @@
 contract;
 
 use std::execution::run_external;
-use std::constants::ZERO_B256;
-use standards::src5::{AccessError, SRC5, State};
-use standards::src14::SRC14;
+use standards::src5::{AccessError, State};
+use standards::src14::{SRC14, SRC14Extension};
 
 /// The owner of this contract at deployment.
-const INITIAL_OWNER: Identity = Identity::Address(Address::from(ZERO_B256));
+const INITIAL_OWNER: Identity = Identity::Address(Address::zero());
 
 // use sha256("storage_SRC14") as base to avoid collisions
 #[namespace(SRC14)]
 storage {
     // target is at sha256("storage_SRC14_0")
-    target: ContractId = ContractId::from(ZERO_B256),
+    target: ContractId = ContractId::zero(),
     owner: State = State::Initialized(INITIAL_OWNER),
 }
 
-impl SRC5 for Contract {
-    #[storage(read)]
-    fn owner() -> State {
-        storage.owner.read()
-    }
-}
-
 impl SRC14 for Contract {
-    #[storage(write)]
+    #[storage(read, write)]
     fn set_proxy_target(new_target: ContractId) {
         only_owner();
         storage.target.write(new_target);
+    }
+}
+
+impl SRC14Extension for Contract {
+    #[storage(read)]
+    fn proxy_owner() -> State {
+        storage.owner.read()
     }
 }
 

--- a/standards/src/src14.sw
+++ b/standards/src/src14.sw
@@ -1,5 +1,7 @@
 library;
 
+use ::src5::State;
+
 abi SRC14 {
     /// Change the target address of a proxy contract.
     ///
@@ -18,8 +20,30 @@ abi SRC14 {
     ///     contract_abi.set_proxy_target(new_target);
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     fn set_proxy_target(new_target: ContractId);
+}
+
+abi SRC14Extension {
+    /// Returns the owner of the proxy contract.
+    ///
+    /// # Returns
+    ///
+    /// * [State] - Represents the state of ownership for this contract.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// fn foo() {
+    ///     match owner() {
+    ///         State::Uninitalized => log("The ownership is uninitalized"),
+    ///         State::Initialized(owner) => log("The ownership is initalized"),
+    ///         State::Revoked => log("The ownership is revoked"),
+    ///     }
+    /// }
+    /// ```
+    #[storage(read)]
+    fn proxy_owner() -> State;
 }
 
 /// The standard storage slot to store proxy target address.


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix
- New feature

## Changes

The following changes have been made:

- Adds `proxy_owner()` function
- Discourages the use of the SRC-5 ownership standard when implementing the SRC-14 standard
- Updates examples with `proxy_owner()`

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
