### PR TITLE
SRC14 add `proxy_target()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Description of the upcoming release here.
 ### Added
 
 - [#107](https://github.com/FuelLabs/sway-standards/pull/107) Adds the `proxy_owner()` function to the SRC-14 standard.
+- [#110](https://github.com/FuelLabs/sway-standards/pull/110) Adds the `proxy_target()` function to the SRC-14 standard.
 - Something new here 2
 
 ### Changed
@@ -25,5 +26,13 @@ Description of the upcoming release here.
 
 #### Breaking
 
-- Some breaking change here 1
-- Some breaking change here 2
+- [#110](https://github.com/FuelLabs/sway-standards/pull/110) Breaks the `SRC14` abi by adding the `proxy_target()` function. This will need to be added to any SRC14 implementation. The new abi is as follows:
+
+```sway
+abi SRC14 {
+    #[storage(read, write)]
+    fn set_proxy_target(new_target: ContractId);
+    #[storage(read)]
+    fn proxy_target() -> Option<ContractId>;
+}
+```

--- a/docs/src/src-14-simple-upgradeable-proxies.md
+++ b/docs/src/src-14-simple-upgradeable-proxies.md
@@ -38,8 +38,12 @@ The following functions MUST be implemented by a proxy contract to follow the SR
 
 #### `fn set_proxy_target(new_target: ContractId);`
 
-If a valid call is made to this function it MUST change the target address of the proxy to `new_target`.
+If a valid call is made to this function it MUST change the target contract of the proxy to `new_target`.
 This method SHOULD implement access controls such that the target can only be changed by a user that possesses the right permissions (typically the proxy owner).
+
+#### `fn proxy_target() -> Option<ContractId>;`
+
+This function MUST return the target contract of the proxy as `Some`. If no proxy is set then `None` MUST be returned.
 
 ### Optional Public Functions
 
@@ -73,6 +77,8 @@ Use of the [SRC-5; Ownership Standard](./src-5-ownership.md) is discouraged. If 
 abi SRC14 {
     #[storage(read, write)]
     fn set_proxy_target(new_target: ContractId);
+    #[storage(read)]
+    fn proxy_target() -> Option<ContractId>;
 }
 
 abi SRC14Extension {

--- a/examples/src14-simple-proxy/minimal/src/minimal.sw
+++ b/examples/src14-simple-proxy/minimal/src/minimal.sw
@@ -15,6 +15,11 @@ impl SRC14 for Contract {
     fn set_proxy_target(new_target: ContractId) {
         storage.target.write(new_target);
     }
+
+    #[storage(read)]
+    fn proxy_target() -> Option<ContractId> {
+        storage.target.try_read()
+    }
 }
 
 #[fallback]

--- a/examples/src14-simple-proxy/owned/src/owned.sw
+++ b/examples/src14-simple-proxy/owned/src/owned.sw
@@ -21,6 +21,11 @@ impl SRC14 for Contract {
         only_owner();
         storage.target.write(new_target);
     }
+
+    #[storage(read)]
+    fn proxy_target() -> Option<ContractId> {
+        storage.target.try_read()
+    }
 }
 
 impl SRC14Extension for Contract {

--- a/standards/src/src14.sw
+++ b/standards/src/src14.sw
@@ -3,7 +3,7 @@ library;
 use ::src5::State;
 
 abi SRC14 {
-    /// Change the target address of a proxy contract.
+    /// Change the target contract of a proxy contract.
     ///
     /// # Arguments
     ///
@@ -22,6 +22,25 @@ abi SRC14 {
     /// ```
     #[storage(read, write)]
     fn set_proxy_target(new_target: ContractId);
+
+    /// Returns the target contract of a proxy contract.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<ContractId>] - The new proxy contract to which all fallback calls will be passed or `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src14::SRC14;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let contract_abi = abi(SRC14, contract_id.bits());
+    ///     let target_contract: Option<ContractId> = contract_abi.proxy_target();
+    /// }
+    /// ```
+    #[storage(read)]
+    fn proxy_target() -> Option<ContractId>;
 }
 
 abi SRC14Extension {


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- The `proxy_target()` function has been added to the SRC14 standard. 

## Notes

- There is currently no standardized way for a contract to query and check what the proxy target contract is. This has been added in this PR.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
