### PR TITLE
Fix vault standard examples

### DIFF
--- a/examples/src6-vault/multi_asset_vault/src/main.sw
+++ b/examples/src6-vault/multi_asset_vault/src/main.sw
@@ -50,7 +50,14 @@ impl SRC6 for Contract {
 
         _mint(receiver, share_asset, share_asset_vault_sub_id, shares);
 
-        let mut vault_info = storage.vault_info.get(share_asset).read();
+        let mut vault_info = match storage.vault_info.get(share_asset).try_read() {
+            Some(vault_info) => vault_info,
+            None => VaultInfo {
+                managed_assets: 0,
+                vault_sub_id,
+                asset: underlying_asset,
+            },
+        };
         vault_info.managed_assets = vault_info.managed_assets + asset_amount;
         storage.vault_info.insert(share_asset, vault_info);
 

--- a/examples/src6-vault/single_asset_vault/src/main.sw
+++ b/examples/src6-vault/single_asset_vault/src/main.sw
@@ -51,7 +51,14 @@ impl SRC6 for Contract {
 
         _mint(receiver, share_asset, share_asset_vault_sub_id, shares);
 
-        let mut vault_info = storage.vault_info.get(share_asset).read();
+        let mut vault_info = match storage.vault_info.get(share_asset).try_read() {
+            Some(vault_info) => vault_info,
+            None => VaultInfo {
+                managed_assets: 0,
+                vault_sub_id,
+                asset: underlying_asset,
+            },
+        };
         vault_info.managed_assets = vault_info.managed_assets + asset_amount;
         storage.vault_info.insert(share_asset, vault_info);
 


### PR DESCRIPTION
## Type of change

- Bug fix

## Changes

The examples which used the `Vault` struct in the vault examples did not initialize a new asset with an empty vault when the vault is deposited to for the first time, this will result in all deposits failing.

## Notes

The bug originates because in prior versions of Sway, reads could not fail and would return 0'ed out values for all struct fields, leading to a oversight when updating versions

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.
