### PR TITLE
SRC-6 example contract does not update managed assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Description of the upcoming release here.
 
 ### Fixed
 
-- [#122](https://github.com/FuelLabs/sway-standards/pull/107) Fixes the SRC-6 example contract from a critical bug where the contract can be drained.
+- [#122](https://github.com/FuelLabs/sway-standards/pull/122) Fixes the SRC-6 example contract from a critical bug where the contract can be drained.
 
 ## [Version 0.5.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+Description of the upcoming release here.
+
+### Added
+
+- Something new here
+
+### Changed
+
+- Something new here
+
+### Fixed
+
+- [#122](https://github.com/FuelLabs/sway-standards/pull/107) Fixes the SRC-6 example contract from a critical bug where the contract can be drained.
+
 ## [Version 0.5.1]
 
 Description of the upcoming release here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
-### Added
+### Added Unreleased
 
 - Something new here
 
-### Changed
+### Changed Unreleased
 
 - Something new here
 
-### Fixed
+### Fixed Unreleased
 
 - [#122](https://github.com/FuelLabs/sway-standards/pull/122) Fixes the SRC-6 example contract from a critical bug where the contract can be drained.
 
@@ -25,26 +25,26 @@ Description of the upcoming release here.
 
 Description of the upcoming release here.
 
-### Added
+### Added v0.5.1
 
 - [#107](https://github.com/FuelLabs/sway-standards/pull/107): Adds the `proxy_owner()` function to the SRC-14 standard.
 - [#104](https://github.com/FuelLabs/sway-standards/pull/104): Adds the CHANGELOG.md file to Sway-Standards.
 - [#110](https://github.com/FuelLabs/sway-standards/pull/110) Adds the `proxy_target()` function to the SRC-14 standard.
 - [#103](https://github.com/FuelLabs/sway-standards/pull/103): Adds Sway-Standards to the [docs hub](https://docs.fuel.network/docs/sway-standards/).
 
-### Changed
+### Changed v0.5.1
 
 - [#103](https://github.com/FuelLabs/sway-standards/pull/103) Removes standards in the `./SRC` folder in favor of `./docs`.
 - [#106](https://github.com/FuelLabs/sway-standards/pull/106) Updates links from the Sway Book to Docs Hub.
 
-### Fixed
+### Fixed v0.5.1
 
 - [#107](https://github.com/FuelLabs/sway-standards/pull/107) resolves the conflict when SRC-5's `owner()` function is used in both the proxy and target contract in the SRC-14 standard.
 - [#99](https://github.com/FuelLabs/sway-standards/pull/99) Fixes links and typos in the SRC-14 standard.
 - [#112](https://github.com/FuelLabs/sway-standards/pull/112) Fixes inline documentation code in the SRC-3 standard.
 - [#115](https://github.com/FuelLabs/sway-standards/pull/115) Hotfixes the Cargo.toml version to the v0.5.1 release.
 
-#### Breaking
+#### Breaking v0.5.1
 
 - [#110](https://github.com/FuelLabs/sway-standards/pull/110) Breaks the `SRC14` abi by adding the `proxy_target()` function. This will need to be added to any SRC14 implementation. The new abi is as follows:
 

--- a/examples/src6-vault/multi_asset_vault/src/main.sw
+++ b/examples/src6-vault/multi_asset_vault/src/main.sw
@@ -83,6 +83,7 @@ impl SRC6 for Contract {
 
         let mut vault_info = storage.vault_info.get(share_asset_id).read();
         vault_info.managed_assets = vault_info.managed_assets - shares;
+        storage.vault_info.insert(share_asset_id, vault_info);
 
         _burn(share_asset_id, share_asset_vault_sub_id, shares);
 

--- a/examples/src6-vault/multi_asset_vault/src/main.sw
+++ b/examples/src6-vault/multi_asset_vault/src/main.sw
@@ -81,6 +81,9 @@ impl SRC6 for Contract {
         require(msg_asset_id() == share_asset_id, "INVALID_ASSET_ID");
         let assets = preview_withdraw(share_asset_id, shares);
 
+        let mut vault_info = storage.vault_info.get(share_asset_id).read();
+        vault_info.managed_assets = vault_info.managed_assets - shares;
+
         _burn(share_asset_id, share_asset_vault_sub_id, shares);
 
         transfer(receiver, underlying_asset, assets);

--- a/examples/src6-vault/single_asset_single_sub_vault/src/main.sw
+++ b/examples/src6-vault/single_asset_single_sub_vault/src/main.sw
@@ -78,6 +78,10 @@ impl SRC6 for Contract {
         require(msg_asset_id() == share_asset_id, "INVALID_ASSET_ID");
         let assets = preview_withdraw(shares);
 
+        storage
+            .managed_assets
+            .write(storage.managed_assets.read() - shares);
+
         _burn(share_asset_id, shares);
 
         transfer(receiver, underlying_asset, assets);

--- a/examples/src6-vault/single_asset_vault/src/main.sw
+++ b/examples/src6-vault/single_asset_vault/src/main.sw
@@ -82,6 +82,9 @@ impl SRC6 for Contract {
         require(msg_asset_id() == share_asset_id, "INVALID_ASSET_ID");
         let assets = preview_withdraw(share_asset_id, shares);
 
+        let mut vault_info = storage.vault_info.get(share_asset_id).read();
+        vault_info.managed_assets = vault_info.managed_assets - shares;
+
         _burn(share_asset_id, share_asset_vault_sub_id, shares);
 
         transfer(receiver, underlying_asset, assets);

--- a/examples/src6-vault/single_asset_vault/src/main.sw
+++ b/examples/src6-vault/single_asset_vault/src/main.sw
@@ -84,6 +84,7 @@ impl SRC6 for Contract {
 
         let mut vault_info = storage.vault_info.get(share_asset_id).read();
         vault_info.managed_assets = vault_info.managed_assets - shares;
+        storage.vault_info.insert(share_asset_id, vault_info);
 
         _burn(share_asset_id, share_asset_vault_sub_id, shares);
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix

## Changes

The following changes have been made:

- There is a critical flaw in the SRC-6 example contract where the managed assets is not updated with assets are withdrawn. This can be exploited to drain the contract. This PR resolves this critical bug.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
