### PR TITLE
Fix Sway Standards inline docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Description of the upcoming release here.
 ### Fixed Unreleased
 
 - [#137](https://github.com/FuelLabs/sway-standards/pull/137) Resolves warnings for SRC-6, SRC-14, and SRC-5 standard examples.
+- [#142](https://github.com/FuelLabs/sway-standards/pull/142) Fixes errors in inline documentation for SRC-10, SRC-12, SRC-14, SRC-20, SRC-3, SRC-5, SRC-7 standards.
 
 #### Breaking Unreleased
 

--- a/examples/src5-ownership/initialized_example/src/initialized_example.sw
+++ b/examples/src5-ownership/initialized_example/src/initialized_example.sw
@@ -31,7 +31,7 @@ impl SRC5 for Contract {
     ///     let ownership_abi = abi(contract_id, SRC_5);
     ///
     ///     match ownership_abi.owner() {
-    ///         State::Initialized(owner) => log("The ownership is initalized"),
+    ///         State::Initialized(owner) => log("The ownership is initialized"),
     ///         _ => log("This example will never reach this statement"),
     ///     }
     /// }

--- a/standards/src/src10.sw
+++ b/standards/src/src10.sw
@@ -58,10 +58,10 @@ abi SRC10 {
     /// # Examples
     ///
     /// ```sway
-    /// use src10::SRC10;
+    /// use standards::src10::SRC10;
     ///
     /// fn foo(message_index: u64, bridge: ContractId) {
-    ///     let bridge_abi = abi(SRC10, bridge.value);
+    ///     let bridge_abi = abi(SRC10, bridge.bits());
     ///     bridge_abi.process_message(message_index);
     /// }
     /// ```
@@ -79,10 +79,10 @@ abi SRC10 {
     /// # Examples
     ///
     /// ```sway
-    /// use src10::SRC10;
+    /// use standards::src10::SRC10;
     ///
     /// fn foo(to_address: b256, bridge: ContractId, bridged_asset: AssetId) {
-    ///     let bridge_abi = abi(SRC10, bridge.value);
+    ///     let bridge_abi = abi(SRC10, bridge.bits());
     ///     bridge_abi {
     ///         gas: 10000,
     ///         coins: 100,
@@ -105,10 +105,10 @@ abi SRC10 {
     /// # Examples
     ///
     /// ```sway
-    /// use src10::SRC10;
+    /// use standards::src10::SRC10;
     ///
     /// fn foo(to_address: b256, token_address: b256, token_id: b256, gateway_contract: b256, bridge: ContractId) {
-    ///     let bridge_abi = abi(SRC10, bridge.value);
+    ///     let bridge_abi = abi(SRC10, bridge.bits());
     ///     bridge_abi.claim_refund(to_address, token_address, token_id, gateway_contract);
     /// }
     /// ```

--- a/standards/src/src12.sw
+++ b/standards/src/src12.sw
@@ -20,11 +20,12 @@ abi SRC12 {
     /// # Examples
     ///
     /// ```sway
-    /// use src12::SRC12;
+    /// use standards::src12::SRC12;
     ///
-    /// fn foo(my_src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
-    ///     let src_12_contract_abi = abi(SRC12, my_src_12_contract.bits());
-    ///     src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
+    /// fn foo(src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
+    ///     let src_12_contract_abi = abi(SRC12, src_12_contract.bits());
+    ///     let result = src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
+    ///     assert(result.is_ok());
     ///     assert(src_12_contract_abi.is_valid(my_deployed_contract));
     /// }
     /// ```
@@ -47,12 +48,14 @@ abi SRC12 {
     /// # Examples
     ///
     /// ```sway
-    /// use src12::SRC12;
+    /// use standards::src12::SRC12;
     ///
-    /// fn foo(my_src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
-    ///     let src_12_contract_abi = abi(SRC12, my_src_12_contract.bits());
-    ///     src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
-    ///     assert(src_12_contract_abi.is_valid(my_deployed_contract));
+    /// fn foo(src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
+    ///     let src_12_contract_abi = abi(SRC12, src_12_contract.bits());
+    ///     let _ = src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
+    ///
+    ///     let result: bool = src_12_contract_abi.is_valid(my_deployed_contract)
+    ///     assert(result);
     /// }
     /// ```
     #[storage(read)]
@@ -67,11 +70,11 @@ abi SRC12 {
     /// # Examples
     ///
     /// ```sway
-    /// use src12::SRC12;
+    /// use standards::src12::SRC12;
     ///
-    /// fn foo(my_src_12_contract: ContractId) {
-    ///     let src_12_contract_abi = abi(SRC12, my_src_12_contract.bits());
-    ///     let root = src_12_contract_abi.factory_bytecode_root();
+    /// fn foo(src_12_contract: ContractId) {
+    ///     let src_12_contract_abi = abi(SRC12, src_12_contract.bits());
+    ///     let root: Option<BytecodeRoot> = src_12_contract_abi.factory_bytecode_root();
     ///     assert(root.unwrap() != b256::zero());
     /// }
     /// ```
@@ -93,12 +96,13 @@ abi SRC12_Extension {
     /// # Examples
     ///
     /// ```sway
-    /// use src12::SRC12;
+    /// use standards::src12::SRC12;
     ///
-    /// fn foo(my_src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
-    ///     let src_12_contract_abi = abi(SRC12, my_src_12_contract.bits());
-    ///     src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
-    ///     let result_contract_id = src_12_contract_abi.get_contract_id(my_configurables);
+    /// fn foo(src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
+    ///     let src_12_contract_abi = abi(SRC12, src_12_contract.bits());
+    ///     let _ = src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
+    ///
+    ///     let result_contract_id: Option<ContractId> = src_12_contract_abi.get_contract_id(my_configurables);
     ///     assert(result_contract_id.unwrap() == my_deployed_contract);
     /// }
     /// ```

--- a/standards/src/src14.sw
+++ b/standards/src/src14.sw
@@ -12,7 +12,7 @@ abi SRC14 {
     /// # Examples
     ///
     /// ```sway
-    /// use src14::SRC14;
+    /// use standards::src14::SRC14;
     ///
     /// fn foo(contract_id: ContractId) {
     ///     let contract_abi = abi(SRC14, contract_id.bits());
@@ -32,11 +32,12 @@ abi SRC14 {
     /// # Examples
     ///
     /// ```sway
-    /// use src14::SRC14;
+    /// use standards::src14::SRC14;
     ///
     /// fn foo(contract_id: ContractId) {
     ///     let contract_abi = abi(SRC14, contract_id.bits());
     ///     let target_contract: Option<ContractId> = contract_abi.proxy_target();
+    ///     assert(target_contract.is_some());
     /// }
     /// ```
     #[storage(read)]
@@ -53,8 +54,12 @@ abi SRC14Extension {
     /// # Examples
     ///
     /// ```sway
-    /// fn foo() {
-    ///     match owner() {
+    /// use standards::{src5::State, src14::{SRC14Extension, proxy_owner}};
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let contract_abi = abi(SRC14Extension, contract_id.bits());
+    ///
+    ///     match contract_abi.proxy_owner() {
     ///         State::Uninitalized => log("The ownership is uninitalized"),
     ///         State::Initialized(owner) => log("The ownership is initalized"),
     ///         State::Revoked => log("The ownership is revoked"),

--- a/standards/src/src14.sw
+++ b/standards/src/src14.sw
@@ -61,7 +61,7 @@ abi SRC14Extension {
     ///
     ///     match contract_abi.proxy_owner() {
     ///         State::Uninitialized => log("The ownership is uninitialized"),
-    ///         State::Initialized(owner) => log("The ownership is initalized"),
+    ///         State::Initialized(owner) => log("The ownership is initialized"),
     ///         State::Revoked => log("The ownership is revoked"),
     ///     }
     /// }

--- a/standards/src/src20.sw
+++ b/standards/src/src20.sw
@@ -12,11 +12,11 @@ abi SRC20 {
     /// # Examples
     ///
     /// ```sway
-    /// use src20::SRC20;
+    /// use standards::src20::SRC20;
     ///
-    /// fn foo(contract: ContractId) {
-    ///     let contract_abi = abi(SRC20, contract);
-    ///     let total_assets = contract_abi.total_assets();
+    /// fn foo(contract_id: ContractId) {
+    ///     let contract_abi = abi(SRC20, contract_id.bits());
+    ///     let total_assets: u64 = contract_abi.total_assets();
     ///     assert(total_assets != 0);
     /// }
     /// ```
@@ -36,11 +36,11 @@ abi SRC20 {
     /// # Examples
     ///
     /// ```sway
-    /// use src20::SRC20;
+    /// use standards::src20::SRC20;
     ///
-    /// fn foo(contract: ContractId, asset: AssetId) {
-    ///     let contract_abi = abi(SRC20, contract);
-    ///     let total_supply = contract_abi.total_supply(asset);
+    /// fn foo(contract_id: ContractId, asset: AssetId) {
+    ///     let contract_abi = abi(SRC20, contract_id.bits());
+    ///     let total_supply: Option<u64> = contract_abi.total_supply(asset);
     ///     assert(total_supply.unwrap() != 0);
     /// }
     /// ```
@@ -60,12 +60,12 @@ abi SRC20 {
     /// # Examples
     ///
     /// ```sway
-    /// use src20::SRC20;
+    /// use standards::src20::SRC20;
     /// use std::string::String;
     ///
-    /// fn foo(contract: ContractId, asset: AssetId) {
-    ///     let contract_abi = abi(SRC20, contract);
-    ///     let name = contract_abi.name(asset);
+    /// fn foo(contract_id: ContractId, asset: AssetId) {
+    ///     let contract_abi = abi(SRC20, contract_id.bits());
+    ///     let name: Option<String> = contract_abi.name(asset);
     ///     assert(name.is_some());
     /// }
     /// ```
@@ -84,12 +84,12 @@ abi SRC20 {
     /// # Examples
     ///
     /// ```sway
-    /// use src20::SRC20;
+    /// use standards::src20::SRC20;
     /// use std::string::String;
     ///
-    /// fn foo(contract: ContractId, asset: AssetId) {
-    ///     let contract_abi = abi(SRC20, contract);
-    ///     let symbol = contract_abi.symbol(asset);
+    /// fn foo(contract_id: ContractId, asset: AssetId) {
+    ///     let contract_abi = abi(SRC20, contract_id.bits());
+    ///     let symbol: Option<String> = contract_abi.symbol(asset);
     ///     assert(symbol.is_some());
     /// }
     /// ```
@@ -112,11 +112,11 @@ abi SRC20 {
     /// # Examples
     ///
     /// ```sway
-    /// use src20::SRC20;
+    /// use standards::src20::SRC20;
     ///
-    /// fn foo(contract: ContractId, asset: AssedId) {
-    ///     let contract_abi = abi(SRC20, contract);
-    ///     let decimals = contract_abi.decimals(asset);
+    /// fn foo(contract_id: ContractId, asset: AssedId) {
+    ///     let contract_abi = abi(SRC20, contract_id.bits());
+    ///     let decimals: Option<u8> = contract_abi.decimals(asset);
     ///     assert(decimals.unwrap() == 8u8);
     /// }
     /// ```

--- a/standards/src/src3.sw
+++ b/standards/src/src3.sw
@@ -12,10 +12,10 @@ abi SRC3 {
     /// # Examples
     ///
     /// ```sway
-    /// use src3::SRC3;
+    /// use standards::src3::SRC3;
     ///
     /// fn foo(contract_id: ContractId) {
-    ///     let contract_abi = abi(SRC3, contract);
+    ///     let contract_abi = abi(SRC3, contract_id.bits());
     ///     contract_abi.mint(Identity::ContractId(contract_id), SubId::zero(), 100);
     /// }
     /// ```
@@ -37,10 +37,10 @@ abi SRC3 {
     /// # Examples
     ///
     /// ```sway
-    /// use src3::SRC3;
+    /// use standards::src3::SRC3;
     ///
     /// fn foo(contract_id: ContractId, asset_id: AssetId) {
-    ///     let contract_abi = abi(SRC3, contract_id);
+    ///     let contract_abi = abi(SRC3, contract_id.bits());
     ///     contract_abi {
     ///         gas: 10000,
     ///         coins: 100,

--- a/standards/src/src5.sw
+++ b/standards/src/src5.sw
@@ -39,8 +39,12 @@ abi SRC5 {
     /// # Examples
     ///
     /// ```sway
-    /// fn foo() {
-    ///     match owner() {
+    /// use standards::src5::{SRC5, Owner, State};
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let contract_abi = abi(SRC5, contract_id.bits());
+    ///
+    ///     match contract_abi.owner() {
     ///         State::Uninitalized => log("The ownership is uninitalized"),
     ///         State::Initialized(owner) => log("The ownership is initalized"),
     ///         State::Revoked => log("The ownership is revoked"),

--- a/standards/src/src7.sw
+++ b/standards/src/src7.sw
@@ -17,13 +17,13 @@ abi SRC7 {
     /// # Examples
     ///
     /// ```sway
-    /// use src7::{SRC7, Metadata};
+    /// use standards::src7::{SRC7, Metadata};
     /// use std::string::String;
     ///
     /// fn foo(contract_id: ContractId, asset: AssetId) {
-    ///     let contract_abi = abi(SRC7, contract_id);
+    ///     let contract_abi = abi(SRC7, contract_id.bits());
     ///     let key = String::from_ascii_str("image");
-    ///     let data = contract_abi.metadata(asset, key);
+    ///     let result_metadata: Option<Metadata> = contract_abi.metadata(asset, key);
     ///     assert(data.is_some());
     /// }
     /// ```


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Imports missing `standards::`
- Using `contract` which is a reserved keyword as function arguments
- Missing type annotations
- Attempted accessing of private values of structs
- Missing contract abi defintion

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
