### PR TITLE
Add helper functions to SRC7 standard's `Metadata`

### DIFF
--- a/standards/src/src7.sw
+++ b/standards/src/src7.sw
@@ -74,3 +74,217 @@ impl core::ops::Eq for Metadata {
         }
     }
 }
+
+impl Metadata {
+    /// Returns the underlying metadata as a `String`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<String>] - `Some` if the underlying type is a `String`, otherwise `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::string::String;
+    /// use standards::src7::{SRC7, Metadata};
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
+    ///     let metadata_abi = abi(SRC7, contract_id);
+    ///     let metadata: Option<Metadata> = metadata_abi.metadata(asset, key);
+    ///
+    ///     let string = metadata.unwrap().as_string();
+    ///     assert(string.len() != 0);
+    /// }
+    /// ```
+    pub fn as_string(self) -> Option<String> {
+        match self {
+            Self::String(data) => Option::Some(data),
+            _ => Option::None,
+        }
+    }
+
+    /// Returns whether the underlying metadata is a `String`.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - `true` if the metadata is a `String`, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::string::String;
+    /// use standards::src7::{SRC7, Metadata};
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
+    ///     let metadata_abi = abi(SRC7, contract_id);
+    ///     let metadata: Option<Metadata> = metadata_abi.metadata(asset, key);
+    ///
+    ///     assert(metadata.unwrap().is_string());
+    /// }
+    /// ```
+    pub fn is_string(self) -> bool {
+        match self {
+            Self::String(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns the underlying metadata as a `u64`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<u64>] - `Some` if the underlying type is a `u64`, otherwise `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::string::String;
+    /// use standards::src7::{SRC7, Metadata};
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
+    ///     let metadata_abi = abi(SRC7, contract_id);
+    ///     let metadata: Option<Metadata> = metadata_abi.metadata(asset, key);
+    ///
+    ///     let int = metadata.unwrap().as_u64();
+    ///     assert(int != 0);
+    /// }
+    /// ```
+    pub fn as_u64(self) -> Option<u64> {
+        match self {
+            Self::Int(data) => Option::Some(data),
+            _ => Option::None,
+        }
+    }
+
+    /// Returns whether the underlying metadata is a `u64`.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - `true` if the metadata is a `u64`, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::string::String;
+    /// use standards::src7::{SRC7, Metadata};
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
+    ///     let metadata_abi = abi(SRC7, contract_id);
+    ///     let metadata: Option<Metadata> = metadata_abi.metadata(asset, key);
+    ///
+    ///     assert(metadata.unwrap().is_u64());
+    /// }
+    /// ```
+    pub fn is_u64(self) -> bool {
+        match self {
+            Self::Int(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns the underlying metadata as `Bytes`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<Bytes>] - `Some` if the underlying type is `Bytes`, otherwise `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::{bytes::Bytes, string::String};
+    /// use standards::src7::{SRC7, Metadata};
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
+    ///     let metadata_abi = abi(SRC7, contract_id);
+    ///     let metadata: Option<Metadata> = metadata_abi.metadata(asset, key);
+    ///
+    ///     let bytes = metadata.unwrap().as_bytes();
+    ///     assert(bytes.len() != 0);
+    /// }
+    /// ```
+    pub fn as_bytes(self) -> Option<Bytes> {
+        match self {
+            Self::Bytes(data) => Option::Some(data),
+            _ => Option::None,
+        }
+    }
+
+    /// Returns whether the underlying metadata is `Bytes`.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - `true` if the metadata is `Bytes`, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::{bytes::Bytes, string::String};
+    /// use standards::src7::{SRC7, Metadata};
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
+    ///     let metadata_abi = abi(SRC7, contract_id);
+    ///     let metadata: Option<Metadata> = metadata_abi.metadata(asset, key);
+    ///
+    ///     assert(metadata.unwrap().is_bytes());
+    /// }
+    /// ```
+    pub fn is_bytes(self) -> bool {
+        match self {
+            Self::Bytes(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns the underlying metadata as a `b256`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<u64>] - `Some` if the underlying type is a `b256`, otherwise `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::string::String;
+    /// use standards::src7::{SRC7, Metadata};
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
+    ///     let metadata_abi = abi(SRC7, contract_id);
+    ///     let metadata: Option<Metadata> = metadata_abi.metadata(asset, key);
+    ///
+    ///     let val = metadata.unwrap().as_b256();
+    ///     assert(val != b256::zero());
+    /// }
+    /// ```
+    pub fn as_b256(self) -> Option<b256> {
+        match self {
+            Self::B256(data) => Option::Some(data),
+            _ => Option::None,
+        }
+    }
+
+    /// Returns whether the underlying metadata is a `b256`.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - `true` if the metadata is a `b256`, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::string::String;
+    /// use standards::src7::{SRC7, Metadata};
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
+    ///     let metadata_abi = abi(SRC7, contract_id);
+    ///     let metadata: Option<Metadata> = metadata_abi.metadata(asset, key);
+    ///
+    ///     assert(metadata.unwrap().is_b256());
+    /// }
+    /// ```
+    pub fn is_b256(self) -> bool {
+        match self {
+            Self::B256(_) => true,
+            _ => false,
+        }
+    }
+}


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- Adds `as_string()` function to `Metadata`
- Adds `is_string()` function to `Metadata`
- Adds `as_u64()` function to `Metadata`
- Adds `is_u64()` function to `Metadata`
- Adds `as_bytes()` function to `Metadata`
- Adds `is_bytes()` function to `Metadata`
- Adds `as_b256()` function to `Metadata`
- Adds `is_b256()` function to `Metadata`

## Notes

- This has been moved over from Sway-Libs

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.
