### PR TITLE
Add helper functions to struct types and `Eq` implementations for all types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ Description of the upcoming release here.
 
 ### Added Unreleased
 
-- None
+- [#149](https://github.com/FuelLabs/sway-standards/pull/149) Adds struct field getters, `new()`, and `Eq` implementations to SRC-10's `DepositMessage` and `MetadataMessage` types and SRC-11's `SecurityInformation` type.
+- [#149](https://github.com/FuelLabs/sway-standards/pull/149) Adds `Eq` implementation to SRC-5's `AccessError` error.
+- [#149](https://github.com/FuelLabs/sway-standards/pull/149) Adds check functions and `Eq` implementation to SRC-5's `State` type and SRC-10's `DepositType` type.
+- [#149](https://github.com/FuelLabs/sway-standards/pull/149) Adds struct field getters, `new()`, `log()`, and `Eq` implementations to SRC-6's `Deposit`, and `Withdraw` types, SRC-20's `SetNameEvent`, `SetSymbolEvent`, `SetDecimalsEvent`, and `TotalSupplyEvent` events, and SRC-7's `SetMetadataEvent` event.
 
 ### Changed Unreleased
 

--- a/examples/src20-native-asset/multi_asset/src/multi_asset.sw
+++ b/examples/src20-native-asset/multi_asset/src/multi_asset.sw
@@ -177,8 +177,8 @@ abi SetSRC20Data {
     fn set_src20_data(
         asset: AssetId,
         total_supply: u64,
-        name: String,
-        symbol: String,
+        name: Option<String>,
+        symbol: Option<String>,
         decimals: u8,
     );
 }
@@ -188,8 +188,8 @@ impl SetSRC20Data for Contract {
     fn set_src20_data(
         asset: AssetId,
         supply: u64,
-        name: String,
-        symbol: String,
+        name: Option<String>,
+        symbol: Option<String>,
         decimals: u8,
     ) {
         // NOTE: There are no checks for if the caller has permissions to update the metadata
@@ -199,28 +199,9 @@ impl SetSRC20Data for Contract {
         }
         let sender = msg_sender().unwrap();
 
-        log(SetNameEvent {
-            asset,
-            name: Some(name),
-            sender,
-        });
-
-        log(SetSymbolEvent {
-            asset,
-            symbol: Some(symbol),
-            sender,
-        });
-
-        log(SetDecimalsEvent {
-            asset,
-            decimals,
-            sender,
-        });
-
-        log(TotalSupplyEvent {
-            asset,
-            supply,
-            sender,
-        });
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, decimals, sender).log();
+        TotalSupplyEvent::new(asset, supply, sender).log();
     }
 }

--- a/examples/src20-native-asset/single_asset/src/single_asset.sw
+++ b/examples/src20-native-asset/single_asset/src/single_asset.sw
@@ -175,29 +175,12 @@ impl EmitSRC20Events for Contract {
         // Metadata that is stored as a configurable should only be emitted once.
         let asset = AssetId::default();
         let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
 
-        log(SetNameEvent {
-            asset,
-            name: Some(String::from_ascii_str(from_str_array(NAME))),
-            sender,
-        });
-
-        log(SetSymbolEvent {
-            asset,
-            symbol: Some(String::from_ascii_str(from_str_array(SYMBOL))),
-            sender,
-        });
-
-        log(SetDecimalsEvent {
-            asset,
-            decimals: DECIMALS,
-            sender,
-        });
-
-        log(TotalSupplyEvent {
-            asset,
-            supply: TOTAL_SUPPLY,
-            sender,
-        });
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, TOTAL_SUPPLY, sender).log();
     }
 }

--- a/examples/src6-vault/multi_asset_vault/src/main.sw
+++ b/examples/src6-vault/multi_asset_vault/src/main.sw
@@ -61,14 +61,16 @@ impl SRC6 for Contract {
         vault_info.managed_assets = vault_info.managed_assets + asset_amount;
         storage.vault_info.insert(share_asset, vault_info);
 
-        log(Deposit {
-            caller: msg_sender().unwrap(),
+        Deposit::new(
+            msg_sender()
+                .unwrap(),
             receiver,
             underlying_asset,
             vault_sub_id,
-            deposited_amount: asset_amount,
-            minted_shares: shares,
-        });
+            asset_amount,
+            shares,
+        )
+            .log();
 
         shares
     }
@@ -96,14 +98,16 @@ impl SRC6 for Contract {
 
         transfer(receiver, underlying_asset, assets);
 
-        log(Withdraw {
-            caller: msg_sender().unwrap(),
+        Withdraw::new(
+            msg_sender()
+                .unwrap(),
             receiver,
             underlying_asset,
             vault_sub_id,
-            withdrawn_amount: assets,
-            burned_shares: shares,
-        });
+            assets,
+            shares,
+        )
+            .log();
 
         assets
     }

--- a/examples/src6-vault/single_asset_single_sub_vault/src/main.sw
+++ b/examples/src6-vault/single_asset_single_sub_vault/src/main.sw
@@ -46,14 +46,16 @@ impl SRC6 for Contract {
             .managed_assets
             .write(storage.managed_assets.read() + asset_amount);
 
-        log(Deposit {
-            caller: msg_sender().unwrap(),
+        Deposit::new(
+            msg_sender()
+                .unwrap(),
             receiver,
             underlying_asset,
             vault_sub_id,
-            deposited_amount: asset_amount,
-            minted_shares: shares,
-        });
+            asset_amount,
+            shares,
+        )
+            .log();
 
         shares
     }
@@ -84,14 +86,16 @@ impl SRC6 for Contract {
 
         transfer(receiver, underlying_asset, assets);
 
-        log(Withdraw {
-            caller: msg_sender().unwrap(),
+        Withdraw::new(
+            msg_sender()
+                .unwrap(),
             receiver,
             underlying_asset,
             vault_sub_id,
-            withdrawn_amount: assets,
-            burned_shares: shares,
-        });
+            assets,
+            shares,
+        )
+            .log();
 
         assets
     }

--- a/examples/src6-vault/single_asset_vault/src/main.sw
+++ b/examples/src6-vault/single_asset_vault/src/main.sw
@@ -62,14 +62,16 @@ impl SRC6 for Contract {
         vault_info.managed_assets = vault_info.managed_assets + asset_amount;
         storage.vault_info.insert(share_asset, vault_info);
 
-        log(Deposit {
-            caller: msg_sender().unwrap(),
-            receiver: receiver,
+        Deposit::new(
+            msg_sender()
+                .unwrap(),
+            receiver,
             underlying_asset,
-            vault_sub_id: vault_sub_id,
-            deposited_amount: asset_amount,
-            minted_shares: shares,
-        });
+            vault_sub_id,
+            asset_amount,
+            shares,
+        )
+            .log();
 
         shares
     }
@@ -97,14 +99,16 @@ impl SRC6 for Contract {
 
         transfer(receiver, underlying_asset, assets);
 
-        log(Withdraw {
-            caller: msg_sender().unwrap(),
-            receiver: receiver,
+        Withdraw::new(
+            msg_sender()
+                .unwrap(),
+            receiver,
             underlying_asset,
-            vault_sub_id: vault_sub_id,
-            withdrawn_amount: assets,
-            burned_shares: shares,
-        });
+            vault_sub_id,
+            assets,
+            shares,
+        )
+            .log();
 
         assets
     }

--- a/examples/src7-metadata/multi_asset/src/multi_asset.sw
+++ b/examples/src7-metadata/multi_asset/src/multi_asset.sw
@@ -115,38 +115,29 @@ impl SetSRC7Events for Contract {
         if storage.total_supply.get(asset).try_read().is_none() {
             revert(0);
         }
-        let sender = msg_sender().unwrap();
-
-        log(SetMetadataEvent {
-            asset,
-            metadata: Some(Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X)))),
-            key: String::from_ascii_str("social:x"),
-            sender,
-        });
-
-        log(SetMetadataEvent {
-            asset,
-            metadata: Some(Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM)))),
-            key: String::from_ascii_str("site:forum"),
-            sender,
-        });
 
         storage.svg_images.try_insert(asset, StorageString {});
         storage.svg_images.get(asset).write_slice(svg_image);
-        log(SetMetadataEvent {
-            asset,
-            metadata: Some(Metadata::String(svg_image)),
-            key: String::from_ascii_str("image:svg"),
-            sender,
-        });
-
         storage.health_attributes.insert(asset, health_attribute);
-        log(SetMetadataEvent {
-            asset,
-            metadata: Some(Metadata::Int(health_attribute)),
-            key: String::from_ascii_str("attr:health"),
-            sender,
-        });
+
+        let sender = msg_sender().unwrap();
+        let metadata_1 = Some(Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X))));
+        let metadata_2 = Some(Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM))));
+        let metadata_3 = Some(Metadata::String(svg_image));
+        let metadata_4 = Some(Metadata::Int(health_attribute));
+        let key_1 = String::from_ascii_str("social:x");
+        let key_2 = String::from_ascii_str("site:forum");
+        let key_3 = String::from_ascii_str("image:svg");
+        let key_4 = String::from_ascii_str("attr:health");
+
+        SetMetadataEvent::new(asset, metadata_1, key_1, sender)
+            .log();
+        SetMetadataEvent::new(asset, metadata_2, key_2, sender)
+            .log();
+        SetMetadataEvent::new(asset, metadata_3, key_3, sender)
+            .log();
+        SetMetadataEvent::new(asset, metadata_4, key_4, sender)
+            .log();
     }
 }
 
@@ -195,29 +186,12 @@ impl SetSRC20Data for Contract {
     fn set_src20_data(asset: AssetId, supply: u64) {
         // NOTE: There are no checks for if the caller has permissions to update the metadata
         let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
 
-        log(SetNameEvent {
-            asset,
-            name: Some(String::from_ascii_str(from_str_array(NAME))),
-            sender,
-        });
-
-        log(SetSymbolEvent {
-            asset,
-            symbol: Some(String::from_ascii_str(from_str_array(SYMBOL))),
-            sender,
-        });
-
-        log(SetDecimalsEvent {
-            asset,
-            decimals: DECIMALS,
-            sender,
-        });
-
-        log(TotalSupplyEvent {
-            asset,
-            supply,
-            sender,
-        });
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, supply, sender).log();
     }
 }

--- a/examples/src7-metadata/single_asset/src/single_asset.sw
+++ b/examples/src7-metadata/single_asset/src/single_asset.sw
@@ -87,27 +87,19 @@ impl EmitSRC7Events for Contract {
     fn emit_src7_events() {
         let asset = AssetId::default();
         let sender = msg_sender().unwrap();
+        let metadata_1 = Some(Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X))));
+        let metadata_2 = Some(Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM))));
+        let metadata_3 = Some(Metadata::Int(ATTR_HEALTH));
+        let key_1 = String::from_ascii_str("social:x");
+        let key_2 = String::from_ascii_str("site:forum");
+        let key_3 = String::from_ascii_str("attr:health");
 
-        log(SetMetadataEvent {
-            asset,
-            metadata: Some(Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X)))),
-            key: String::from_ascii_str("social:x"),
-            sender,
-        });
-
-        log(SetMetadataEvent {
-            asset,
-            metadata: Some(Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM)))),
-            key: String::from_ascii_str("site:forum"),
-            sender,
-        });
-
-        log(SetMetadataEvent {
-            asset,
-            metadata: Some(Metadata::Int(ATTR_HEALTH)),
-            key: String::from_ascii_str("attr:health"),
-            sender,
-        });
+        SetMetadataEvent::new(asset, metadata_1, key_1, sender)
+            .log();
+        SetMetadataEvent::new(asset, metadata_2, key_2, sender)
+            .log();
+        SetMetadataEvent::new(asset, metadata_3, key_3, sender)
+            .log();
     }
 }
 
@@ -164,29 +156,12 @@ impl EmitSRC20Events for Contract {
         // Metadata that is stored as a configurable should only be emitted once.
         let asset = AssetId::default();
         let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
 
-        log(SetNameEvent {
-            asset,
-            name: Some(String::from_ascii_str(from_str_array(NAME))),
-            sender,
-        });
-
-        log(SetSymbolEvent {
-            asset,
-            symbol: Some(String::from_ascii_str(from_str_array(SYMBOL))),
-            sender,
-        });
-
-        log(SetDecimalsEvent {
-            asset,
-            decimals: DECIMALS,
-            sender,
-        });
-
-        log(TotalSupplyEvent {
-            asset,
-            supply: TOTAL_SUPPLY,
-            sender,
-        });
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, TOTAL_SUPPLY, sender).log();
     }
 }

--- a/standards/src/src10.sw
+++ b/standards/src/src10.sw
@@ -13,27 +13,20 @@ pub enum DepositType {
 }
 
 /// Enscapsultes metadata sent between the canonical chain and Fuel when a deposit is made.
-struct DepositMessage {
+pub struct DepositMessage {
     /// The number of tokens.
-    #[allow(dead_code)]
     pub amount: b256,
     /// The user's address on the canonical chain.
-    #[allow(dead_code)]
     pub from: b256,
     /// The bridging target destination on the Fuel chain.
-    #[allow(dead_code)]
     pub to: Identity,
     /// The bridged token's address on the canonical chain.
-    #[allow(dead_code)]
     pub token_address: b256,
     /// The token's ID on the canonical chain.
-    #[allow(dead_code)]
     pub token_id: b256,
     /// The decimals of the token.
-    #[allow(dead_code)]
     pub decimals: u8,
     /// The type of deposit made.
-    #[allow(dead_code)]
     pub deposit_type: DepositType,
 }
 
@@ -119,4 +112,471 @@ abi SRC10 {
         token_id: b256,
         gateway_contract: b256,
     );
+}
+
+impl core::ops::Eq for DepositType {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::Address, Self::Address) => true,
+            (Self::Contract, Self::Contract) => true,
+            (Self::ContractWithData, Self::ContractWithData) => true,
+            _ => false,
+        }
+    }
+}
+
+impl core::ops::Eq for DepositMessage {
+    fn eq(self, other: Self) -> bool {
+        self.amount == other.amount && self.from == other.from && self.to == other.to && self.token_address == other.token_address && self.token_id == other.token_id && self.decimals == other.decimals && self.deposit_type == other.deposit_type
+    }
+}
+
+impl core::ops::Eq for MetadataMessage {
+    fn eq(self, other: Self) -> bool {
+        self.token_address == other.token_address && self.token_id == other.token_id && self.name == other.name && self.symbol == other.symbol
+    }
+}
+
+impl DepositMessage {
+    /// Returns a new `DepositMessage`.
+    ///
+    /// # Arguments
+    ///
+    /// * `amount`: [b256] - The number of tokens.
+    /// * `from`: [b256] - The user's address on the canonical chain.
+    /// * `to`: [Identity] - The bridging target destination on the Fuel chain.
+    /// * `token_address`: [b256] - The bridged token's address on the canonical chain.
+    /// * `token_id`: [b256] - The token's ID on the canonical chain.
+    /// * `decimals`: [u8] - The decimals of the token.
+    /// * `deposit_type`: [DepositType] - The type of deposit made.
+    ///
+    /// # Returns
+    ///
+    /// * [DepositMessage] - The newly created `DepositMessage`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositMessage;
+    ///
+    /// fn foo(
+    ///     amount: b256,
+    ///     from: b256,
+    ///     to: Identity,
+    ///     token_address: b256,
+    ///     token_id: b256,
+    ///     decimals: u8,
+    ///     deposit_type: DepositType
+    /// ) {
+    ///     let deposit_message = DepositMessage::new(
+    ///         amount,
+    ///         from,
+    ///         to,
+    ///         token_address,
+    ///         token_id,
+    ///         decimals,
+    ///         deposit_type
+    ///     );
+    ///     assert(deposit_message.amount == amount);
+    ///     assert(deposit_message.from == from);
+    ///     assert(deposit_message.to == to);
+    ///     assert(deposit_message.token_address == token_address);
+    ///     assert(deposit_message.token_id == token_id);
+    ///     assert(deposit_message.decimals == decimals);
+    ///     assert(deposit_message.deposit_type == deposit_type);
+    /// }
+    /// ```
+    pub fn new(
+        amount: b256,
+        from: b256,
+        to: Identity,
+        token_address: b256,
+        token_id: b256,
+        decimals: u8,
+        deposit_type: DepositType,
+    ) -> Self {
+        Self {
+            amount,
+            from,
+            to,
+            token_address,
+            token_id,
+            decimals,
+            deposit_type,
+        }
+    }
+
+    /// Returns the `amount` of the `DepositMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The amount for the deposit message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositMessage;
+    ///
+    /// fn foo(
+    ///     amount: b256,
+    ///     from: b256,
+    ///     to: Identity,
+    ///     token_address: b256,
+    ///     token_id: b256,
+    ///     decimals: u8,
+    ///     deposit_type: DepositType
+    /// ) {
+    ///     let deposit_message = DepositMessage::new(
+    ///         amount,
+    ///         from,
+    ///         to,
+    ///         token_address,
+    ///         token_id,
+    ///         decimals,
+    ///         deposit_type
+    ///     );
+    ///     assert(deposit_message.amount() == amount);
+    /// }
+    /// ```
+    pub fn amount(self) -> b256 {
+        self.amount
+    }
+
+    /// Returns the `from` of the `DepositMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The from address for the deposit message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositMessage;
+    ///
+    /// fn foo(
+    ///     amount: b256,
+    ///     from: b256,
+    ///     to: Identity,
+    ///     token_address: b256,
+    ///     token_id: b256,
+    ///     decimals: u8,
+    ///     deposit_type: DepositType
+    /// ) {
+    ///     let deposit_message = DepositMessage::new(
+    ///         amount,
+    ///         from,
+    ///         to,
+    ///         token_address,
+    ///         token_id,
+    ///         decimals,
+    ///         deposit_type
+    ///     );
+    ///     assert(deposit_message.from() == from);
+    /// }
+    /// ```
+    pub fn from(self) -> b256 {
+        self.from
+    }
+
+    /// Returns the `to` of the `DepositMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The to `Identity` for the deposit message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositMessage;
+    ///
+    /// fn foo(
+    ///     amount: b256,
+    ///     from: b256,
+    ///     to: Identity,
+    ///     token_address: b256,
+    ///     token_id: b256,
+    ///     decimals: u8,
+    ///     deposit_type: DepositType
+    /// ) {
+    ///     let deposit_message = DepositMessage::new(
+    ///         amount,
+    ///         from,
+    ///         to,
+    ///         token_address,
+    ///         token_id,
+    ///         decimals,
+    ///         deposit_type
+    ///     );
+    ///     assert(deposit_message.to() == to);
+    /// }
+    /// ```
+    pub fn to(self) -> Identity {
+        self.to
+    }
+
+    /// Returns the `token_address` of the `DepositMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The token address for the deposit message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositMessage;
+    ///
+    /// fn foo(
+    ///     amount: b256,
+    ///     from: b256,
+    ///     to: Identity,
+    ///     token_address: b256,
+    ///     token_id: b256,
+    ///     decimals: u8,
+    ///     deposit_type: DepositType
+    /// ) {
+    ///     let deposit_message = DepositMessage::new(
+    ///         amount,
+    ///         from,
+    ///         to,
+    ///         token_address,
+    ///         token_id,
+    ///         decimals,
+    ///         deposit_type
+    ///     );
+    ///     assert(deposit_message.token_address() == token_address);
+    /// }
+    /// ```
+    pub fn token_address(self) -> b256 {
+        self.token_address
+    }
+
+    /// Returns the `token_id` of the `DepositMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The token id for the deposit message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositMessage;
+    ///
+    /// fn foo(
+    ///     amount: b256,
+    ///     from: b256,
+    ///     to: Identity,
+    ///     token_address: b256,
+    ///     token_id: b256,
+    ///     decimals: u8,
+    ///     deposit_type: DepositType
+    /// ) {
+    ///     let deposit_message = DepositMessage::new(
+    ///         amount,
+    ///         from,
+    ///         to,
+    ///         token_address,
+    ///         token_id,
+    ///         decimals,
+    ///         deposit_type
+    ///     );
+    ///     assert(deposit_message.token_id() == token_id);
+    /// }
+    /// ```
+    pub fn token_id(self) -> b256 {
+        self.token_id
+    }
+
+    /// Returns the `decimals` of the `DepositMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [u8] - The decimals for the deposit message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositMessage;
+    ///
+    /// fn foo(
+    ///     amount: b256,
+    ///     from: b256,
+    ///     to: Identity,
+    ///     token_address: b256,
+    ///     token_id: b256,
+    ///     decimals: u8,
+    ///     deposit_type: DepositType
+    /// ) {
+    ///     let deposit_message = DepositMessage::new(
+    ///         amount,
+    ///         from,
+    ///         to,
+    ///         token_address,
+    ///         token_id,
+    ///         decimals,
+    ///         deposit_type
+    ///     );
+    ///     assert(deposit_message.decimals() == decimals);
+    /// }
+    /// ```
+    pub fn decimals(self) -> u8 {
+        self.decimals
+    }
+
+    /// Returns the `deposit_type` of the `DepositMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [DepositType] - The deposit type for the deposit message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositMessage;
+    ///
+    /// fn foo(
+    ///     amount: b256,
+    ///     from: b256,
+    ///     to: Identity,
+    ///     token_address: b256,
+    ///     token_id: b256,
+    ///     decimals: u8,
+    ///     deposit_type: DepositType
+    /// ) {
+    ///     let deposit_message = DepositMessage::new(
+    ///         amount,
+    ///         from,
+    ///         to,
+    ///         token_address,
+    ///         token_id,
+    ///         decimals,
+    ///         deposit_type
+    ///     );
+    ///     assert(deposit_message.deposit_type() == deposit_type);
+    /// }
+    /// ```
+    pub fn deposit_type(self) -> DepositType {
+        self.deposit_type
+    }
+}
+
+impl MetadataMessage {
+    /// Returns a new `MetadataMessage`.
+    ///
+    /// # Arguments
+    ///
+    /// * `token_address`: [b256] - The bridged token's address on the canonical chain.
+    /// * `token_id`: [b256] - The token's ID on the canonical chain.
+    /// * `name`: [String] - The bridged token's name on the canonical chain.
+    /// * `symbol`: [String] - The bridged token's symbol on the canonical chain.
+    ///
+    /// # Returns
+    ///
+    /// * [MetadataMessage] - The newly created `MetadataMessage`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::MetadataMessage;
+    ///
+    /// fn foo(token_address: b256, token_id: b256, name: String, symbol: String) {
+    ///     let metadata_message = MetadataMessage::new(token_address, token_id, name, symbol);
+    ///     assert(metadata_message.token_address == token_address);
+    ///     assert(metadata_message.token_id == token_id);
+    ///     assert(deposit_message.name == name);
+    ///     assert(deposit_message.symbol == symbol);
+    /// }
+    /// ```
+    pub fn new(
+        token_address: b256,
+        token_id: b256,
+        name: String,
+        symbol: String,
+    ) -> Self {
+        Self {
+            token_address,
+            token_id,
+            name,
+            symbol,
+        }
+    }
+
+    /// Returns the `token_address` of the `MetadataMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The token address for the metdata message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::MetadataMessage;
+    ///
+    /// fn foo(token_address: b256, token_id: b256, name: String, symbol: String) {
+    ///     let metadata_message = MetadataMessage::new(token_address, token_id, name, symbol);
+    ///     assert(metadata_message.token_address() == token_address);
+    /// }
+    /// ```
+    pub fn token_address(self) -> b256 {
+        self.token_address
+    }
+
+    /// Returns the `token_id` of the `MetadataMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The token id for the metdata message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::MetadataMessage;
+    ///
+    /// fn foo(token_address: b256, token_id: b256, name: String, symbol: String) {
+    ///     let metadata_message = MetadataMessage::new(token_address, token_id, name, symbol);
+    ///     assert(metadata_message.token_id() == token_id);
+    /// }
+    /// ```
+    pub fn token_id(self) -> b256 {
+        self.token_id
+    }
+
+    /// Returns the `name` of the `MetadataMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [String] - The name for the metdata message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::MetadataMessage;
+    ///
+    /// fn foo(token_address: b256, token_id: b256, name: String, symbol: String) {
+    ///     let metadata_message = MetadataMessage::new(token_address, token_id, name, symbol);
+    ///     assert(metadata_message.name() == name);
+    /// }
+    /// ```
+    pub fn name(self) -> String {
+        self.name
+    }
+
+    /// Returns the `symbol` of the `MetadataMessage`.
+    ///
+    /// # Returns
+    ///
+    /// * [String] - The symbol for the metdata message.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::MetadataMessage;
+    ///
+    /// fn foo(token_address: b256, token_id: b256, name: String, symbol: String) {
+    ///     let metadata_message = MetadataMessage::new(token_address, token_id, name, symbol);
+    ///     assert(metadata_message.symbol() == symbol);
+    /// }
+    /// ```
+    pub fn symbol(self) -> String {
+        self.symbol
+    }
 }

--- a/standards/src/src10.sw
+++ b/standards/src/src10.sw
@@ -580,3 +580,71 @@ impl MetadataMessage {
         self.symbol
     }
 }
+
+impl DepositType {
+    /// Returns whether the deposit type is an address.
+    ///
+    /// # Return Values
+    ///
+    /// * [bool] - `true` if the deposit type is an address, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositType;
+    ///
+    /// fn foo(deposit_type: DepositType) {
+    ///     assert(DepositType.is_address());
+    /// }
+    /// ```
+    pub fn is_address(self) -> bool {
+        match self {
+            Self::Address => true,
+            _ => false,
+        }
+    }
+
+    /// Returns whether the deposit type is a contract.
+    ///
+    /// # Return Values
+    ///
+    /// * [bool] - `true` if the deposit type is a contract, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositType;
+    ///
+    /// fn foo(deposit_type: DepositType) {
+    ///     assert(DepositType.is_contract());
+    /// }
+    /// ```
+    pub fn is_contract(self) -> bool {
+        match self {
+            Self::Contract => true,
+            _ => false,
+        }
+    }
+
+    /// Returns whether the deposit type is a contract with data.
+    ///
+    /// # Return Values
+    ///
+    /// * [bool] - `true` if the deposit type is a contract with data, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src10::DepositType;
+    ///
+    /// fn foo(deposit_type: DepositType) {
+    ///     assert(DepositType.is_contract_with_data());
+    /// }
+    /// ```
+    pub fn is_contract_with_data(self) -> bool {
+        match self {
+            Self::ContractWithData => true,
+            _ => false,
+        }
+    }
+}

--- a/standards/src/src11.sw
+++ b/standards/src/src11.sw
@@ -46,3 +46,728 @@ abi SRC11 {
     #[storage(read)]
     fn security_information() -> SecurityInformation;
 }
+
+impl core::ops::Eq for SecurityInformation {
+    fn eq(self, other: Self) -> bool {
+        // If both contact info contain data, check each string
+        let self_contact_information_len = self.contact_information.len();
+        let other_contact_information_len = other.contact_information.len();
+        if self_contact_information_len > 0 && other_contact_information_len > 0 {
+            // Check each string matches
+            let mut iter = 0;
+            while iter < self_contact_information_len {
+                if self.contact_information.get(iter) != other.contact_information.get(iter)
+                {
+                    return false;
+                }
+                iter += 1;
+            }
+        } else if !(self_contact_information_len == 0 && self_contact_information_len == 0) { // Otherwise both must contain nothing
+            return false;
+        }
+
+        // If both prefered languages info contain data, check each string
+        if self.preferred_languages.is_some() && other.preferred_languages.is_some() {
+            let self_preferred_languages = self.preferred_languages.unwrap();
+            let other_preferred_languages = self.preferred_languages.unwrap();
+
+            let self_preferred_languages_len = self_preferred_languages.len();
+            let other_preferred_languages_len = other_preferred_languages.len();
+            // If lengths do not match, we do not need to iterate over the strings
+            if self_preferred_languages_len != other_preferred_languages_len
+            {
+                return false;
+            }
+
+            // Check each string matches
+            let mut iter = 0;
+            while iter < self_preferred_languages_len {
+                if self_preferred_languages.get(iter) != other_preferred_languages.get(iter)
+                {
+                    return false;
+                }
+                iter += 1;
+            }
+        } else if !(self.preferred_languages.is_none() && other.preferred_languages.is_none()) { // Otherwise both must be none
+            return false;
+        }
+
+        // If both auditors info contain data, check each string
+        if self.auditors.is_some() && other.auditors.is_some() {
+            let self_auditors = self.auditors.unwrap();
+            let other_auditors = self.auditors.unwrap();
+
+            let self_auditors_len = self_auditors.len();
+            let other_auditors_len = other_auditors.len();
+            // If lengths do not match, we do not need to iterate over the strings
+            if self_auditors_len != other_auditors_len {
+                return false;
+            }
+
+            // Check each string matches
+            let mut iter = 0;
+            while iter < self_auditors_len {
+                if self_auditors.get(iter) != other_auditors.get(iter) {
+                    return false;
+                }
+                iter += 1;
+            }
+        } else if !(self.auditors.is_none() && other.auditors.is_none()) { // Otherwise both must be none
+            return false;
+        }
+
+        self.name == other.name && self.project_url == other.project_url && self.policy == other.policy && self.encryption == other.encryption && self.source_code == other.source_code && self.source_release == other.source_release && self.source_revision == other.source_revision && self.acknowledgments == other.acknowledgments && self.additional_information == other.additional_information
+    }
+}
+
+impl SecurityInformation {
+    /// Returns a new `SecurityInformation`.
+    ///
+    /// # Arguments
+    ///
+    /// * `name`: [String] - Name of the project.
+    /// * `project_url`: [Option<String>] - Website URL of the project.
+    /// * `contact_information`: [Vec<String>] - List of contact information to contact developers of the project.
+    /// * `policy`: [String] - Text describing the project's security policy, or a link to it.
+    /// * `preferred_languages`: [Option<Vec<String>>] - A list of preferred languages (ISO 639-1).
+    /// * `encryption`: [Option<String>] - A PGP public key block (or similar) or a link to one.
+    /// * `source_code`: [Option<String>] - A URL to the project's source code.
+    /// * `source_release`: [Option<String>] - The release identifier of this build, ideally corresponding to a tag on git that can be rebuilt to reproduce the same binary.
+    /// * `source_revision`: [Option<String>] - The revision identifier of this build, usually a git commit hash that can be rebuilt to reproduce the same binary.
+    /// * `auditors`: [Option<Vec<String>>] - A list of people or entities that audited this smart contract, or links to pages where audit reports are hosted.
+    /// * `acknowledgments`: [Option<String>] - Text containing acknowledgments to security researchers who have previously found vulnerabilities in the project, or a link to it.
+    /// * `additional_information`: [Option<String>] - Text containing any additional information you want to provide, or a link to it.
+    ///
+    /// # Returns
+    ///
+    /// * [SecurityInformation] - The newly created `SecurityInformation`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.name == name);
+    ///     assert(security_information.project_url == project_url);
+    ///     assert(security_information.contact_information == contact_information);
+    ///     assert(security_information.policy == policy);
+    ///     assert(security_information.preferred_languages == preferred_languages);
+    ///     assert(security_information.encryption == encryption);
+    ///     assert(security_information.source_code == source_code);
+    ///     assert(security_information.source_release == source_release);
+    ///     assert(security_information.source_revision == source_revision);
+    ///     assert(security_information.auditors == auditors);
+    ///     assert(security_information.acknowledgments == acknowledgments);
+    ///     assert(security_information.additional_information == additional_information);
+    /// }
+    /// ```
+    pub fn new(
+        name: String,
+        project_url: Option<String>,
+        contact_information: Vec<String>,
+        policy: String,
+        preferred_languages: Option<Vec<String>>,
+        encryption: Option<String>,
+        source_code: Option<String>,
+        source_release: Option<String>,
+        source_revision: Option<String>,
+        auditors: Option<Vec<String>>,
+        acknowledgments: Option<String>,
+        additional_information: Option<String>,
+    ) -> Self {
+        Self {
+            name,
+            project_url,
+            contact_information,
+            policy,
+            preferred_languages,
+            encryption,
+            source_code,
+            source_release,
+            source_revision,
+            auditors,
+            acknowledgments,
+            additional_information,
+        }
+    }
+
+    /// Returns the `name` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `name`: [String] - Name of the project.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.name() == name);
+    /// }
+    /// ```
+    pub fn name(self) -> String {
+        self.name
+    }
+
+    /// Returns the `project_url` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `project_url`: [Option<String>] - Website URL of the project.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.project_url() == project_url);
+    /// }
+    /// ```
+    pub fn project_url(self) -> Option<String> {
+        self.project_url
+    }
+
+    /// Returns the `contact_information` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `contact_information`: [Vec<String>] - List of contact information to contact developers of the project.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.contact_information() == contact_information);
+    /// }
+    /// ```
+    pub fn contact_information(self) -> Vec<String> {
+        self.contact_information
+    }
+
+    /// Returns the `policy` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `policy`: [String] - Text describing the project's security policy, or a link to it.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.policy() == policy);
+    /// }
+    /// ```
+    pub fn policy(self) -> String {
+        self.policy
+    }
+
+    /// Returns the `preferred_languages` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `preferred_languages`: [Option<Vec<String>>] - A list of preferred languages (ISO 639-1).
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.preferred_languages() == preferred_languages);
+    /// }
+    /// ```
+    pub fn preferred_languages(self) -> Option<Vec<String>> {
+        self.preferred_languages
+    }
+
+    /// Returns the `encryption` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `encryption`: [Option<String>] - A PGP public key block (or similar) or a link to one.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.encryption() == encryption);
+    /// }
+    /// ```
+    pub fn encryption(self) -> Option<String> {
+        self.encryption
+    }
+
+    /// Returns the `source_code` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `source_code`: [Option<String>] - A URL to the project's source code.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.source_code() == source_code);
+    /// }
+    /// ```
+    pub fn source_code(self) -> Option<String> {
+        self.source_code
+    }
+
+    /// Returns the `source_release` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `source_release`: [Option<String>] - The release identifier of this build, ideally corresponding to a tag on git that can be rebuilt to reproduce the same binary.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.source_release() == source_release);
+    /// }
+    /// ```
+    pub fn source_release(self) -> Option<String> {
+        self.source_release
+    }
+
+    /// Returns the `source_revision` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `source_revision`: [Option<String>] - The revision identifier of this build, usually a git commit hash that can be rebuilt to reproduce the same binary.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.source_revision() == source_revision);
+    /// }
+    /// ```
+    pub fn source_revision(self) -> Option<String> {
+        self.source_revision
+    }
+
+    /// Returns the `auditors` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `auditors`: [Option<Vec<String>>] - A list of people or entities that audited this smart contract, or links to pages where audit reports are hosted.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.auditors() == auditors);
+    /// }
+    /// ```
+    pub fn auditors(self) -> Option<Vec<String>> {
+        self.auditors
+    }
+
+    /// Returns the `acknowledgments` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `acknowledgments`: [Option<String>] - Text containing acknowledgments to security researchers who have previously found vulnerabilities in the project, or a link to it.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.acknowledgments() == acknowledgments);
+    /// }
+    /// ```
+    pub fn acknowledgments(self) -> Option<String> {
+        self.acknowledgments
+    }
+
+    /// Returns the `additional_information` of the `SecurityInformation`.
+    ///
+    /// # Returns
+    ///
+    /// * `additional_information`: [Option<String>] - Text containing any additional information you want to provide, or a link to it.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src11::SecurityInformation;
+    ///
+    /// fn foo(
+    ///     name: String,
+    ///     project_url: Option<String>,
+    ///     contact_information: Vec<String>,
+    ///     policy: String,
+    ///     preferred_languages: Option<Vec<String>>,
+    ///     encryption: Option<String>,
+    ///     source_code: Option<String>,
+    ///     source_release: Option<String>,
+    ///     source_revision: Option<String>,
+    ///     auditors: Option<Vec<String>>,
+    ///     acknowledgments: Option<String>,
+    ///     additional_information: Option<String>,
+    /// ) {
+    ///     let security_information = SecurityInformation::new(
+    ///         name,
+    ///         project_url,
+    ///         contact_information,
+    ///         policy,
+    ///         preferred_languages,
+    ///         encryption,
+    ///         source_code,
+    ///         source_release,
+    ///         source_revision,
+    ///         auditors,
+    ///         acknowledgments,
+    ///         additional_information,
+    ///     );
+    ///     assert(security_information.additional_information() == additional_information);
+    /// }
+    /// ```
+    pub fn additional_information(self) -> Option<String> {
+        self.additional_information
+    }
+}

--- a/standards/src/src20.sw
+++ b/standards/src/src20.sw
@@ -163,3 +163,457 @@ pub struct TotalSupplyEvent {
     /// The caller that updated the supply.
     pub sender: Identity,
 }
+
+impl core::ops::Eq for SetNameEvent {
+    fn eq(self, other: Self) -> bool {
+        self.asset == other.asset && self.name == other.name && self.sender == other.sender
+    }
+}
+
+impl SetNameEvent {
+    /// Returns a new `SetNameEvent` event.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset for which name is set.
+    /// * `name`: [Option<String>] - The name that is set.
+    /// * `sender`: [Identity] - The caller that set the name.
+    ///
+    /// # Returns
+    ///
+    /// * [SetNameEvent] - The new `SetNameEvent` event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetNameEvent;
+    ///
+    /// fn foo(asset: AssetId, name: Option<String>, sender: Identity) {
+    ///     let my_event = SetNameEvent::new(asset, name, sender);
+    ///     assert(my_event.asset == asset);
+    ///     assert(my_event.name == name);
+    ///     assert(my_event.sender == sender);
+    /// }
+    pub fn new(asset: AssetId, name: Option<String>, sender: Identity) -> Self {
+        Self {
+            asset,
+            name,
+            sender,
+        }
+    }
+
+    /// Returns the asset of the `SetNameEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [AssetId] - The asset for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetNameEvent;
+    ///
+    /// fn foo(asset: AssetId, name: Option<String>, sender: Identity) {
+    ///     let my_event = SetNameEvent::new(asset, name, sender);
+    ///     assert(my_event.asset() == asset);
+    /// }
+    pub fn asset(self) -> AssetId {
+        self.asset
+    }
+
+    /// Returns the name of the `SetNameEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<String>] - The name for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetNameEvent;
+    ///
+    /// fn foo(asset: AssetId, name: Option<String>, sender: Identity) {
+    ///     let my_event = SetNameEvent::new(asset, name, sender);
+    ///     assert(my_event.name() == name);
+    /// }
+    pub fn name(self) -> Option<String> {
+        self.name
+    }
+
+    /// Returns the sender of the `SetNameEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The sender of the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetNameEvent;
+    ///
+    /// fn foo(asset: AssetId, name: Option<String>, sender: Identity) {
+    ///     let my_event = SetNameEvent::new(asset, name, sender);
+    ///     assert(my_event.sender() == sender);
+    /// }
+    pub fn sender(self) -> Identity {
+        self.sender
+    }
+
+    /// Logs the `SetNameEvent`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetNameEvent;
+    ///
+    /// fn foo(asset: AssetId, name: Option<String>, sender: Identity) {
+    ///     let my_event = SetNameEvent::new(asset, name, sender);
+    ///     my_event.log();
+    /// }
+    pub fn log(self) {
+        log(self);
+    }
+}
+
+impl core::ops::Eq for SetSymbolEvent {
+    fn eq(self, other: Self) -> bool {
+        self.asset == other.asset && self.symbol == other.symbol && self.sender == other.sender
+    }
+}
+
+impl SetSymbolEvent {
+    /// Returns a new `SetSymbolEvent` event.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset for which symbol is set.
+    /// * `symbol`: [Option<String>] - The symbol that is set.
+    /// * `sender`: [Identity] - The caller that set the symbol.
+    ///
+    /// # Returns
+    ///
+    /// * [SetSymbolEvent] - The new `SetSymbolEvent` event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetSymbolEvent;
+    ///
+    /// fn foo(asset: AssetId, symbol: Option<String>, sender: Identity) {
+    ///     let my_event = SetSymbolEvent::new(asset, symbol, sender);
+    ///     assert(my_event.asset == asset);
+    ///     assert(my_event.symbol == symbol);
+    ///     assert(my_event.sender == sender);
+    /// }
+    pub fn new(asset: AssetId, symbol: Option<String>, sender: Identity) -> Self {
+        Self {
+            asset,
+            symbol,
+            sender,
+        }
+    }
+
+    /// Returns the asset of the `SetSymbolEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [AssetId] - The asset for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetSymbolEvent;
+    ///
+    /// fn foo(asset: AssetId, symbol: Option<String>, sender: Identity) {
+    ///     let my_event = SetSymbolEvent::new(asset, symbol, sender);
+    ///     assert(my_event.asset() == asset);
+    /// }
+    pub fn asset(self) -> AssetId {
+        self.asset
+    }
+
+    /// Returns the symbol of the `SetSymbolEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<String>] - The symbol for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetSymbolEvent;
+    ///
+    /// fn foo(asset: AssetId, symbol: Option<String>, sender: Identity) {
+    ///     let my_event = SetSymbolEvent::new(asset, symbol, sender);
+    ///     assert(my_event.symbol() == symbol);
+    /// }
+    pub fn symbol(self) -> Option<String> {
+        self.symbol
+    }
+
+    /// Returns the sender of the `SetSymbolEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The sender of the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetSymbolEvent;
+    ///
+    /// fn foo(asset: AssetId, symbol: Option<String>, sender: Identity) {
+    ///     let my_event = SetSymbolEvent::new(asset, symbol, sender);
+    ///     assert(my_event.sender() == sender);
+    /// }
+    pub fn sender(self) -> Identity {
+        self.sender
+    }
+
+    /// Logs the `SetSymbolEvent`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetSymbolEvent;
+    ///
+    /// fn foo(asset: AssetId, symbol: Option<String>, sender: Identity) {
+    ///     let my_event = SetSymbolEvent::new(asset, symbol, sender);
+    ///     my_event.log();
+    /// }
+    pub fn log(self) {
+        log(self);
+    }
+}
+
+impl core::ops::Eq for SetDecimalsEvent {
+    fn eq(self, other: Self) -> bool {
+        self.asset == other.asset && self.decimals == other.decimals && self.sender == other.sender
+    }
+}
+
+impl SetDecimalsEvent {
+    /// Returns a new `SetDecimalsEvent` event.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset for which decimals is set.
+    /// * `decimals`: [u8] - The decimals that is set.
+    /// * `sender`: [Identity] - The caller that set the decimals.
+    ///
+    /// # Returns
+    ///
+    /// * [SetDecimalsEvent] - The new `SetDecimalsEvent` event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetDecimalsEvent;
+    ///
+    /// fn foo(asset: AssetId, decimals: u8, sender: Identity) {
+    ///     let my_event = SetDecimalsEvent::new(asset, decimals, sender);
+    ///     assert(my_event.asset == asset);
+    ///     assert(my_event.decimals == decimals);
+    ///     assert(my_event.sender == sender);
+    /// }
+    /// ```
+    pub fn new(asset: AssetId, decimals: u8, sender: Identity) -> Self {
+        Self {
+            asset,
+            decimals,
+            sender,
+        }
+    }
+
+    /// Returns the asset of the `SetDecimalsEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [AssetId] - The asset for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetDecimalsEvent;
+    ///
+    /// fn foo(asset: AssetId, decimals: u8, sender: Identity) {
+    ///     let my_event = SetDecimalsEvent::new(asset, decimals, sender);
+    ///     assert(my_event.asset() == asset);
+    /// }
+    /// ```
+    pub fn asset(self) -> AssetId {
+        self.asset
+    }
+
+    /// Returns the decimals of the `SetDecimalsEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [u8] - The decimals for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetDecimalsEvent;
+    ///
+    /// fn foo(asset: AssetId, decimals: u8, sender: Identity) {
+    ///     let my_event = SetDecimalsEvent::new(asset, decimals, sender);
+    ///     assert(my_event.decimals() == decimals);
+    /// }
+    /// ```
+    pub fn decimals(self) -> u8 {
+        self.decimals
+    }
+
+    /// Returns the sender of the `SetDecimalsEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The sender of the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetDecimalsEvent;
+    ///
+    /// fn foo(asset: AssetId, decimals: u8, sender: Identity) {
+    ///     let my_event = SetDecimalsEvent::new(asset, decimals, sender);
+    ///     assert(my_event.sender() == sender);
+    /// }
+    /// ```
+    pub fn sender(self) -> Identity {
+        self.sender
+    }
+
+    /// Logs the `SetDecimalsEvent`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::SetDecimalsEvent;
+    ///
+    /// fn foo(asset: AssetId, decimals: u8, sender: Identity) {
+    ///     let my_event = SetDecimalsEvent::new(asset, decimals, sender);
+    ///     my_event.log();
+    /// }
+    /// ```
+    pub fn log(self) {
+        log(self);
+    }
+}
+
+impl core::ops::Eq for TotalSupplyEvent {
+    fn eq(self, other: Self) -> bool {
+        self.asset == other.asset && self.supply == other.supply && self.sender == other.sender
+    }
+}
+
+impl TotalSupplyEvent {
+    /// Returns a new `TotalSupplyEvent` event.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset for which supply is updated.
+    /// * `supply`: [u64] - The new supply of the asset.
+    /// * `sender`: [Identity] - The caller that updated the supply.
+    ///
+    /// # Returns
+    ///
+    /// * [TotalSupplyEvent] - The new `TotalSupplyEvent` event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::TotalSupplyEvent;
+    ///
+    /// fn foo(asset: AssetId, supply: u64, sender: Identity) {
+    ///     let my_event = TotalSupplyEvent::new(asset, supply, sender);
+    ///     assert(my_event.asset == asset);
+    ///     assert(my_event.supply == supply);
+    ///     assert(my_event.sender == sender);
+    /// }
+    /// ```
+    pub fn new(asset: AssetId, supply: u64, sender: Identity) -> Self {
+        Self {
+            asset,
+            supply,
+            sender,
+        }
+    }
+
+    /// Returns the asset of the `TotalSupplyEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [AssetId] - The asset for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::TotalSupplyEvent;
+    ///
+    /// fn foo(asset: AssetId, supply: u64, sender: Identity) {
+    ///     let my_event = TotalSupplyEvent::new(asset, supply, sender);
+    ///     assert(my_event.asset() == asset);
+    /// }
+    /// ```
+    pub fn asset(self) -> AssetId {
+        self.asset
+    }
+
+    /// Returns the supply of the `TotalSupplyEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The supply for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::TotalSupplyEvent;
+    ///
+    /// fn foo(asset: AssetId, supply: u64, sender: Identity) {
+    ///     let my_event = TotalSupplyEvent::new(asset, supply, sender);
+    ///     assert(my_event.supply() == supply);
+    /// }
+    /// ```
+    pub fn supply(self) -> u64 {
+        self.supply
+    }
+
+    /// Returns the sender of the `TotalSupplyEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The sender of the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::TotalSupplyEvent;
+    ///
+    /// fn foo(asset: AssetId, supply: u64, sender: Identity) {
+    ///     let my_event = TotalSupplyEvent::new(asset, supply, sender);
+    ///     assert(my_event.sender() == sender);
+    /// }
+    /// ```
+    pub fn sender(self) -> Identity {
+        self.sender
+    }
+
+    /// Logs the `TotalSupplyEvent`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src20::TotalSupplyEvent;
+    ///
+    /// fn foo(asset: AssetId, supply: u64, sender: Identity) {
+    ///     let my_event = TotalSupplyEvent::new(asset, supply, sender);
+    ///     my_event.log();
+    /// }
+    /// ```
+    pub fn log(self) {
+        log(self);
+    }
+}

--- a/standards/src/src5.sw
+++ b/standards/src/src5.sw
@@ -10,31 +10,10 @@ pub enum State {
     Revoked: (),
 }
 
-impl core::ops::Eq for State {
-    fn eq(self, other: Self) -> bool {
-        match (self, other) {
-            (Self::Initialized(owner1), Self::Initialized(owner2)) => {
-                owner1 == owner2
-            },
-            (Self::Uninitialized, Self::Uninitialized) => true,
-            (Self::Revoked, Self::Revoked) => true,
-            _ => false,
-        }
-    }
-}
-
 /// Error log for when access is denied.
 pub enum AccessError {
     /// Emitted when the caller is not the owner of the contract.
     NotOwner: (),
-}
-
-impl core::ops::Eq for AccessError {
-    fn eq(self, other: Self) -> bool {
-        match (self, other) {
-            (Self::NotOwner, Self::NotOwner) => true,
-        }
-    }
 }
 
 abi SRC5 {
@@ -47,7 +26,7 @@ abi SRC5 {
     /// # Examples
     ///
     /// ```sway
-    /// use standards::src5::{SRC5, Owner, State};
+    /// use standards::src5::{SRC5, State};
     ///
     /// fn foo(contract_id: ContractId) {
     ///     let contract_abi = abi(SRC5, contract_id.bits());
@@ -61,4 +40,127 @@ abi SRC5 {
     /// ```
     #[storage(read)]
     fn owner() -> State;
+}
+
+impl core::ops::Eq for State {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::Initialized(owner1), Self::Initialized(owner2)) => {
+                owner1 == owner2
+            },
+            (Self::Uninitialized, Self::Uninitialized) => true,
+            (Self::Revoked, Self::Revoked) => true,
+            _ => false,
+        }
+    }
+}
+
+impl core::ops::Eq for AccessError {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::NotOwner, Self::NotOwner) => true,
+        }
+    }
+}
+
+impl State {
+    /// Returns whether the state is uninitialized.
+    ///
+    /// # Return Values
+    ///
+    /// * [bool] - `true` if the state is uninitialized, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src5::{SRC5, State};
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let contract_abi = abi(SRC5, contract_id.bits());
+    ///
+    ///     let owner_state: State = contract_abi.owner();
+    ///     assert(owner_state.is_uninitialized());
+    /// }
+    /// ```
+    pub fn is_uninitialized(self) -> bool {
+        match self {
+            Self::Uninitialized => true,
+            _ => false,
+        }
+    }
+
+    /// Returns whether the state is initialized.
+    ///
+    /// # Return Values
+    ///
+    /// * [bool] - `true` if the state is initialized, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src5::{SRC5, State};
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let contract_abi = abi(SRC5, contract_id.bits());
+    ///
+    ///     let owner_state: State = contract_abi.owner();
+    ///     assert(owner_state.is_initialized());
+    /// }
+    /// ```
+    pub fn is_initialized(self) -> bool {
+        match self {
+            Self::Initialized(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns whether the state is revoked.
+    ///
+    /// # Return Values
+    ///
+    /// * [bool] - `true` if the state is revoked, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src5::{SRC5, State};
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let contract_abi = abi(SRC5, contract_id.bits());
+    ///
+    ///     let owner_state: State = contract_abi.owner();
+    ///     assert(owner_state.is_revoked());
+    /// }
+    /// ```
+    pub fn is_revoked(self) -> bool {
+        match self {
+            Self::Revoked => true,
+            _ => false,
+        }
+    }
+
+    /// Returns the underlying owner as a `Identity`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<Identity>] - `Some` if the state is initialized, otherwise `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src5::{SRC5, State};
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let contract_abi = abi(SRC5, contract_id.bits());
+    ///
+    ///     let owner_state: State = contract_abi.owner();
+    ///     assert(owner_state.owner().is_some());
+    /// }
+    /// ```
+    pub fn owner(self) -> Option<Identity> {
+        match self {
+            Self::Initialized(owner) => Some(owner),
+            _ => None,
+        }
+    }
 }

--- a/standards/src/src5.sw
+++ b/standards/src/src5.sw
@@ -13,11 +13,11 @@ pub enum State {
 impl core::ops::Eq for State {
     fn eq(self, other: Self) -> bool {
         match (self, other) {
-            (State::Initialized(owner1), State::Initialized(owner2)) => {
+            (Self::Initialized(owner1), Self::Initialized(owner2)) => {
                 owner1 == owner2
             },
-            (State::Uninitialized, State::Uninitialized) => true,
-            (State::Revoked, State::Revoked) => true,
+            (Self::Uninitialized, Self::Uninitialized) => true,
+            (Self::Revoked, Self::Revoked) => true,
             _ => false,
         }
     }
@@ -27,6 +27,14 @@ impl core::ops::Eq for State {
 pub enum AccessError {
     /// Emitted when the caller is not the owner of the contract.
     NotOwner: (),
+}
+
+impl core::ops::Eq for AccessError {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::NotOwner, Self::NotOwner) => true,
+        }
+    }
 }
 
 abi SRC5 {

--- a/standards/src/src6.sw
+++ b/standards/src/src6.sw
@@ -141,3 +141,499 @@ abi SRC6 {
     #[storage(read)]
     fn max_withdrawable(underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64>;
 }
+
+impl core::ops::Eq for Deposit {
+    fn eq(self, other: Self) -> bool {
+        self.caller == other.caller && self.receiver == other.receiver && self.underlying_asset == other.underlying_asset && self.vault_sub_id == other.vault_sub_id && self.deposited_amount == other.deposited_amount && self.minted_shares == other.minted_shares
+    }
+}
+
+impl core::ops::Eq for Withdraw {
+    fn eq(self, other: Self) -> bool {
+        self.caller == other.caller && self.receiver == other.receiver && self.underlying_asset == other.underlying_asset && self.vault_sub_id == other.vault_sub_id && self.withdrawn_amount == other.withdrawn_amount && self.burned_shares == other.burned_shares
+    }
+}
+
+impl Deposit {
+    /// Returns a new `Deposit` event.
+    ///
+    /// # Arguments
+    ///
+    /// * `caller`: [Identity] - The caller of the deposit function.
+    /// * `receiver`: [Identity] - The receiver of the deposit.
+    /// * `underlying_asset`: [AssetId] - The asset being deposited.
+    /// * `vault_sub_id`: [SubId] - The SubId of the vault.
+    /// * `deposited_amount`: [u64] - The amount of assets being deposited.
+    /// * `minted_shares`: [u64] - The amount of shares being minted.
+    ///
+    /// # Returns
+    ///
+    /// * [Deposit] - The new `Deposit` event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Deposit;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     deposited_amount: u64,
+    ///     minted_shares: u64
+    /// ) {
+    ///     let my_event = Deposit::new(caller, receiver, underlying_asset, vault_sub_id, deposited_amount, minted_shares);
+    ///     assert(my_event.caller == caller);
+    ///     assert(my_event.receiver == receiver);
+    ///     assert(my_event.underlying_asset == underlying_asset);
+    ///     assert(my_event.vault_sub_id == vault_sub_id);
+    ///     assert(my_event.deposited_amount == deposited_amount);
+    ///     assert(my_event.minted_shares == minted_shares);
+    /// }
+    /// ```
+    pub fn new(
+        caller: Identity,
+        receiver: Identity,
+        underlying_asset: AssetId,
+        vault_sub_id: SubId,
+        deposited_amount: u64,
+        minted_shares: u64,
+    ) -> Self {
+        Self {
+            caller,
+            receiver,
+            underlying_asset,
+            vault_sub_id,
+            deposited_amount,
+            minted_shares,
+        }
+    }
+
+    /// Returns the `caller` of the `Deposit` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The caller for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Deposit;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     deposited_amount: u64,
+    ///     minted_shares: u64
+    /// ) {
+    ///     let my_event = Deposit::new(caller, receiver, underlying_asset, vault_sub_id, deposited_amount, minted_shares);
+    ///     assert(my_event.caller() == caller);
+    /// }
+    /// ```
+    pub fn caller(self) -> Identity {
+        self.caller
+    }
+
+    /// Returns the `receiver` of the `Deposit` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The receiver for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Deposit;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     deposited_amount: u64,
+    ///     minted_shares: u64
+    /// ) {
+    ///     let my_event = Deposit::new(caller, receiver, underlying_asset, vault_sub_id, deposited_amount, minted_shares);
+    ///     assert(my_event.receiver() == receiver);
+    /// }
+    /// ```
+    pub fn receiver(self) -> Identity {
+        self.receiver
+    }
+
+    /// Returns the `underlying_asset` of the `Deposit` event.
+    ///
+    /// # Returns
+    ///
+    /// * [AssetId] - The underlying asset for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Deposit;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     deposited_amount: u64,
+    ///     minted_shares: u64
+    /// ) {
+    ///     let my_event = Deposit::new(caller, receiver, underlying_asset, vault_sub_id, deposited_amount, minted_shares);
+    ///     assert(my_event.underlying_asset() == underlying_asset);
+    /// }
+    /// ```
+    pub fn underlying_asset(self) -> AssetId {
+        self.underlying_asset
+    }
+
+    /// Returns the `vault_sub_id` of the `Deposit` event.
+    ///
+    /// # Returns
+    ///
+    /// * [SubId] - The vault sub id for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Deposit;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     deposited_amount: u64,
+    ///     minted_shares: u64
+    /// ) {
+    ///     let my_event = Deposit::new(caller, receiver, underlying_asset, vault_sub_id, deposited_amount, minted_shares);
+    ///     assert(my_event.vault_sub_id() == vault_sub_id);
+    /// }
+    /// ```
+    pub fn vault_sub_id(self) -> SubId {
+        self.vault_sub_id
+    }
+
+    /// Returns the `deposited_amount` of the `Deposit` event.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The deposited amount for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Deposit;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     deposited_amount: u64,
+    ///     minted_shares: u64
+    /// ) {
+    ///     let my_event = Deposit::new(caller, receiver, underlying_asset, vault_sub_id, deposited_amount, minted_shares);
+    ///     assert(my_event.deposited_amount() == deposited_amount);
+    /// }
+    /// ```
+    pub fn deposited_amount(self) -> u64 {
+        self.deposited_amount
+    }
+
+    /// Returns the `minted_shares` of the `Deposit` event.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The minted shares for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Deposit;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     deposited_amount: u64,
+    ///     minted_shares: u64
+    /// ) {
+    ///     let my_event = Deposit::new(caller, receiver, underlying_asset, vault_sub_id, deposited_amount, minted_shares);
+    ///     assert(my_event.minted_shares() == minted_shares);
+    /// }
+    /// ```
+    pub fn minted_shares(self) -> u64 {
+        self.minted_shares
+    }
+
+    /// Logs the `Deposit`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Deposit;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     deposited_amount: u64,
+    ///     minted_shares: u64
+    /// ) {
+    ///     let my_event = Deposit::new(caller, receiver, underlying_asset, vault_sub_id, deposited_amount, minted_shares);
+    ///     my_event.log();
+    /// }
+    /// ```
+    pub fn log(self) {
+        log(self);
+    }
+}
+
+impl Withdraw {
+    /// Returns a new `Withdraw` event.
+    ///
+    /// # Arguments
+    ///
+    /// * `caller`: [Identity] - The caller of the withdrawal function.
+    /// * `receiver`: [Identity] - The receiver of the withdrawal.
+    /// * `underlying_asset`: [AssetId] - The asset being withdrawn.
+    /// * `vault_sub_id`: [SubId] - The SubId of the vault.
+    /// * `withdrawn_amount`: [u64] - The amount of assets being withdrawn.
+    /// * `burned_shares`: [u64] - The amount of shares being burned.
+    ///
+    /// # Returns
+    ///
+    /// * [Withdraw] - The new `Withdraw` event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Withdraw;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     withdrawn_amount: u64,
+    ///     burned_shares: u64
+    /// ) {
+    ///     let my_event = Withdraw::new(caller, receiver, underlying_asset, vault_sub_id, withdrawn_amount, burned_shares);
+    ///     assert(my_event.caller == caller);
+    ///     assert(my_event.receiver == receiver);
+    ///     assert(my_event.underlying_asset == underlying_asset);
+    ///     assert(my_event.vault_sub_id == vault_sub_id);
+    ///     assert(my_event.withdrawn_amount == withdrawn_amount);
+    ///     assert(my_event.burned_shares == burned_shares);
+    /// }
+    /// ```
+    pub fn new(
+        caller: Identity,
+        receiver: Identity,
+        underlying_asset: AssetId,
+        vault_sub_id: SubId,
+        withdrawn_amount: u64,
+        burned_shares: u64,
+    ) -> Self {
+        Self {
+            caller,
+            receiver,
+            underlying_asset,
+            vault_sub_id,
+            withdrawn_amount,
+            burned_shares,
+        }
+    }
+
+    /// Returns the `caller` of the `Withdraw` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The caller for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Withdraw;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     withdrawn_amount: u64,
+    ///     burned_shares: u64
+    /// ) {
+    ///     let my_event = Withdraw::new(caller, receiver, underlying_asset, vault_sub_id, withdrawn_amount, burned_shares);
+    ///     assert(my_event.caller() == caller);
+    /// }
+    /// ```
+    pub fn caller(self) -> Identity {
+        self.caller
+    }
+
+    /// Returns the `receiver` of the `Withdraw` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The receiver for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Withdraw;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     withdrawn_amount: u64,
+    ///     burned_shares: u64
+    /// ) {
+    ///     let my_event = Withdraw::new(caller, receiver, underlying_asset, vault_sub_id, withdrawn_amount, burned_shares);
+    ///     assert(my_event.receiver() == receiver);
+    /// }
+    /// ```
+    pub fn receiver(self) -> Identity {
+        self.receiver
+    }
+
+    /// Returns the `underlying_asset` of the `Withdraw` event.
+    ///
+    /// # Returns
+    ///
+    /// * [AssetId] - The underlying asset for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Withdraw;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     withdrawn_amount: u64,
+    ///     burned_shares: u64
+    /// ) {
+    ///     let my_event = Withdraw::new(caller, receiver, underlying_asset, vault_sub_id, withdrawn_amount, burned_shares);
+    ///     assert(my_event.underlying_asset() == underlying_asset);
+    /// }
+    /// ```
+    pub fn underlying_asset(self) -> AssetId {
+        self.underlying_asset
+    }
+
+    /// Returns the `vault_sub_id` of the `Withdraw` event.
+    ///
+    /// # Returns
+    ///
+    /// * [SubId] - The vault sub id for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Withdraw;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     withdrawn_amount: u64,
+    ///     burned_shares: u64
+    /// ) {
+    ///     let my_event = Withdraw::new(caller, receiver, underlying_asset, vault_sub_id, withdrawn_amount, burned_shares);
+    ///     assert(my_event.vault_sub_id() == vault_sub_id);
+    /// }
+    /// ```
+    pub fn vault_sub_id(self) -> SubId {
+        self.vault_sub_id
+    }
+
+    /// Returns the `withdrawn_amount` of the `Withdraw` event.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The withdrawn amount for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Withdraw;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     withdrawn_amount: u64,
+    ///     burned_shares: u64
+    /// ) {
+    ///     let my_event = Withdraw::new(caller, receiver, underlying_asset, vault_sub_id, withdrawn_amount, burned_shares);
+    ///     assert(my_event.withdrawn_amount() == withdrawn_amount);
+    /// }
+    /// ```
+    pub fn withdrawn_amount(self) -> u64 {
+        self.withdrawn_amount
+    }
+
+    /// Returns the `burned_shares` of the `Withdraw` event.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The burned shares for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Withdraw;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     withdrawn_amount: u64,
+    ///     burned_shares: u64
+    /// ) {
+    ///     let my_event = Withdraw::new(caller, receiver, underlying_asset, vault_sub_id, withdrawn_amount, burned_shares);
+    ///     assert(my_event.burned_shares() == burned_shares);
+    /// }
+    /// ```
+    pub fn burned_shares(self) -> u64 {
+        self.burned_shares
+    }
+
+    /// Logs the `Withdraw`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src6::Withdraw;
+    ///
+    /// fn foo(
+    ///     caller: Identity,
+    ///     receiver: Identity,
+    ///     underlying_asset: AssetId,
+    ///     vault_sub_id: SubId,
+    ///     withdrawn_amount: u64,
+    ///     burned_shares: u64
+    /// ) {
+    ///     let my_event = Withdraw::new(caller, receiver, underlying_asset, vault_sub_id, withdrawn_amount, burned_shares);
+    ///     my_event.log();
+    /// }
+    /// ```
+    pub fn log(self) {
+        log(self);
+    }
+}

--- a/standards/src/src7.sw
+++ b/standards/src/src7.sw
@@ -74,3 +74,147 @@ impl core::ops::Eq for Metadata {
         }
     }
 }
+
+impl core::ops::Eq for SetMetadataEvent {
+    fn eq(self, other: Self) -> bool {
+        self.asset == other.asset && self.metadata == other.metadata && self.key == other.key && self.sender == other.sender
+    }
+}
+
+impl SetMetadataEvent {
+    /// Returns a new `SetMetadataEvent` event.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset for which metadata is set.
+    /// * `metadata`: [Option<Metdata>] - The Metadata that is set.
+    /// * `ket`: [String] - The key used for the metadata.
+    /// * `sender`: [Identity] - The caller that set the metadata.
+    ///
+    /// # Returns
+    ///
+    /// * [SetMetadataEvent] - The new `SetMetadataEvent` event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src7::SetMetadataEvent;
+    ///
+    /// fn foo(asset: AssetId, metadata: Option<Metadata>, key: String, sender: Identity) {
+    ///     let my_set_metadata_event = SetMetadataEvent::new(asset, metadata, key, sender);
+    ///     assert(my_set_metadata_event.asset == asset);
+    ///     assert(my_set_metadata_event.metadata == metadata);
+    ///     assert(my_set_metadata_event.key == key);
+    ///     assert(my_set_metadata_event.sender == sender);
+    /// }
+    /// ```
+    pub fn new(
+        asset: AssetId,
+        metadata: Option<Metadata>,
+        key: String,
+        sender: Identity,
+    ) -> Self {
+        Self {
+            asset,
+            metadata,
+            key,
+            sender,
+        }
+    }
+
+    /// Returns the asset of the `SetMetadataEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [AssetId] - The asset for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src7::SetMetadataEvent;
+    ///
+    /// fn foo(asset: AssetId, metadata: Option<Metadata>, key: String, sender: Identity) {
+    ///     let my_set_metadata_event = SetMetadataEvent::new(asset, metadata, key, sender);
+    ///     assert(my_set_metadata_event.asset() == asset);
+    /// }
+    /// ```
+    pub fn asset(self) -> AssetId {
+        self.asset
+    }
+
+    /// Returns the metadata of the `SetMetadataEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<Metadata>] - The metadata for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src7::SetMetadataEvent;
+    ///
+    /// fn foo(asset: AssetId, metadata: Option<Metadata>, key: String, sender: Identity) {
+    ///     let my_set_metadata_event = SetMetadataEvent::new(asset, metadata, key, sender);
+    ///     assert(my_set_metadata_event.metadata() == metadata);
+    /// }
+    /// ```
+    pub fn metadata(self) -> Option<Metadata> {
+        self.metadata
+    }
+
+    /// Returns the key of the `SetMetadataEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [String] - The key for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src7::SetMetadataEvent;
+    ///
+    /// fn foo(asset: AssetId, metadata: Option<Metadata>, key: String, sender: Identity) {
+    ///     let my_set_metadata_event = SetMetadataEvent::new(asset, metadata, key, sender);
+    ///     assert(my_set_metadata_event.key() == key);
+    /// }
+    /// ```
+    pub fn key(self) -> String {
+        self.key
+    }
+
+    /// Returns the sender of the `SetMetadataEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The sender of the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src7::SetMetadataEvent;
+    ///
+    /// fn foo(asset: AssetId, metadata: Option<Metadata>, key: String, sender: Identity) {
+    ///     let my_set_metadata_event = SetMetadataEvent::new(asset, metadata, key, sender);
+    ///     assert(my_set_metadata_event.sender() == sender);
+    /// }
+    /// ```
+    pub fn sender(self) -> Identity {
+        self.sender
+    }
+
+    /// Logs the `SetMetadataEvent`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src7::SetMetadataEvent;
+    ///
+    /// fn foo(asset: AssetId, metadata: Option<Metadata>, key: String, sender: Identity) {
+    ///     let my_event = SetMetadataEvent::new(asset, metadata, key, sender);
+    ///     my_event.log();
+    /// }
+    /// ```
+    pub fn log(self) {
+        log(self);
+    }
+}


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- Adds struct field getters, `new()`, and `Eq` implementation to SRC-10's `DepositMessage`
- Adds struct field getters, `new()`, and `Eq` implementation to SRC-10's `MetadataMessage`
- Adds check functions and `Eq` implementation to SRC-10's `DepositType`
- Adds struct field getters, `new()`, and `Eq` implementation to SRC-11's `SecurityInformation`
- Adds struct field getters, `new()`, `log()`, and `Eq` implementation to SRC-20's `SetNameEvent`
- Adds struct field getters, `new()`, `log()`, and `Eq` implementation to SRC-20's `SetSymbolEvent`
- Adds struct field getters, `new()`, `log()`, and `Eq` implementation to SRC-20's `SetDecimalsEvent`
- Adds struct field getters, `new()`, `log()`, and `Eq` implementation to SRC-20's `TotalSupplyEvent`
- Adds `Eq` implementation to SRC-5's `AccessError`
- Adds check functions and `Eq` implementation to SRC-5's `State`
- Adds struct field getters, `new()`, `log()`, and `Eq` implementation to SRC-6's `Deposit`
- Adds struct field getters, `new()`, `log()`, and `Eq` implementation to SRC-6's `Withdraw`
- Adds struct field getters, `new()`, `log()`, and `Eq` implementation to SRC-7's `SetMetadataEvent`

## Notes

- The SRC-7 `Metadata` type's helper functions are in Sway-Libs

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
