### PR TITLE
Actually write to storage in src20 multi asset example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ Description of the upcoming release here.
 
 ### Fixed
 
-- Some fix here 1
-- Some fix here 2
+- [#153](https://github.com/FuelLabs/sway-standards/pull/153) Actually write to storage in `set_src20_data()` in the SRC-20 multi asset example.
 
 #### Breaking
 

--- a/examples/src20-native-asset/multi_asset/src/multi_asset.sw
+++ b/examples/src20-native-asset/multi_asset/src/multi_asset.sw
@@ -199,9 +199,32 @@ impl SetSRC20Data for Contract {
         }
         let sender = msg_sender().unwrap();
 
-        SetNameEvent::new(asset, name, sender).log();
-        SetSymbolEvent::new(asset, symbol, sender).log();
+        match name {
+            Some(unwrapped_name) => {
+                storage.name.get(asset).write_slice(unwrapped_name);
+                SetNameEvent::new(asset, name, sender).log();
+            },
+            None => {
+                let _ = storage.name.get(asset).clear();
+                SetNameEvent::new(asset, name, sender).log();
+            }
+        }
+
+        match symbol {
+            Some(unwrapped_symbol) => {
+                storage.symbol.get(asset).write_slice(unwrapped_symbol);
+                SetSymbolEvent::new(asset, symbol, sender).log();
+            },
+            None => {
+                let _ = storage.symbol.get(asset).clear();
+                SetSymbolEvent::new(asset, symbol, sender).log();
+            }
+        }
+
+        storage.decimals.get(asset).write(decimals);
         SetDecimalsEvent::new(asset, decimals, sender).log();
+
+        storage.total_supply.get(asset).write(supply);
         TotalSupplyEvent::new(asset, supply, sender).log();
     }
 }

--- a/examples/src20-native-asset/multi_asset/src/multi_asset.sw
+++ b/examples/src20-native-asset/multi_asset/src/multi_asset.sw
@@ -173,7 +173,7 @@ impl SRC20 for Contract {
 }
 
 abi SetSRC20Data {
-    #[storage(read)]
+    #[storage(read, write)]
     fn set_src20_data(
         asset: AssetId,
         total_supply: u64,
@@ -184,7 +184,7 @@ abi SetSRC20Data {
 }
 
 impl SetSRC20Data for Contract {
-    #[storage(read)]
+    #[storage(read, write)]
     fn set_src20_data(
         asset: AssetId,
         supply: u64,


### PR DESCRIPTION
## Type of change

- Bug fix

## Changes

The following changes have been made:

- The src20 multi asset example has a set_src20_data that is supposed to set the data, however it just emits the logs of setting the data without actually setting the data. This pr fixes that


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
