### PR TITLE
Rename SRC-7 to Onchain Native Asset Metadata Standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Description of the upcoming release here.
 ### Changed
 
 - [#154](https://github.com/FuelLabs/sway-standards/pull/154) Updates the examples in the standards specififcations to use the offical abi name.
+- [#157](https://github.com/FuelLabs/sway-standards/pull/157) Updates the name of the SRC-7 standard to "Onchain Native Asset Metadata Standard".
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you don't find what you're looking for, feel free to create an issue and prop
 
 - [SRC-20; Native Asset Standard](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
 - [SRC-3; Mint and Burn](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) is used to enable mint and burn functionality for fungible assets.
-- [SRC-7; Arbitrary Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
+- [SRC-7; Onchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
 - [SRC-9; Metadata Keys Standard](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
 - [SRC-6; Vault Standard](https://docs.fuel.network/docs/sway-standards/src-6-vault/) defines the implementation of a standard API for asset vaults developed in Sway.
 - [SRC-13; Soulbound Address](https://docs.fuel.network/docs/sway-standards/src-13-soulbound-address/) provides a predicate interface to lock [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) as soulbound.

--- a/docs/spell-check-custom-words.txt
+++ b/docs/spell-check-custom-words.txt
@@ -266,3 +266,5 @@ SetNameEvent
 SetSymbolEvent
 SetDecimalsEvent
 UpdateTotalSupplyEvent
+Onchain
+onchain

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,7 +6,7 @@
 - [SRC-3: Minting and Burning](./src-3-minting-and-burning.md)
 - [SRC-5: Ownership](./src-5-ownership.md)
 - [SRC-6: Vault](./src-6-vault.md)
-- [SRC-7: Asset Metadata](./src-7-asset-metadata.md)
+- [SRC-7: Onchain Asset Metadata](./src-7-asset-metadata.md)
 - [SRC-8: Bridged Asset](./src-8-bridged-asset.md)
 - [SRC-9: Metadata Keys](./src-9-metadata-keys.md)
 - [SRC-10: Native Bridge](./src-10-native-bridge.md)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,7 +38,7 @@ use standards::src20::SRC20;
 
 - [SRC-20; Native Asset Standard](./src-20-native-asset.md) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
 - [SRC-3; Mint and Burn](./src-3-minting-and-burning.md) is used to enable mint and burn functionality for fungible assets.
-- [SRC-7; Arbitrary Asset Metadata Standard](./src-7-asset-metadata.md) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
+- [SRC-7; Onchain Asset Metadata Standard](./src-7-asset-metadata.md) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
 - [SRC-9; Metadata Keys Standard](./src-9-metadata-keys.md) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
 - [SRC-6; Vault Standard](./src-6-vault.md) defines the implementation of a standard API for asset vaults developed in Sway.
 - [SRC-13; Soulbound Address](./src-13-soulbound-address.md) defines the implementation of a soulbound address.

--- a/docs/src/src-7-asset-metadata.md
+++ b/docs/src/src-7-asset-metadata.md
@@ -1,10 +1,10 @@
-# SRC-7: Arbitrary Native Asset Metadata
+# SRC-7: Onchain Native Asset Metadata
 
-The following standard attempts to define the retrieval of on-chain arbitrary metadata for any [Native Asset](https://docs.fuel.network/docs/sway/blockchain-development/native_assets). Any contract that implements the SRC-7 standard MUST implement the [SRC-20](./src-20-native-asset.md) standard.
+The following standard attempts to define the retrieval of on-chain arbitrary metadata for any [Native Asset](https://docs.fuel.network/docs/sway/blockchain-development/native_assets). This standard should be used if a stateful approach is needed. Any contract that implements the SRC-7 standard MUST implement the [SRC-20](./src-20-native-asset.md) standard.
 
 ## Motivation
 
-The SRC-7 standard seeks to enable data-rich assets on the Fuel Network while maintaining compatibility between multiple assets minted by the same contract. The standard ensures type safety with the use of an `enum` and an `Option`. All metadata queries are done through a single function to facilitate cross-contract calls.
+The SRC-7 standard seeks to enable stateful data-rich assets on the Fuel Network while maintaining compatibility between multiple assets minted by the same contract. The standard ensures type safety with the use of an `enum` and an `Option`. All metadata queries are done through a single function to facilitate cross-contract calls.
 
 ## Prior Art
 
@@ -57,7 +57,7 @@ The `SetMetadataEvent` MUST be emitted when the metadata of an asset has updated
 
 There SHALL be the following fields in the `SetMetadataEvent` struct:
 
-* `asset`: The `asset` field SHALL be used for the corresponding `AssetId` of the asset has been updated.
+* `asset`: The `asset` field SHALL be used for the corresponding `AssetId` for the asset that has been updated.
 * `metadata`: The `metadata` field SHALL be used for the corresponding `Option<Metadata>` which represents the metadata of the asset.
 * `key`: The `key` field SHALL be used for the corresponding `String` which represents the key used for storing the metadata.
 * `sender`: The `sender` field SHALL be used for the corresponding `Identity` which made the function call that has updated the metadata of the asset.
@@ -75,7 +75,7 @@ pub struct SetMetadataEvent {
 
 ## Rationale
 
-The SRC-7 standard should allow for data-rich assets to interact with one another in a safe manner.
+The SRC-7 standard should allow for stateful data-rich assets to interact with one another in a safe manner.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates the SRC-7 naming from "Arbitrary Native Asset Metadata" to "Onchain Native Asset Metadata"
- Adds comments on the stateful intent of the standard.


## Notes

- A stateless metadata standard is being written https://github.com/FuelLabs/sway-standards/issues/156

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
