### PR TITLE
Fix typo in SRC-7 inline docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Description of the upcoming release here.
 ### Fixed
 
 - [#153](https://github.com/FuelLabs/sway-standards/pull/153) Actually write to storage in `set_src20_data()` in the SRC-20 multi asset example.
+- [#160](https://github.com/FuelLabs/sway-standards/pull/160) Fixes a typo in the SRC-7 inline docs.
 
 #### Breaking
 

--- a/standards/src/src7.sw
+++ b/standards/src/src7.sw
@@ -88,7 +88,7 @@ impl SetMetadataEvent {
     ///
     /// * `asset`: [AssetId] - The asset for which metadata is set.
     /// * `metadata`: [Option<Metdata>] - The Metadata that is set.
-    /// * `ket`: [String] - The key used for the metadata.
+    /// * `key`: [String] - The key used for the metadata.
     /// * `sender`: [Identity] - The caller that set the metadata.
     ///
     /// # Returns


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Changes "ket" to "key"

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
