### PR TITLE
Create Metadata section for standards and add SRC-16 to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- [#169](https://github.com/FuelLabs/sway-standards/pull/169) Adds a metadata section to the README and about page of the docs hub.
+
+### Changed
+
+- Some change here 1
+- Some change here 2
+
+### Fixed
+
+- Some fix here 1
+- Some fix here 2
+
+### Breaking
+
+- Some breaking change here 1
+- Some breaking change here 2
+
 ## [Version 0.6.3]
 
 ### New Standards v0.6.3

--- a/README.md
+++ b/README.md
@@ -31,36 +31,6 @@ If you don't find what you're looking for, feel free to create an issue and prop
 > **Note**
 > Sway is a language under heavy development therefore the standards may not be the most ergonomic. Over time they should receive updates / improvements in order to demonstrate how Sway can be used in real use cases.
 
-## Standards
-
-### Native Assets
-
-- [SRC-20; Native Asset Standard](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
-- [SRC-3; Mint and Burn](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) is used to enable mint and burn functionality for fungible assets.
-- [SRC-7; Onchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
-- [SRC-9; Metadata Keys Standard](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
-- [SRC-6; Vault Standard](https://docs.fuel.network/docs/sway-standards/src-6-vault/) defines the implementation of a standard API for asset vaults developed in Sway.
-- [SRC-13; Soulbound Address](https://docs.fuel.network/docs/sway-standards/src-13-soulbound-address/) provides a predicate interface to lock [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) as soulbound.
-- [SRC-15; Offchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-15-offchain-asset-metadata/) enables arbitrary metadata that is not required by other contracts onchain, in a stateless manner for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
-
-### Access Control
-
-- [SRC-5; Ownership Standard](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) is used to restrict function calls to admin users in contracts.
-
-### Contracts
-
-- [SRC-12; Contract Factory](https://docs.fuel.network/docs/sway-standards/src-12-contract-factory/) defines the implementation of a standard API for contract factories.
-- [SRC-14; Simple Upgradable Proxies](https://docs.fuel.network/docs/sway-standards/src-14-simple-upgradeable-proxies/) defines the implementation of a standard API for simple upgradable proxies.
-
-### Bridge
-
-- [SRC-8; Bridged Asset](https://docs.fuel.network/docs/sway-standards/src-8-bridged-asset/) defines the metadata required for an asset bridged to the Fuel Network.
-- [SRC-10; Native Bridge Standard](https://docs.fuel.network/docs/sway-standards/src-10-native-bridge/) defines the standard API for the Native Bridge between the Fuel Chain and the canonical base chain.
-
-### Documentation
-
-- [SRC-2; Inline Documentation](https://docs.fuel.network/docs/sway-standards/src-2-inline-documentation/) defines how to document your Sway files.
-
 ## Using a standard
 
 To import a standard the following should be added to the project's `Forc.toml` file under `[dependencies]` with the most recent release:
@@ -84,7 +54,45 @@ For example, to import the SRC-20 Native Asset Standard use the following statem
 use standards::src20::SRC20;
 ```
 
-### Examples of Standards
+## Standards
+
+### Native Assets
+
+- [SRC-20; Native Asset Standard](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
+- [SRC-3; Mint and Burn](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) is used to enable mint and burn functionality for fungible assets.
+- [SRC-6; Vault Standard](https://docs.fuel.network/docs/sway-standards/src-6-vault/) defines the implementation of a standard API for asset vaults developed in Sway.
+- [SRC-13; Soulbound Address](https://docs.fuel.network/docs/sway-standards/src-13-soulbound-address/) provides a predicate interface to lock [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) as soulbound.
+
+### Metadata
+
+- [SRC-7; Onchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
+- [SRC-9; Metadata Keys Standard](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
+- [SRC-15; Offchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-15-offchain-asset-metadata/) enables arbitrary metadata that is not required by other contracts onchain, in a stateless manner for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
+
+### Security and Access Control
+
+- [SRC-5; Ownership Standard](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) is used to restrict function calls to admin users in contracts.
+- [SRC-11; Security Information Standard]([./src-11-security-information.md](https://docs.fuel.network/docs/sway-standards/src-11-security-information/)) is used to make communication information readily available in the case white hat hackers find a vulnerability in a contract.
+
+### Contracts
+
+- [SRC-12; Contract Factory](https://docs.fuel.network/docs/sway-standards/src-12-contract-factory/) defines the implementation of a standard API for contract factories.
+- [SRC-14; Simple Upgradable Proxies](https://docs.fuel.network/docs/sway-standards/src-14-simple-upgradeable-proxies/) defines the implementation of a standard API for simple upgradable proxies.
+
+### Bridge
+
+- [SRC-8; Bridged Asset](https://docs.fuel.network/docs/sway-standards/src-8-bridged-asset/) defines the metadata required for an asset bridged to the Fuel Network.
+- [SRC-10; Native Bridge Standard](https://docs.fuel.network/docs/sway-standards/src-10-native-bridge/) defines the standard API for the Native Bridge between the Fuel Chain and the canonical base chain.
+
+### Encoding and Hashing
+
+- [SRC-16; Typed Structure Data](https://docs.fuel.network/docs/sway-standards/src-16-typed-structured-data/) standardize encoding and hashing of typed structured data.
+
+### Documentation
+
+- [SRC-2; Inline Documentation](https://docs.fuel.network/docs/sway-standards/src-2-inline-documentation/) defines how to document your Sway files.
+
+## Examples of Standards
 
 Minimal example implementations for every standard can be found in the [`examples/`](./examples/) folder.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ use standards::src20::SRC20;
 ### Security and Access Control
 
 - [SRC-5; Ownership Standard](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) is used to restrict function calls to admin users in contracts.
-- [SRC-11; Security Information Standard]([./src-11-security-information.md](https://docs.fuel.network/docs/sway-standards/src-11-security-information/)) is used to make communication information readily available in the case white hat hackers find a vulnerability in a contract.
+- [SRC-11; Security Information Standard](https://docs.fuel.network/docs/sway-standards/src-11-security-information/) is used to make communication information readily available in the case white hat hackers find a vulnerability in a contract.
 
 ### Contracts
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,10 +38,13 @@ use standards::src20::SRC20;
 
 - [SRC-20; Native Asset Standard](./src-20-native-asset.md) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
 - [SRC-3; Mint and Burn](./src-3-minting-and-burning.md) is used to enable mint and burn functionality for fungible assets.
-- [SRC-7; Onchain Asset Metadata Standard](./src-7-asset-metadata.md) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
-- [SRC-9; Metadata Keys Standard](./src-9-metadata-keys.md) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
 - [SRC-6; Vault Standard](./src-6-vault.md) defines the implementation of a standard API for asset vaults developed in Sway.
 - [SRC-13; Soulbound Address](./src-13-soulbound-address.md) defines the implementation of a soulbound address.
+
+### Metadata
+
+- [SRC-7; Onchain Asset Metadata Standard](./src-7-asset-metadata.md) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
+- [SRC-9; Metadata Keys Standard](./src-9-metadata-keys.md) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
 - [SRC-15; Offchain Asset Metadata Standard](./src-15-offchain-asset-metadata.md) is used to associated metadata with [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) offchain.
 
 ### Security and Access Control


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Moves using standards to the top of the README.
- Adds a `Metadata` section to the README and `index.html` of the docs. This should improve visibility on the metadata standards and help with organization.
- Adds SRC-16 to the README.

## Notes

- CI will fail with an invalid link until SRC-16 is available in the docs hub.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
