### PR TITLE
Release v0.7.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.80.1
-  FORC_VERSION: 0.66.6
-  CORE_VERSION: 0.40.0
+  FORC_VERSION: 0.67.0
+  CORE_VERSION: 0.41.4
   PATH_TO_SCRIPTS: .github/scripts
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Some addition here.
+- Some addition here.
+
+### Changed
+
+- Some change here.
+- Some change here.
+
+### Fixed
+
+- Some fix here.
+- Some fix here.
+
+### Breaking
+
+- Some breaking change here.
+- Some breaking change here.
+
+## [Version 0.7.0]
+
+### Added v0.7.0
+
+- [#169](https://github.com/FuelLabs/sway-standards/pull/169) Adds a metadata section to the README and about page of the docs hub.
+
+### Changed v0.7.0
+
+- [#172](https://github.com/FuelLabs/sway-standards/pull/172) Prepares for the `v0.7.0` release.
+
+### Fixed v0.7.0
+
+- None
+
+### Breaking v0.7.0
+
+- [#172](https://github.com/FuelLabs/sway-standards/pull/172) Updates to the forc `v0.67.0` release. Earlier releases are not compatible.
+
 ## [Version 0.6.3]
 
 ### New Standards v0.6.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "sway-standards"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yaml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yaml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.66.6" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.66.6-orange" />
+    <a href="https://crates.io/crates/forc/0.67.0" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.67.0-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-standards" />
@@ -31,42 +31,12 @@ If you don't find what you're looking for, feel free to create an issue and prop
 > **Note**
 > Sway is a language under heavy development therefore the standards may not be the most ergonomic. Over time they should receive updates / improvements in order to demonstrate how Sway can be used in real use cases.
 
-## Standards
-
-### Native Assets
-
-- [SRC-20; Native Asset Standard](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
-- [SRC-3; Mint and Burn](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) is used to enable mint and burn functionality for fungible assets.
-- [SRC-7; Onchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
-- [SRC-9; Metadata Keys Standard](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
-- [SRC-6; Vault Standard](https://docs.fuel.network/docs/sway-standards/src-6-vault/) defines the implementation of a standard API for asset vaults developed in Sway.
-- [SRC-13; Soulbound Address](https://docs.fuel.network/docs/sway-standards/src-13-soulbound-address/) provides a predicate interface to lock [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) as soulbound.
-- [SRC-15; Offchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-15-offchain-asset-metadata/) enables arbitrary metadata that is not required by other contracts onchain, in a stateless manner for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
-
-### Access Control
-
-- [SRC-5; Ownership Standard](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) is used to restrict function calls to admin users in contracts.
-
-### Contracts
-
-- [SRC-12; Contract Factory](https://docs.fuel.network/docs/sway-standards/src-12-contract-factory/) defines the implementation of a standard API for contract factories.
-- [SRC-14; Simple Upgradable Proxies](https://docs.fuel.network/docs/sway-standards/src-14-simple-upgradeable-proxies/) defines the implementation of a standard API for simple upgradable proxies.
-
-### Bridge
-
-- [SRC-8; Bridged Asset](https://docs.fuel.network/docs/sway-standards/src-8-bridged-asset/) defines the metadata required for an asset bridged to the Fuel Network.
-- [SRC-10; Native Bridge Standard](https://docs.fuel.network/docs/sway-standards/src-10-native-bridge/) defines the standard API for the Native Bridge between the Fuel Chain and the canonical base chain.
-
-### Documentation
-
-- [SRC-2; Inline Documentation](https://docs.fuel.network/docs/sway-standards/src-2-inline-documentation/) defines how to document your Sway files.
-
 ## Using a standard
 
 To import a standard the following should be added to the project's `Forc.toml` file under `[dependencies]` with the most recent release:
 
 ```toml
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.7.0" }
 ```
 
 > **NOTE:**
@@ -84,7 +54,45 @@ For example, to import the SRC-20 Native Asset Standard use the following statem
 use standards::src20::SRC20;
 ```
 
-### Examples of Standards
+## Standards
+
+### Native Assets
+
+- [SRC-20; Native Asset Standard](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
+- [SRC-3; Mint and Burn](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) is used to enable mint and burn functionality for fungible assets.
+- [SRC-6; Vault Standard](https://docs.fuel.network/docs/sway-standards/src-6-vault/) defines the implementation of a standard API for asset vaults developed in Sway.
+- [SRC-13; Soulbound Address](https://docs.fuel.network/docs/sway-standards/src-13-soulbound-address/) provides a predicate interface to lock [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) as soulbound.
+
+### Metadata
+
+- [SRC-7; Onchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
+- [SRC-9; Metadata Keys Standard](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
+- [SRC-15; Offchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-15-offchain-asset-metadata/) enables arbitrary metadata that is not required by other contracts onchain, in a stateless manner for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
+
+### Security and Access Control
+
+- [SRC-5; Ownership Standard](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) is used to restrict function calls to admin users in contracts.
+- [SRC-11; Security Information Standard](https://docs.fuel.network/docs/sway-standards/src-11-security-information/) is used to make communication information readily available in the case white hat hackers find a vulnerability in a contract.
+
+### Contracts
+
+- [SRC-12; Contract Factory](https://docs.fuel.network/docs/sway-standards/src-12-contract-factory/) defines the implementation of a standard API for contract factories.
+- [SRC-14; Simple Upgradable Proxies](https://docs.fuel.network/docs/sway-standards/src-14-simple-upgradeable-proxies/) defines the implementation of a standard API for simple upgradable proxies.
+
+### Bridge
+
+- [SRC-8; Bridged Asset](https://docs.fuel.network/docs/sway-standards/src-8-bridged-asset/) defines the metadata required for an asset bridged to the Fuel Network.
+- [SRC-10; Native Bridge Standard](https://docs.fuel.network/docs/sway-standards/src-10-native-bridge/) defines the standard API for the Native Bridge between the Fuel Chain and the canonical base chain.
+
+### Encoding and Hashing
+
+- [SRC-16; Typed Structure Data](https://docs.fuel.network/docs/sway-standards/src-16-typed-structured-data/) standardize encoding and hashing of typed structured data.
+
+### Documentation
+
+- [SRC-2; Inline Documentation](https://docs.fuel.network/docs/sway-standards/src-2-inline-documentation/) defines how to document your Sway files.
+
+## Examples of Standards
 
 Minimal example implementations for every standard can be found in the [`examples/`](./examples/) folder.
 
@@ -163,7 +171,7 @@ Example of a minimal SRC-14 implementation with no access control.
 Example of a SRC-14 implementation that also implements [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/).
 
 > **Note**
-> All standards currently use `forc v0.66.6`.
+> All standards currently use `forc v0.67.0`.
 
 <!-- TODO:
 ## Contributing

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,14 +7,14 @@ Standards in this repository may be in various stages of development. Use of dra
 If you don't find what you're looking for, feel free to create an issue and propose a new standard!
 
 > **Note**
-> All standards currently use `forc v0.66.6`.
+> All standards currently use `forc v0.67.0`.
 
 ## Using a standard
 
 To import a standard the following should be added to the project's `Forc.toml` file under `[dependencies]` with the most recent release:
 
 ```toml
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.7.0" }
 ```
 
 > **NOTE:**
@@ -38,10 +38,13 @@ use standards::src20::SRC20;
 
 - [SRC-20; Native Asset Standard](./src-20-native-asset.md) defines the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language.
 - [SRC-3; Mint and Burn](./src-3-minting-and-burning.md) is used to enable mint and burn functionality for fungible assets.
-- [SRC-7; Onchain Asset Metadata Standard](./src-7-asset-metadata.md) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
-- [SRC-9; Metadata Keys Standard](./src-9-metadata-keys.md) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
 - [SRC-6; Vault Standard](./src-6-vault.md) defines the implementation of a standard API for asset vaults developed in Sway.
 - [SRC-13; Soulbound Address](./src-13-soulbound-address.md) defines the implementation of a soulbound address.
+
+### Metadata
+
+- [SRC-7; Onchain Asset Metadata Standard](./src-7-asset-metadata.md) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
+- [SRC-9; Metadata Keys Standard](./src-9-metadata-keys.md) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
 - [SRC-15; Offchain Asset Metadata Standard](./src-15-offchain-asset-metadata.md) is used to associated metadata with [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) offchain.
 
 ### Security and Access Control

--- a/docs/src/src-16-typed-structured-data.md
+++ b/docs/src/src-16-typed-structured-data.md
@@ -266,6 +266,8 @@ Example of the SRC16 implementation where a contract utilizes the encoding schem
 
 ```sway
 {{#include ../examples/src16-typed-data/fuel_example/src/main.sw}}
+```
 
+```sway
 {{#include ../examples/src16-typed-data/ethereum_example/src/main.sw}}
 ```

--- a/standards/src/src10.sw
+++ b/standards/src/src10.sw
@@ -15,25 +15,18 @@ pub enum DepositType {
 /// Enscapsultes metadata sent between the canonical chain and Fuel when a deposit is made.
 pub struct DepositMessage {
     /// The number of tokens.
-    #[allow(dead_code)]
     pub amount: b256,
     /// The user's address on the canonical chain.
-    #[allow(dead_code)]
     pub from: b256,
     /// The bridging target destination on the Fuel chain.
-    #[allow(dead_code)]
     pub to: Identity,
     /// The bridged token's address on the canonical chain.
-    #[allow(dead_code)]
     pub token_address: b256,
     /// The token's ID on the canonical chain.
-    #[allow(dead_code)]
     pub token_id: b256,
     /// The decimals of the token.
-    #[allow(dead_code)]
     pub decimals: u8,
     /// The type of deposit made.
-    #[allow(dead_code)]
     pub deposit_type: DepositType,
 }
 
@@ -121,7 +114,7 @@ abi SRC10 {
     );
 }
 
-impl core::ops::Eq for DepositType {
+impl PartialEq for DepositType {
     fn eq(self, other: Self) -> bool {
         match (self, other) {
             (Self::Address, Self::Address) => true,
@@ -132,17 +125,23 @@ impl core::ops::Eq for DepositType {
     }
 }
 
-impl core::ops::Eq for DepositMessage {
+impl Eq for DepositType {}
+
+impl PartialEq for DepositMessage {
     fn eq(self, other: Self) -> bool {
         self.amount == other.amount && self.from == other.from && self.to == other.to && self.token_address == other.token_address && self.token_id == other.token_id && self.decimals == other.decimals && self.deposit_type == other.deposit_type
     }
 }
 
-impl core::ops::Eq for MetadataMessage {
+impl Eq for DepositMessage {}
+
+impl PartialEq for MetadataMessage {
     fn eq(self, other: Self) -> bool {
         self.token_address == other.token_address && self.token_id == other.token_id && self.name == other.name && self.symbol == other.symbol
     }
 }
+
+impl Eq for MetadataMessage {}
 
 impl DepositMessage {
     /// Returns a new `DepositMessage`.

--- a/standards/src/src11.sw
+++ b/standards/src/src11.sw
@@ -47,7 +47,7 @@ abi SRC11 {
     fn security_information() -> SecurityInformation;
 }
 
-impl core::ops::Eq for SecurityInformation {
+impl PartialEq for SecurityInformation {
     fn eq(self, other: Self) -> bool {
         // If both contact info contain data, check each string
         let self_contact_information_len = self.contact_information.len();
@@ -119,6 +119,8 @@ impl core::ops::Eq for SecurityInformation {
         self.name == other.name && self.project_url == other.project_url && self.policy == other.policy && self.encryption == other.encryption && self.source_code == other.source_code && self.source_release == other.source_release && self.source_revision == other.source_revision && self.acknowledgments == other.acknowledgments && self.additional_information == other.additional_information
     }
 }
+
+impl Eq for SecurityInformation {}
 
 impl SecurityInformation {
     /// Returns a new `SecurityInformation`.

--- a/standards/src/src15.sw
+++ b/standards/src/src15.sw
@@ -10,11 +10,13 @@ pub struct SRC15MetadataEvent {
     pub metadata: Metadata,
 }
 
-impl core::ops::Eq for SRC15MetadataEvent {
+impl PartialEq for SRC15MetadataEvent {
     fn eq(self, other: Self) -> bool {
         self.asset == other.asset && self.metadata == other.metadata
     }
 }
+
+impl Eq for SRC15MetadataEvent {}
 
 impl SRC15MetadataEvent {
     /// Returns a new `SRC15MetadataEvent` event.

--- a/standards/src/src16.sw
+++ b/standards/src/src16.sw
@@ -215,7 +215,7 @@ impl EIP712Domain {
             name: domain_name,
             version: version,
             chain_id: chain_id,
-            verifying_contract: verifying_contract_last_20.into(),
+            verifying_contract: verifying_contract_last_20.try_into().unwrap(),
         }
     }
 

--- a/standards/src/src20.sw
+++ b/standards/src/src20.sw
@@ -164,11 +164,13 @@ pub struct TotalSupplyEvent {
     pub sender: Identity,
 }
 
-impl core::ops::Eq for SetNameEvent {
+impl PartialEq for SetNameEvent {
     fn eq(self, other: Self) -> bool {
         self.asset == other.asset && self.name == other.name && self.sender == other.sender
     }
 }
+
+impl Eq for SetNameEvent {}
 
 impl SetNameEvent {
     /// Returns a new `SetNameEvent` event.
@@ -275,11 +277,13 @@ impl SetNameEvent {
     }
 }
 
-impl core::ops::Eq for SetSymbolEvent {
+impl PartialEq for SetSymbolEvent {
     fn eq(self, other: Self) -> bool {
         self.asset == other.asset && self.symbol == other.symbol && self.sender == other.sender
     }
 }
+
+impl Eq for SetSymbolEvent {}
 
 impl SetSymbolEvent {
     /// Returns a new `SetSymbolEvent` event.
@@ -386,11 +390,13 @@ impl SetSymbolEvent {
     }
 }
 
-impl core::ops::Eq for SetDecimalsEvent {
+impl PartialEq for SetDecimalsEvent {
     fn eq(self, other: Self) -> bool {
         self.asset == other.asset && self.decimals == other.decimals && self.sender == other.sender
     }
 }
+
+impl Eq for SetDecimalsEvent {}
 
 impl SetDecimalsEvent {
     /// Returns a new `SetDecimalsEvent` event.
@@ -502,11 +508,13 @@ impl SetDecimalsEvent {
     }
 }
 
-impl core::ops::Eq for TotalSupplyEvent {
+impl PartialEq for TotalSupplyEvent {
     fn eq(self, other: Self) -> bool {
         self.asset == other.asset && self.supply == other.supply && self.sender == other.sender
     }
 }
+
+impl Eq for TotalSupplyEvent {}
 
 impl TotalSupplyEvent {
     /// Returns a new `TotalSupplyEvent` event.

--- a/standards/src/src5.sw
+++ b/standards/src/src5.sw
@@ -42,7 +42,7 @@ abi SRC5 {
     fn owner() -> State;
 }
 
-impl core::ops::Eq for State {
+impl PartialEq for State {
     fn eq(self, other: Self) -> bool {
         match (self, other) {
             (Self::Initialized(owner1), Self::Initialized(owner2)) => {
@@ -55,13 +55,17 @@ impl core::ops::Eq for State {
     }
 }
 
-impl core::ops::Eq for AccessError {
+impl Eq for State {}
+
+impl PartialEq for AccessError {
     fn eq(self, other: Self) -> bool {
         match (self, other) {
             (Self::NotOwner, Self::NotOwner) => true,
         }
     }
 }
+
+impl Eq for AccessError {}
 
 impl State {
     /// Returns whether the state is uninitialized.

--- a/standards/src/src6.sw
+++ b/standards/src/src6.sw
@@ -234,17 +234,21 @@ abi SRC6 {
     fn max_withdrawable(underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64>;
 }
 
-impl core::ops::Eq for Deposit {
+impl PartialEq for Deposit {
     fn eq(self, other: Self) -> bool {
         self.caller == other.caller && self.receiver == other.receiver && self.underlying_asset == other.underlying_asset && self.vault_sub_id == other.vault_sub_id && self.deposited_amount == other.deposited_amount && self.minted_shares == other.minted_shares
     }
 }
 
-impl core::ops::Eq for Withdraw {
+impl Eq for Deposit {}
+
+impl PartialEq for Withdraw {
     fn eq(self, other: Self) -> bool {
         self.caller == other.caller && self.receiver == other.receiver && self.underlying_asset == other.underlying_asset && self.vault_sub_id == other.vault_sub_id && self.withdrawn_amount == other.withdrawn_amount && self.burned_shares == other.burned_shares
     }
 }
+
+impl Eq for Withdraw {}
 
 impl Deposit {
     /// Returns a new `Deposit` event.

--- a/standards/src/src7.sw
+++ b/standards/src/src7.sw
@@ -55,7 +55,7 @@ pub struct SetMetadataEvent {
     pub sender: Identity,
 }
 
-impl core::ops::Eq for Metadata {
+impl PartialEq for Metadata {
     fn eq(self, other: Self) -> bool {
         match (self, other) {
             (Metadata::B256(bytes1), Metadata::B256(bytes2)) => {
@@ -75,11 +75,15 @@ impl core::ops::Eq for Metadata {
     }
 }
 
-impl core::ops::Eq for SetMetadataEvent {
+impl Eq for Metadata {}
+
+impl PartialEq for SetMetadataEvent {
     fn eq(self, other: Self) -> bool {
         self.asset == other.asset && self.metadata == other.metadata && self.key == other.key && self.sender == other.sender
     }
 }
+
+impl Eq for SetMetadataEvent {}
 
 impl SetMetadataEvent {
     /// Returns a new `SetMetadataEvent` event.


### PR DESCRIPTION
## [Version 0.7.0]

### Added v0.7.0

- [#169](https://github.com/FuelLabs/sway-standards/pull/169) Adds a metadata section to the README and about page of the docs hub.

### Changed v0.7.0

- [#172](https://github.com/FuelLabs/sway-standards/pull/172) Prepares for the `v0.7.0` release.

### Fixed v0.7.0

- None

### Breaking v0.7.0

- [#172](https://github.com/FuelLabs/sway-standards/pull/172) Updates to the forc `v0.67.0` release. Earlier releases are not compatible.