### PR TITLE
Release v0.7.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @FuelLabs/swayex
+* @FuelLabs/onchain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.80.1
-  FORC_VERSION: 0.67.0
-  CORE_VERSION: 0.41.4
+  FORC_VERSION: 0.68.1
+  CORE_VERSION: 0.43.1
   PATH_TO_SCRIPTS: .github/scripts
 
 jobs:
@@ -78,6 +78,8 @@ jobs:
                 "examples/src12-contract-factory",
                 "examples/src14-simple-proxy",
                 "examples/src15-offchain-metadata",
+                "examples/src16-typed-data",
+                "examples/src17-naming-verification",
                 "examples/src20-native-asset",
               ]
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Some breaking change here.
 - Some breaking change here.
 
+## [Version 0.7.1]
+
+### Added v0.7.1
+
+- [#175](https://github.com/FuelLabs/sway-standards/pull/175) Introduces the SRC-17; Naming Verification Standard.
+- [#178](https://github.com/FuelLabs/sway-standards/pull/178) Creates a Offchain Data section in the docs and README.
+
+### Changed v0.7.1
+
+- [#176](https://github.com/FuelLabs/sway-standards/pull/176) Updates the repository to forc `v0.68.1`, fuel-core `v0.43.1`, and Sway-Libs `v0.25.2`.
+- [#174](https://github.com/FuelLabs/sway-standards/pull/174) Updates CODEOWNERS from SwayEx to Onchain.
+- [#177](https://github.com/FuelLabs/sway-standards/pull/177) Prepares for the `v0.7.1` release.
+
+### Fixed v0.7.1
+
+- None
+
+### Breaking v0.7.1
+
+- None
+
 ## [Version 0.7.0]
 
 ### Added v0.7.0

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yaml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yaml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.67.0" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.67.0-orange" />
+    <a href="https://crates.io/crates/forc/0.68.1" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.68.1-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-standards" />
@@ -36,7 +36,7 @@ If you don't find what you're looking for, feel free to create an issue and prop
 To import a standard the following should be added to the project's `Forc.toml` file under `[dependencies]` with the most recent release:
 
 ```toml
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.7.0" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.7.1" }
 ```
 
 > **NOTE:**
@@ -63,11 +63,17 @@ use standards::src20::SRC20;
 - [SRC-6; Vault Standard](https://docs.fuel.network/docs/sway-standards/src-6-vault/) defines the implementation of a standard API for asset vaults developed in Sway.
 - [SRC-13; Soulbound Address](https://docs.fuel.network/docs/sway-standards/src-13-soulbound-address/) provides a predicate interface to lock [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) as soulbound.
 
-### Metadata
+### Onchain Data
 
 - [SRC-7; Onchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
 - [SRC-9; Metadata Keys Standard](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
+
+### Offchain Data
+
 - [SRC-15; Offchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-15-offchain-asset-metadata/) enables arbitrary metadata that is not required by other contracts onchain, in a stateless manner for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
+<!-- TODO:
+- [SRC-17; Naming Verification Standard](https://docs.fuel.network/docs/sway-standards/src-17-naming-verification/) defines a naming verification standard for onchain identities using offchain data.
+-->
 
 ### Security and Access Control
 
@@ -171,7 +177,7 @@ Example of a minimal SRC-14 implementation with no access control.
 Example of a SRC-14 implementation that also implements [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/).
 
 > **Note**
-> All standards currently use `forc v0.67.0`.
+> All standards currently use `forc v0.68.1`.
 
 <!-- TODO:
 ## Contributing

--- a/docs/spell-check-custom-words.txt
+++ b/docs/spell-check-custom-words.txt
@@ -275,3 +275,8 @@ injective
 encodings
 endian
 DeFi
+frontends
+Bako
+FNS
+AltBn
+NameEvent

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,4 +16,5 @@
 - [SRC-14: Simple Upgradeable Contract](./src-14-simple-upgradeable-proxies.md)
 - [SRC-15: Offchain Asset Metadata](./src-15-offchain-asset-metadata.md)
 - [SRC-16: Typed Structured Data](./src-16-typed-structured-data.md)
+- [SRC-17: Naming Verification](./src-17-naming-verification.md)
 - [SRC-20: Native Asset](./src-20-native-asset.md)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,14 +7,14 @@ Standards in this repository may be in various stages of development. Use of dra
 If you don't find what you're looking for, feel free to create an issue and propose a new standard!
 
 > **Note**
-> All standards currently use `forc v0.67.0`.
+> All standards currently use `forc v0.68.1`.
 
 ## Using a standard
 
 To import a standard the following should be added to the project's `Forc.toml` file under `[dependencies]` with the most recent release:
 
 ```toml
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.7.0" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.7.1" }
 ```
 
 > **NOTE:**
@@ -41,11 +41,15 @@ use standards::src20::SRC20;
 - [SRC-6; Vault Standard](./src-6-vault.md) defines the implementation of a standard API for asset vaults developed in Sway.
 - [SRC-13; Soulbound Address](./src-13-soulbound-address.md) defines the implementation of a soulbound address.
 
-### Metadata
+### Onchain Data
 
 - [SRC-7; Onchain Asset Metadata Standard](./src-7-asset-metadata.md) is used to store metadata for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets).
 - [SRC-9; Metadata Keys Standard](./src-9-metadata-keys.md) is used to store standardized metadata keys for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) in combination with the SRC-7 standard.
+
+### Offchain Data
+
 - [SRC-15; Offchain Asset Metadata Standard](./src-15-offchain-asset-metadata.md) is used to associated metadata with [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) offchain.
+- [SRC-17; Naming Verification Standard](./src-17-naming-verification.md) defines a naming verification standard for onchain identities using offchain data.
 
 ### Security and Access Control
 

--- a/docs/src/src-17-naming-verification.md
+++ b/docs/src/src-17-naming-verification.md
@@ -1,0 +1,152 @@
+# SRC-17: Naming Verification Standard
+
+The following standard defines a naming verification standard for onchain identities using offchain data.
+
+## Motivation
+
+A standard interface for names on Fuel allows external applications to verify and determine the resolver of a name, whether that be decentralized exchanges frontends, wallets, explorers, or other infrastructure providers.
+
+## Prior Art
+
+A number of existing name service platforms already existed prior to the development of this standard. Notably the most well-known on the Ethereum Blockchain is the [Ethereum Name Service(ENS)](https://ens.domains/). This domain service has a major influence on other name services across multiple platforms. ENS pioneered name service platforms and this standard takes some inspiration from their resolver design.
+
+On Fuel, we have 2 existing name service platforms. These are [Bako ID](https://www.bako.id/) and [Fuel Name Service(FNS)](https://fuelname.com/). This standard was developed in close collaboration with these two platforms to ensure compatibility and ease of upgrade.
+
+## Specification
+
+### Type Aliases
+
+#### `AltBn128Proof` Type Alias
+
+The following describes a type alias for AltBn128 proofs. The `AltBn128Proof` SHALL be defined as the fixed length array `[u8; 288]`.
+
+```sway
+pub type AltBn128Proof = [u8; 288];
+```
+
+#### `SparseMerkleProof` Type Alias
+
+The following describes a type alias for Sparse Merkle Tree proofs. The `SparseMerkleProof` SHALL be defined as the `Proof` type from the Sway-Libs Sparse Merkle Tree Library.
+
+```sway
+pub type SparseMerkleProof = Proof;
+```
+
+### Enums
+
+#### `SRC17VerificationError` Enum
+
+The following describes an enum that is used when verification of a name fails. There SHALL be the following variants in the `SRC17VerificationError` type:
+
+##### `VerificationFailed`
+
+The `VerificationFailed` variant SHALL be used when verification of a name fails for ANY reason.
+
+```sway
+pub enum SRC17VerificationError {
+    VerificationFailed: (),
+}
+```
+
+#### `SRC17Proof` Enum
+
+The following describes an enum that wraps various proof types into a single input type. There SHALL be the following variants in the `SRC17Proof` type:
+
+##### `AltBn128Proof`
+
+The `AltBn128Proof` variant SHALL be used for AltBn128 proofs.
+
+##### `SparseMerkleProof`
+
+The `SparseMerkleProof` variant SHALL be used for Sparse Merkle Tree proofs.
+
+```sway
+pub enum SRC17Proof {
+    AltBn128Proof: AltBn128Proof,
+    SparseMerkleProof: SparseMerkleProof,
+}
+```
+
+### Required Public Functions
+
+The following functions MUST be implemented to follow the SRC-17 standard:
+
+#### `fn verify(proof: SRC17Proof, name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) -> Result<(), SRC17VerificationError>`
+
+- This function MUST return `Ok(())` if the proof verification was successful. Otherwise, it MUST return `Err(SRC17VerificationError::VerificationFailed)`.
+- The `proof` argument MUST be an `SRC17Proof` which proves the `name`, `asset`, `resolver`, and `metadata` are valid and included in the data.
+- The `name` argument MUST the corresponding `String` for the onchain human-readable identity.
+- The `resolver` argument MUST be the identity which the name is pointing to.
+- The `asset` argument MUST be the asset that represents ownership of a name.
+- The `metadata` argument MUST contain `Some` bytes associated with the name or MUST be `None`.
+
+### Logging
+
+The following logs MUST be implemented and emitted to follow the SRC-17 standard. Logs MUST be emitted if there are changes that update ANY proof.
+
+#### SRC17NameEvent
+
+The `SRC17NameEvent` MUST be emitted when ANY data changes occur.
+
+There SHALL be the following fields in the `SRC17UpdateEvent` struct:
+
+- `name`: The `name` field SHALL be used for the corresponding `String` which represents the name.
+- `resolver`: The `resolver` field SHALL be used for the corresponding `Identity` to which the name points.
+- `asset`: The `asset` field SHALL be used for the corresponding `AssetId` that represents ownership of a name.
+- `metadata`: The `metadata` field MUST contain `Some` bytes associated with the name or MUST be `None`.
+
+Example:
+
+```sway
+pub struct SRC17NameEvent {
+    pub name: String,
+    pub resolver: Identity,
+    pub asset: AssetId,
+    pub metadata: Option<Bytes>
+}
+```
+
+## Rationale
+
+The development and implementation of this standard should enable the verification of names for infrastructure providers such as explorers, wallets, and more. Standardizing the verification method and leaving the implementation up to interpretation shall leave room for experimentation and differentiating designs between projects.
+
+Additionally, the use of proofs should reduce the onchain footprint and minimize state. This standard notably has no expiry, a feature of most name service platforms. Should a project wish to implement an expiry, it should be included as part of the metadata.
+
+## Backwards Compatibility
+
+This standard is compatible with the existing name standards in the Fuel ecosystem, namely Bako ID and Fuel Name Service(FNS). There are no other standards that require compatibility.
+
+## Security Considerations
+
+This standard does not introduce any security concerns, as it does not call external contracts, nor does it define any mutations of the contract state.
+
+## Example ABI
+
+```sway
+pub type AltBn128Proof = [u8; 288];
+pub type SparseMerkleProof = Proof;
+
+pub enum SRC17Proof {
+    AltBn128Proof: AltBn128Proof,
+    SparseMerkleProof: SparseMerkleProof,
+}
+
+pub enum SRC17VerificationError {
+    VerificationFailed: (),
+}
+
+abi SRC17 {
+    #[storage(read)]
+    fn verify(proof: SRC17Proof, name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) -> Result<(), SRC17VerificationError>;
+}
+```
+
+## Example Implementation
+
+### Sparse Merkle Verification Example
+
+An example of the SRC-17 implementation where a Sparse Merkle Tree is used to verify the validity of names. In the example, the `name` is the key in the Sparse Merkle Tree and the `asset`, `resolver`, and `metadata` are the data which make up the leaf. The example supports both inclusion and exclusion proofs. If an AltBn128 proof is provided instead, the verification fails.
+
+```sway
+{{#include ../examples/src17-naming-verification/sparse_merkle_proof/src/main.sw}}
+```

--- a/examples/src17-naming-verification/Forc.toml
+++ b/examples/src17-naming-verification/Forc.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["sparse_merkle_proof"]

--- a/examples/src17-naming-verification/sparse_merkle_proof/Forc.toml
+++ b/examples/src17-naming-verification/sparse_merkle_proof/Forc.toml
@@ -1,8 +1,9 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
-entry = "standards.sw"
+entry = "main.sw"
 license = "Apache-2.0"
-name = "standards"
+name = "sparse_merkle_proof"
 
 [dependencies]
+standards = { path = "../../../standards" }
 sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.25.2" }

--- a/examples/src17-naming-verification/sparse_merkle_proof/src/main.sw
+++ b/examples/src17-naming-verification/sparse_merkle_proof/src/main.sw
@@ -1,0 +1,93 @@
+contract;
+
+use std::{bytes::Bytes, hash::{Hash, sha256}, string::String};
+use standards::src17::*;
+use sway_libs::merkle::{common::MerkleRoot, sparse::*};
+
+storage {
+    merkle_root: MerkleRoot = MerkleRoot::zero(),
+}
+
+impl SRC17 for Contract {
+    #[storage(read)]
+    fn verify(
+        proof: SRC17Proof,
+        name: String,
+        resolver: Identity,
+        asset: AssetId,
+        metadata: Option<Bytes>,
+    ) -> Result<(), SRC17VerificationError> {
+        match proof {
+            SRC17Proof::AltBn128Proof(_) => Err(SRC17VerificationError::VerificationFailed),
+            SRC17Proof::SparseMerkleProof(proof) => {
+                let key: MerkleTreeKey = sha256(name);
+
+                match proof {
+                    Proof::Inclusion => {
+                        // Combine the resolver, asset, and metadata into to a single Byte array.
+                        let mut leaf_bytes = Bytes::new();
+                        leaf_bytes.append(resolver.bits().into());
+                        leaf_bytes.append(asset.bits().into());
+                        match metadata {
+                            Some(metadata_bytes) => {
+                                leaf_bytes.append(metadata_bytes);
+                            },
+                            None => (),
+                        }
+
+                        if proof.verify(storage.merkle_root.read(), key, Some(leaf_bytes))
+                        {
+                            Ok(())
+                        } else {
+                            Err(SRC17VerificationError::VerificationFailed)
+                        }
+                    },
+                    Proof::Exclusion => {
+                        if proof.verify(storage.merkle_root.read(), key, None) {
+                            Ok(())
+                        } else {
+                            Err(SRC17VerificationError::VerificationFailed)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+abi UpdateData {
+    fn data_updated(
+        name: String,
+        resolver: Identity,
+        asset: AssetId,
+        metadata: Option<Bytes>,
+    );
+}
+
+impl UpdateData for Contract {
+    fn data_updated(
+        name: String,
+        resolver: Identity,
+        asset: AssetId,
+        metadata: Option<Bytes>,
+    ) {
+        // NOTE: There are no checks for whether someone has the permission to do this. 
+        // It is suggested to add some administrative controls such as the Sway-Libs Ownership Library.
+        let event = SRC17NameEvent::new(name, resolver, asset, metadata);
+        event.log();
+    }
+}
+
+abi SetupExample {
+    #[storage(write)]
+    fn initialize(root: MerkleRoot);
+}
+
+impl SetupExample for Contract {
+    #[storage(write)]
+    fn initialize(root: MerkleRoot) {
+        // NOTE: There are no checks for whether someone has the permission to do this. 
+        // It is suggested to add some administrative controls such as the Sway-Libs Ownership Library.
+        storage.merkle_root.write(root);
+    }
+}

--- a/standards/src/src17.sw
+++ b/standards/src/src17.sw
@@ -1,0 +1,380 @@
+library;
+
+use std::{bytes::Bytes, string::String};
+use sway_libs::merkle::sparse::Proof;
+
+/// AltBN128 proof data.
+pub type AltBn128Proof = [u8; 288];
+/// Sparse Merkle Tree proof data.
+pub type SparseMerkleProof = Proof;
+
+#[cfg(experimental_const_generics = false)]
+impl AbiEncode for AltBn128Proof {
+    fn abi_encode(self, buffer: Buffer) -> Buffer {
+        let mut buffer = buffer;
+        let mut i = 0;
+        while i < 288 {
+            buffer = self[i].abi_encode(buffer);
+            i += 1;
+        };
+        buffer
+    }
+}
+
+#[cfg(experimental_const_generics = false)]
+impl AbiDecode for AltBn128Proof {
+    fn abi_decode(ref mut buffer: BufferReader) -> [u8; 288] {
+        let first: u8 = buffer.decode::<u8>();
+        let mut array = [first; 288];
+        let mut i = 1;
+        while i < 288 {
+            array[i] = buffer.decode::<u8>();
+            i += 1;
+        };
+        array
+    }
+}
+
+/// The error log used something in the SRC-17 verification process fails.
+pub enum SRC17VerificationError {
+    /// Emitted when verification of a SRC-17 proof fails.
+    VerificationFailed: (),
+}
+
+impl PartialEq for SRC17VerificationError {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::VerificationFailed, Self::VerificationFailed) => {
+                true
+            },
+        }
+    }
+}
+
+impl Eq for SRC17VerificationError {}
+
+/// A SRC-17 proof, either an AltBN128 proof or a Sparse Merkle Tree proof.
+pub enum SRC17Proof {
+    /// An AltBN128 proof.
+    AltBn128Proof: AltBn128Proof,
+    /// A Sparse Merkle Tree proof.
+    SparseMerkleProof: SparseMerkleProof,
+}
+
+impl PartialEq for SRC17Proof {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::AltBn128Proof(proof_1), Self::AltBn128Proof(proof_2)) => {
+                let mut i = 1;
+                while i < 288 {
+                    if proof_1[i] != proof_2[i] {
+                        return false
+                    }
+                    i += 1;
+                }
+                true
+            },
+            (Self::SparseMerkleProof(proof_1), Self::SparseMerkleProof(proof_2)) => {
+                proof_1 == proof_2
+            },
+            _ => false,
+        }
+    }
+}
+
+impl Eq for SRC17Proof {}
+
+impl SRC17Proof {
+    /// Returns whether the `SRC17Proof` is an AltBN128 proof.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - `true` if this is an AltBN128 proof, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17Proof;
+    ///
+    /// fn foo(my_proof: SRC17Proof) {
+    ///     let result: bool = my_proof.is_alt_bn128_proof();
+    ///     assert(result);
+    /// }
+    /// ```
+    fn is_alt_bn128_proof(self) -> bool {
+        match self {
+            Self::AltBn128Proof(_) => true,
+            Self::SparseMerkleProof(_) => false,
+        }
+    }
+
+    /// Returns whether the `SRC17Proof` is a Sparse Merkle Tree proof.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - `true` if this is a Sparse Merkle Tree proof, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17Proof;
+    ///
+    /// fn foo(my_proof: SRC17Proof) {
+    ///     let result: bool = my_proof.is_sparse_merkle_proof();
+    ///     assert(result);
+    /// }
+    /// ```
+    fn is_sparse_merkle_proof(self) -> bool {
+        match self {
+            Self::AltBn128Proof(_) => false,
+            Self::SparseMerkleProof(_) => true,
+        }
+    }
+
+    /// Returns the `SRC17Proof` as an AltBN128 proof.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<AltBn128Proof>] - `Some` if this is an AltBn128 proof, otherwise `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17Proof;
+    ///
+    /// fn foo(my_proof: SRC17Proof) {
+    ///     let result: Option<AltBn128Proof> = my_proof.as_alt_bn128_proof();
+    ///     assert(result.is_some());
+    /// }
+    /// ```
+    fn as_alt_bn128_proof(self) -> Option<AltBn128Proof> {
+        match self {
+            Self::AltBn128Proof(proof) => Some(proof),
+            Self::SparseMerkleProof(_) => None,
+        }
+    }
+
+    /// Returns the `SRC17Proof` as a Sparse Merkle Tree proof.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<SparseMerkleProof>] - `Some` if this is a Sparse Merkle Tree proof, otherwise `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17Proof;
+    ///
+    /// fn foo(my_proof: SRC17Proof) {
+    ///     let result: Option<SparseMerkleProof> = my_proof.as_sparse_merkle_proof();
+    ///     assert(result.is_some());
+    /// }
+    /// ```
+    fn as_sparse_merkle_proof(self) -> Option<SparseMerkleProof> {
+        match self {
+            Self::AltBn128Proof(_) => None,
+            Self::SparseMerkleProof(proof) => Some(proof),
+        }
+    }
+}
+
+abi SRC17 {
+    /// Verifies the validity of a name.
+    ///
+    /// # Arguments
+    ///
+    /// * `proof`: [SRC17Proof] - The proof which is used to verify against.
+    /// * `name`: [String] - The name of the onchain identity.
+    /// * `resolver`: [Identity] - The `Identity` which the name resolved to.
+    /// * `asset`: [AssetId] - The asset which represents ownership of the name.
+    /// * `metadata`: [Option<Bytes>] - `Some` metadata associated with the `name`, or `None`.
+    ///
+    /// # Returns
+    ///
+    /// * [Result<(), SRC17VerificationError>] - `Ok(())` if verification passed, otherwise an `Err`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17;
+    ///
+    /// fn foo(contract_id: ContractId, proof: SRC17Proof, name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) {
+    ///     let contract_abi = abi(SRC17, contract_id.bits());
+    ///
+    ///     let result = contract_abi.verify(proof, name, resolver, asset, metadata);
+    ///     assert(result.is_ok());
+    /// }
+    /// ```
+    #[storage(read)]
+    fn verify(
+        proof: SRC17Proof,
+        name: String,
+        resolver: Identity,
+        asset: AssetId,
+        metadata: Option<Bytes>,
+    ) -> Result<(), SRC17VerificationError>;
+}
+
+/// The event used when a data change occurs.
+pub struct SRC17NameEvent {
+    /// The name of the onchain identity.
+    pub name: String,
+    /// The `Identity` which the name resolves to.
+    pub resolver: Identity,
+    /// The asset which represents ownership of the name.
+    pub asset: AssetId,
+    /// Any metadata associated with the name.
+    pub metadata: Option<Bytes>,
+}
+
+impl SRC17NameEvent {
+    /// Returns a new `SRC17NameEvent`.
+    ///
+    /// # Arguments
+    ///
+    /// * `name`: [String] - The name for which the event is for.
+    /// * `resolver`: [Identity] - The `Identity` which the name resolves to.
+    /// * `asset`: [AssetId] - The asset which represents ownership of the name.
+    /// * `metadata`: [Option<Bytes>] - any metadata associated with the name.
+    ///
+    /// # Returns
+    ///
+    /// * [SRC17NameEvent] - The newly created event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17NameEvent;
+    ///
+    /// fn foo(name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) {
+    ///     let my_event = SRC17NameEvent::new(name, resolver, asset, metadata);
+    ///     my_event.log();
+    /// }
+    /// ```
+    pub fn new(
+        name: String,
+        resolver: Identity,
+        asset: AssetId,
+        metadata: Option<Bytes>,
+    ) -> Self {
+        Self {
+            name,
+            resolver,
+            asset,
+            metadata,
+        }
+    }
+
+    /// Returns the name associated with the `SRC17NameEvent`.
+    ///
+    /// # Returns
+    ///
+    /// * [String] - The name for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17NameEvent;
+    ///
+    /// fn foo(name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) {
+    ///     let my_event = SRC17NameEvent::new(name, resolver, asset, metadata);
+    ///
+    ///     let returned_name: String = my_event.name();
+    ///     assert(returned_name == name);
+    /// }
+    /// ```
+    pub fn name(self) -> String {
+        self.name
+    }
+
+    /// Returns the resolver associated with the `SRC17NameEvent`.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The resolver for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17NameEvent;
+    ///
+    /// fn foo(name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) {
+    ///     let my_event = SRC17NameEvent::new(name, resolver, asset, metadata);
+    ///
+    ///     let returned_resolver: String = my_event.resolver();
+    ///     assert(returned_resolver == resolver);
+    /// }
+    /// ```
+    pub fn resolver(self) -> Identity {
+        self.resolver
+    }
+
+    /// Returns the asset associated with the `SRC17NameEvent`.
+    ///
+    /// # Returns
+    ///
+    /// * [AssetId] - The asset for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17NameEvent;
+    ///
+    /// fn foo(name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) {
+    ///     let my_event = SRC17NameEvent::new(name, resolver, asset, metadata);
+    ///
+    ///     let returned_asset: String = my_event.asset();
+    ///     assert(returned_asset == asset);
+    /// }
+    /// ```
+    pub fn asset(self) -> AssetId {
+        self.asset
+    }
+
+    /// Returns the metadata associated with the `SRC17NameEvent`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<Bytes>] - The metadata for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17NameEvent;
+    ///
+    /// fn foo(name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) {
+    ///     let my_event = SRC17NameEvent::new(name, resolver, asset, metadata);
+    ///
+    ///     let returned_metadata: String = my_event.metadata();
+    ///     assert(returned_metadata == metadata);
+    /// }
+    /// ```
+    pub fn metadata(self) -> Option<Bytes> {
+        self.metadata
+    }
+
+    /// Logs the `SRC17NameEvent`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::src17::SRC17NameEvent;
+    ///
+    /// fn foo(name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) {
+    ///     let my_event = SRC17NameEvent::new(name, resolver, asset, metadata);
+    ///
+    ///     my_event.log();
+    /// }
+    /// ```
+    pub fn log(self) {
+        log(self);
+    }
+}
+
+impl PartialEq for SRC17NameEvent {
+    fn eq(self, other: Self) -> bool {
+        self.name == other.name && self.asset == other.asset && self.resolver == other.resolver && self.metadata == other.metadata
+    }
+}
+
+impl Eq for SRC17NameEvent {}

--- a/standards/src/standards.sw
+++ b/standards/src/standards.sw
@@ -10,8 +10,5 @@ pub mod src12;
 pub mod src14;
 pub mod src15;
 pub mod src16;
-<<<<<<< HEAD
-=======
 pub mod src17;
->>>>>>> master
 pub mod src20;

--- a/standards/src/standards.sw
+++ b/standards/src/standards.sw
@@ -10,4 +10,8 @@ pub mod src12;
 pub mod src14;
 pub mod src15;
 pub mod src16;
+<<<<<<< HEAD
+=======
+pub mod src17;
+>>>>>>> master
 pub mod src20;


### PR DESCRIPTION
## [Version 0.7.1]

### Added v0.7.1

- [#175](https://github.com/FuelLabs/sway-standards/pull/175) Introduces the SRC-17; Naming Verification Standard.
- [#178](https://github.com/FuelLabs/sway-standards/pull/178) Creates a Offchain Data section in the docs and README.

### Changed v0.7.1

- [#176](https://github.com/FuelLabs/sway-standards/pull/176) Updates the repository to forc `v0.68.1`, fuel-core `v0.43.1`, and Sway-Libs `v0.25.2`.
- [#174](https://github.com/FuelLabs/sway-standards/pull/174) Updates CODEOWNERS from SwayEx to Onchain.
- [#177](https://github.com/FuelLabs/sway-standards/pull/177) Prepares for the `v0.7.1` release.

### Fixed v0.7.1

- None

### Breaking v0.7.1

- None