### PR TITLE
fix: SRC-20 Single and Multi Asset examples flipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Some fix here.
-- Some fix here.
+- [#180](https://github.com/FuelLabs/sway-standards/pull/180) Fixes SRC-20 Multi and Single Asset example ordering.
 
 ### Breaking
 

--- a/docs/src/src-20-native-asset.md
+++ b/docs/src/src-20-native-asset.md
@@ -172,7 +172,7 @@ abi SRC20 {
 Example of the SRC-20 implementation where a contract contains a single asset with one `SubId`. This implementation is recommended for users that intend to deploy a single asset with their contract.
 
 ```sway
-{{#include ../examples/src20-native-asset/multi_asset/src/multi_asset.sw}}
+{{#include ../examples/src20-native-asset/single_asset/src/single_asset.sw}}
 ```
 
 ### Multi Native Asset
@@ -180,5 +180,5 @@ Example of the SRC-20 implementation where a contract contains a single asset wi
 Example of the SRC-20 implementation where a contract contains multiple assets with differing `SubId`s. This implementation is recommended for users that intend to deploy multiple assets with their contract.
 
 ```sway
-{{#include ../examples/src20-native-asset/single_asset/src/single_asset.sw}}
+{{#include ../examples/src20-native-asset/multi_asset/src/multi_asset.sw}}
 ```


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix

## Changes

The following changes have been made:

- Single asset example was shown for multi asset and vice versa

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
