### PR TITLE
Add `global` key to SRC-9 standard

### DIFF
--- a/docs/src/src-9-metadata-keys.md
+++ b/docs/src/src-9-metadata-keys.md
@@ -16,6 +16,20 @@ The following keys are reserved for the SRC-9 standard. Use of the keys should f
 
 All keys SHALL use snake case.
 
+### Quick Links
+
+[Social](#social)
+[Contact](#contact)
+[External Links](#external-links)
+[Resources](#resources)
+[Images](#images)
+[Video](#video)
+[Audio](#audio)
+[Media](#media)
+[Logos](#logos)
+[Attributes](#attributes)
+[Global](#global)
+
 ### Social
 
 The social prefix SHALL be used for any social media platform and SHALL return usernames.
@@ -342,6 +356,17 @@ Any attribute metadata keys SHALL follow the following syntax `attr:type` where:
 
 There are no standardized types of attributes.
 Example: `attr:eyes`.
+
+### Global
+
+The `global` prefix SHALL be used for any attributes associated with ALL assets minted by a contract.
+
+Any global metadata keys SHALL follow the following syntax `global:key` where:
+
+- The `global` keyword must be prepended to denote this is a global metadata
+- The `key` keyword must be the type of metadata using a SRC-9 key defined above
+
+Example: `global:image:png`.
 
 ## Rationale
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- Defines the `global` key and how to use it in combination with other key schemas to create a key that applies to all NFTs minted by a contract.
- Adds a quick links section to find the key schema section

## Notes

- To be used in combination with ipfs hashes 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
