### PR TITLE
Add `SRC15GlobalMetadataEvent` to SRC-15 standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - [#178](https://github.com/FuelLabs/sway-standards/pull/178) Creates a Offchain Data section in the docs and README.
+- [#181](https://github.com/FuelLabs/sway-standards/pull/181) Adds the `global` key to the SRC-9 standard.
+- [#182](https://github.com/FuelLabs/sway-standards/pull/182) Adds the `SRC15GlobalMetadataEvent` event to the SRC-15 Standard.
 
 ### Changed
 

--- a/docs/spell-check-custom-words.txt
+++ b/docs/spell-check-custom-words.txt
@@ -280,3 +280,4 @@ Bako
 FNS
 AltBn
 NameEvent
+GlobalMetadataEvent

--- a/docs/src/src-15-offchain-asset-metadata.md
+++ b/docs/src/src-15-offchain-asset-metadata.md
@@ -26,7 +26,7 @@ The following logs MUST be implemented and emitted to follow the SRC-15 standard
 
 #### SRC15MetadataEvent
 
-The `SRC15MetadataEvent` MUST be emitted at least once for each distinct piece of metadata. The latest emitted `SRC15MetadataEvent` is determined to be the current metadata.
+The `SRC15MetadataEvent` MUST be emitted at least once for each distinct piece of metadata and each distinct asset. The latest emitted `SRC15MetadataEvent` is determined to be the current metadata.
 
 There SHALL be the following fields in the `SRC15MetadataEvent` struct:
 
@@ -38,6 +38,22 @@ Example:
 ```sway
 pub struct SRC15MetadataEvent {
     pub asset: AssetId,
+    pub metadata: Metadata,
+}
+```
+
+#### SRC15GlobalMetadataEvent
+
+The `SRC15GlobalMetadataEvent` MUST be emitted at least once for each distinct piece of metadata for *all* assets minted by a contract. The latest emitted `SRC15GlobalMetadataEvent` is determined to be the current metadata.
+
+There SHALL be the following fields in the `SRC15GlobalMetadataEvent` struct:
+
+* `metadata`: The `metadata` field SHALL be used for the corresponding `Metadata` which represents the metadata associated with all assets minted by the contract.
+
+Example:
+
+```sway
+pub struct SRC15GlobalMetadataEvent {
     pub metadata: Metadata,
 }
 ```
@@ -70,4 +86,12 @@ Example of the SRC-15 implementation where metadata exists for multiple assets w
 
 ```sway
 {{#include ../examples/src15-offchain-metadata/multi_asset/src/multi_asset.sw}}
+```
+
+### Global
+
+Example of the SRC-15 implementation where global metadata exists for all assets.
+
+```sway
+{{#include ../examples/src15-offchain-metadata/global/src/global.sw}}
 ```

--- a/examples/src15-offchain-metadata/global/Forc.toml
+++ b/examples/src15-offchain-metadata/global/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "global.sw"
+license = "Apache-2.0"
+name = "global_src15_asset"
+
+[dependencies]
+standards = { path = "../../../standards" }

--- a/examples/src15-offchain-metadata/global/src/global.sw
+++ b/examples/src15-offchain-metadata/global/src/global.sw
@@ -1,0 +1,117 @@
+contract;
+
+use standards::{
+    src15::{
+        SRC15GlobalMetadataEvent,
+    },
+    src20::{
+        SetDecimalsEvent,
+        SetNameEvent,
+        SetSymbolEvent,
+        SRC20,
+        TotalSupplyEvent,
+    },
+    src7::{
+        Metadata,
+    },
+};
+
+use std::{hash::Hash, storage::storage_string::*, string::String};
+
+// In this example, all assets minted from this contract have the same decimals, name, and symbol
+configurable {
+    /// The decimals of every asset minted by this contract.
+    DECIMALS: u8 = 0u8,
+    /// The name of every asset minted by this contract.
+    NAME: str[7] = __to_str_array("MyAsset"),
+    /// The symbol of every asset minted by this contract.
+    SYMBOL: str[5] = __to_str_array("MYAST"),
+    /// The metadata for the "social:x" key.
+    SOCIAL_X: str[12] = __to_str_array("fuel_network"),
+    /// The metadata for the "site:forum" key.
+    SITE_FORUM: str[27] = __to_str_array("https://forum.fuel.network/"),
+}
+
+storage {
+    /// The total number of distinguishable assets this contract has minted.
+    total_assets: u64 = 0,
+    /// The total supply of a particular asset.
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+}
+
+abi EmitSRC15Events {
+    #[storage(read)]
+    fn emit_src15_events(svg_image: String, health_attribute: u64);
+}
+
+impl EmitSRC15Events for Contract {
+    #[storage(read)]
+    fn emit_src15_events(svg_image: String, health_attribute: u64) {
+        // NOTE: There are no checks for if the caller has permissions to emit the metadata
+        // NOTE: Nothing is stored in storage and there is no method to retrieve the configurables.
+        let metadata_1 = Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X)));
+        let metadata_2 = Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM)));
+        let metadata_3 = Metadata::String(svg_image);
+        let metadata_4 = Metadata::Int(health_attribute);
+
+        SRC15GlobalMetadataEvent::new(metadata_1).log();
+        SRC15GlobalMetadataEvent::new(metadata_2).log();
+        SRC15GlobalMetadataEvent::new(metadata_3).log();
+        SRC15GlobalMetadataEvent::new(metadata_4).log();
+    }
+}
+
+// SRC15 extends SRC20, so this must be included
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        storage.total_assets.read()
+    }
+
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        storage.total_supply.get(asset).try_read()
+    }
+
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(String::from_ascii_str(from_str_array(NAME))),
+            None => None,
+        }
+    }
+
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(String::from_ascii_str(from_str_array(SYMBOL))),
+            None => None,
+        }
+    }
+
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(DECIMALS),
+            None => None,
+        }
+    }
+}
+
+abi EmitSRC20Data {
+    fn emit_src20_data(asset: AssetId, total_supply: u64);
+}
+
+impl EmitSRC20Data for Contract {
+    fn emit_src20_data(asset: AssetId, supply: u64) {
+        // NOTE: There are no checks for if the caller has permissions to update the metadata
+        let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
+
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, supply, sender).log();
+    }
+}

--- a/standards/src/src15.sw
+++ b/standards/src/src15.sw
@@ -104,3 +104,81 @@ impl SRC15MetadataEvent {
         log(self);
     }
 }
+
+/// The required event to be emitted for the SRC-15 standard.
+pub struct SRC15GlobalMetadataEvent {
+    /// The Metadata of the SRC-15 event.
+    pub metadata: Metadata,
+}
+
+impl PartialEq for SRC15GlobalMetadataEvent {
+    fn eq(self, other: Self) -> bool {
+        self.metadata == other.metadata
+    }
+}
+
+impl Eq for SRC15GlobalMetadataEvent {}
+
+impl SRC15GlobalMetadataEvent {
+    /// Returns a new `SRC15GlobalMetadataEvent` event.
+    ///
+    /// # Arguments
+    ///
+    /// * `metadata`: [Option<Metdata>] - The Metadata that is set.
+    ///
+    /// # Returns
+    ///
+    /// * [SRC15GlobalMetadataEvent] - The new `SRC15GlobalMetadataEvent` event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::{src7::Metadata, src15::SRC15GlobalMetadataEvent};
+    ///
+    /// fn foo(metadata: Metadata) {
+    ///     let my_src15_metadata_event = SRC15GlobalMetadataEvent::new(metadata);
+    ///     assert(my_src15_metadata_event.metadata == metadata);
+    /// }
+    /// ```
+    pub fn new(metadata: Metadata) -> Self {
+        Self {
+            metadata,
+        }
+    }
+
+    /// Returns the metadata of the `SRC15GlobalMetadataEvent` event.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<Metadata>] - The metadata for the event.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::{src7::Metadata, src15::SRC15GlobalMetadataEvent};
+    ///
+    /// fn foo(metadata: Metadata) {
+    ///     let my_src15_metadata_event = SRC15GlobalMetadataEvent::new(metadata);
+    ///     assert(my_src15_metadata_event.metadata() == metadata);
+    /// }
+    /// ```
+    pub fn metadata(self) -> Metadata {
+        self.metadata
+    }
+
+    /// Logs the `SRC15GlobalMetadataEvent`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use standards::{src7::Metadata, src15::SRC15GlobalMetadataEvent};
+    ///
+    /// fn foo(metadata: Metadata) {
+    ///     let my_event = SRC15GlobalMetadataEvent::new(metadata);
+    ///     my_event.log();
+    /// }
+    /// ```
+    pub fn log(self) {
+        log(self);
+    }
+}

--- a/standards/src/src15.sw
+++ b/standards/src/src15.sw
@@ -141,9 +141,7 @@ impl SRC15GlobalMetadataEvent {
     /// }
     /// ```
     pub fn new(metadata: Metadata) -> Self {
-        Self {
-            metadata,
-        }
+        Self { metadata }
     }
 
     /// Returns the metadata of the `SRC15GlobalMetadataEvent` event.

--- a/standards/src/src16.sw
+++ b/standards/src/src16.sw
@@ -134,7 +134,8 @@ impl SRC16Domain {
     /// * [b256] - The Keccak256 hash of the encoded domain parameters
     ///
     pub fn domain_hash(self) -> b256 {
-        let encoded = encode(self);
+        let buffer = self.abi_encode(Buffer::new());
+        let encoded = buffer.as_raw_slice();
         let bytes = Bytes::from(encoded);
         keccak256(bytes)
     }
@@ -230,7 +231,8 @@ impl EIP712Domain {
     /// * [b256] - The Keccak256 hash of the encoded domain parameters
     ///
     pub fn domain_hash(self) -> b256 {
-        let encoded = encode(self);
+        let buffer = self.abi_encode(Buffer::new());
+        let encoded = buffer.as_raw_slice();
         let bytes = Bytes::from(encoded);
         keccak256(bytes)
     }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- Adds the `SRC15GlobalMetadataEvent` to the SRC-15 standard, allowing for a single piece of metadata to be associated with all assets minted by a contract.

## Notes

- This is intended to be used with IFPS hashes

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
