### PR TITLE
Add CI job to run `forc publish` on release changes

### DIFF
--- a/.github/workflows/publish-standards.yaml
+++ b/.github/workflows/publish-standards.yaml
@@ -64,14 +64,22 @@ jobs:
         id: current-version
         run: |
           grep -m1 '^version =' standards/${{ matrix.project }}/Forc.toml | cut -d '"' -f2 > current-version.txt
-          echo "CURRENT_VERSION=$(cat current-version.txt)" >> $GITHUB_ENV
+          if [ "$(wc -c < "current-version.txt")" -eq 0 ]; then 
+              exit 1
+          else
+              echo "CURRENT_VERSION=$(cat current-version.txt)" >> $GITHUB_ENV
+          fi
 
       - name: Get previous version
         id: previous-version
         run: |
           git show HEAD^:standards/${{ matrix.project }}/Forc.toml > previous.toml 2>/dev/null || touch previous.toml
           grep -m1 '^version =' previous.toml | cut -d '"' -f2 > previous-version.txt
-          echo "PREVIOUS_VERSION=$(cat previous-version.txt)" >> $GITHUB_ENV
+          if [ "$(wc -c < "previous-version.txt")" -eq 0 ]; then 
+              echo "PREVIOUS_VERSION=0.0.0" >> $GITHUB_ENV
+          else
+              echo "PREVIOUS_VERSION=$(cat previous-version.txt)" >> $GITHUB_ENV
+          fi
 
       - name: Compare versions
         id: version-check

--- a/.github/workflows/publish-standards.yaml
+++ b/.github/workflows/publish-standards.yaml
@@ -1,4 +1,4 @@
-name: Publish standards
+name: Publish Standards
 
 on:
   push:
@@ -100,7 +100,7 @@ jobs:
           name: my-toolchain
           components: forc@${{ env.FORC_VERSION }}, fuel-core@${{ env.CORE_VERSION }}
 
-      - name: Publish Library
+      - name: Publish Standards
         if: steps.version-check.outputs.changed == 'true'
         run: |
           cd standards/${{ matrix.project }}

--- a/.github/workflows/publish-standards.yaml
+++ b/.github/workflows/publish-standards.yaml
@@ -102,6 +102,8 @@ jobs:
 
       - name: Publish Library
         if: steps.version-check.outputs.changed == 'true'
-        run: forc publish --path standards/${{ matrix.project }}
+        run: |
+          cd standards/${{ matrix.project }}
+          forc publish
         env:
           FORC_PUB_TOKEN: ${{ secrets.FORCPUB_TOKEN }}    

--- a/.github/workflows/publish-standards.yaml
+++ b/.github/workflows/publish-standards.yaml
@@ -1,0 +1,107 @@
+name: Publish standards
+
+on:
+  push:
+    branches:
+      - release
+    paths:
+      - 'standards/**/Forc.toml'  # Only trigger when Forc.toml changes
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+  RUST_VERSION: 1.84.0
+  FORC_VERSION: 0.68.6
+  CORE_VERSION: 0.43.2
+
+jobs:
+  verify-branch:
+      runs-on: ubuntu-latest
+      outputs:
+        is-release: ${{ steps.check-branch.outputs.is-release }}
+      steps:
+        - name: Check current branch
+          id: check-branch
+          run: |
+            if [ "${{ github.ref_name }}" = "release" ]; then
+              echo "is-release=true" >> $GITHUB_OUTPUT
+            else
+              echo "is-release=false" >> $GITHUB_OUTPUT
+            fi
+
+  detect-version-change:
+    runs-on: ubuntu-latest
+    needs: verify-branch
+    if: needs.verify-branch.outputs.is-release == 'true'
+    strategy:
+          matrix:
+            project:
+              [
+                "src3",
+                "src5",
+                "src6",
+                "src7",
+                "src10",
+                "src11",
+                "src12",
+                "src14",
+                "src15",
+                "src16",
+                "src17",
+                "src20",
+              ]
+    steps:
+      - name: Checkout repository (with previous commit)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2  # Required to access previous commit
+
+      - name: Get current version
+        id: current-version
+        run: |
+          grep -m1 '^version =' standards/${{ matrix.project }}/Forc.toml | cut -d '"' -f2 > current-version.txt
+          echo "CURRENT_VERSION=$(cat current-version.txt)" >> $GITHUB_ENV
+
+      - name: Get previous version
+        id: previous-version
+        run: |
+          git show HEAD^:standards/${{ matrix.project }}/Forc.toml > previous.toml 2>/dev/null || touch previous.toml
+          grep -m1 '^version =' previous.toml | cut -d '"' -f2 > previous-version.txt
+          echo "PREVIOUS_VERSION=$(cat previous-version.txt)" >> $GITHUB_ENV
+
+      - name: Compare versions
+        id: version-check
+        run: |
+          if [ "${{ env.CURRENT_VERSION }}" != "${{ env.PREVIOUS_VERSION }}" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install Rust toolchain
+        if: steps.version-check.outputs.changed == 'true'
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          components: rustfmt
+
+      - name: Init cache
+        if: steps.version-check.outputs.changed == 'true'
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Fuel toolchain
+        if: steps.version-check.outputs.changed == 'true'
+        uses: FuelLabs/action-fuel-toolchain@v0.6.0
+        with:
+          name: my-toolchain
+          components: forc@${{ env.FORC_VERSION }}, fuel-core@${{ env.CORE_VERSION }}
+
+      - name: Publish Library
+        if: steps.version-check.outputs.changed == 'true'
+        run: forc publish --path standards/${{ matrix.project }}
+        env:
+          FORC_PUB_TOKEN: ${{ secrets.FORCPUB_TOKEN }}    


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

 Adds job to publish on the `release` branch for every standard.

## Notes

- This will only trigger if the `version` set in the `Forc.toml` updates. This means we can update individual packages separately. 
- Setup to handle cases where a previous version does not exist i.e. a new standard is released

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.
