### PR TITLE
Update to forc `v0.68.7`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.80.1
-  FORC_VERSION: 0.68.1
+  FORC_VERSION: 0.68.7
   CORE_VERSION: 0.43.1
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/.github/workflows/publish-standards.yaml
+++ b/.github/workflows/publish-standards.yaml
@@ -15,7 +15,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.84.0
-  FORC_VERSION: 0.68.6
+  FORC_VERSION: 0.68.7
   CORE_VERSION: 0.43.2
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Some change here.
-- Some change here.
+- [#186](https://github.com/FuelLabs/sway-standards/pull/186) Updates to repository to forc `v0.68.7`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yaml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yaml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.68.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.68.1-orange" />
+    <a href="https://crates.io/crates/forc/0.68.7" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.68.7-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-standards" />
@@ -177,7 +177,7 @@ Example of a minimal SRC-14 implementation with no access control.
 Example of a SRC-14 implementation that also implements [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/).
 
 > **Note**
-> All standards currently use `forc v0.68.1`.
+> All standards currently use `forc v0.68.7`.
 
 <!-- TODO:
 ## Contributing

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@ Standards in this repository may be in various stages of development. Use of dra
 If you don't find what you're looking for, feel free to create an issue and propose a new standard!
 
 > **Note**
-> All standards currently use `forc v0.68.1`.
+> All standards currently use `forc v0.68.7`.
 
 ## Using a standard
 

--- a/standards/src/src12.sw
+++ b/standards/src/src12.sw
@@ -109,24 +109,3 @@ abi SRC12_Extension {
     #[storage(read)]
     fn get_contract_id(configurables: Option<ContractConfigurables>) -> Option<ContractId>;
 }
-
-impl Hash for ContractConfigurables {
-    fn hash(self, ref mut state: Hasher) {
-        // Iterate over every configurable
-        let mut configurable_iterator = 0;
-        while configurable_iterator < self.len() {
-            let (offset, data) = self.get(configurable_iterator).unwrap();
-            let buffer = alloc_bytes(data.len() + 4);
-            let offset_ptr = asm(input: offset) {
-                input: raw_ptr
-            };
-
-            // Overwrite the configurable data into the buffer
-            offset_ptr.copy_bytes_to(buffer, 4);
-            data.ptr().copy_bytes_to(buffer.add::<u8>(4), data.len());
-
-            state.write(Bytes::from(raw_slice::from_parts::<u8>(buffer, data.len() + 4)));
-            configurable_iterator += 1;
-        }
-    }
-}


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates the repository to forc `v0.68.7`. This is required for the new forc publish system

## Notes

- There is a circular dependency where an older version of sway-standards is required to compile sway-libs which is needed in sway-standards. The new refactor will break this circular dependency.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
