### PR TITLE
feat: add a toposort based deployment script

### DIFF
--- a/.github/publisher/Cargo.toml
+++ b/.github/publisher/Cargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+
+[package]
+name = "publisher"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0"
+petgraph = "0.6"
+serde = { version = "1.0", features = ["derive"] }
+toml_edit = { version = "0.22" }

--- a/.github/publisher/src/main.rs
+++ b/.github/publisher/src/main.rs
@@ -121,8 +121,6 @@ fn main() -> Result<()> {
 
         let output = Command::new("forc")
             .arg("publish")
-            .arg("--registry-url")
-            .arg("http://localhost:8080")
             .current_dir(&project_dir)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -145,8 +143,7 @@ fn main() -> Result<()> {
 
         // Clone the version string to release the immutable borrow on `all_packages_data`,
         // allowing us to pass it mutably to `update_dependents`.
-        let published_version = all_packages_data[project_name.as_str()]
-            .0["project"]["version"]
+        let published_version = all_packages_data[project_name.as_str()].0["project"]["version"]
             .as_str()
             .context("Could not find project version in Forc.toml")?
             .to_string();

--- a/.github/publisher/src/main.rs
+++ b/.github/publisher/src/main.rs
@@ -1,0 +1,203 @@
+use anyhow::{anyhow, Context, Result};
+use petgraph::algo::toposort;
+use petgraph::graph::DiGraph;
+use petgraph::visit::Dfs;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use toml_edit::DocumentMut;
+
+fn main() -> Result<()> {
+    if env::var("FORC_PUB_TOKEN").is_err() {
+        return Err(anyhow!(
+            "Error: FORC_PUB_TOKEN environment variable is not set."
+        ));
+    }
+
+    let args: Vec<String> = env::args().skip(1).collect();
+    if args.is_empty() {
+        println!("No projects specified for publishing. Exiting.");
+        return Ok(());
+    }
+    let seed_projects: HashSet<String> = args.into_iter().collect();
+
+    let standards_dir = env::current_dir()?.join("standards");
+    let project_paths = find_sway_projects(&standards_dir)?;
+
+    let mut all_packages_data: BTreeMap<String, (DocumentMut, PathBuf)> = BTreeMap::new();
+    let mut graph = DiGraph::new();
+    let mut node_map = HashMap::new();
+
+    for path in &project_paths {
+        let project_name_from_path = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .context("Could not get project name from path")?
+            .to_string();
+        let toml_path = path.join("Forc.toml");
+        let toml_content = fs::read_to_string(&toml_path)
+            .with_context(|| format!("Failed to read Forc.toml for {}", project_name_from_path))?;
+        let forc_toml: DocumentMut = toml_content
+            .parse::<DocumentMut>()
+            .with_context(|| format!("Failed to parse Forc.toml for {}", project_name_from_path))?;
+
+        let project_name_from_toml = forc_toml["project"]["name"]
+            .as_str()
+            .context("Could not get project name from Forc.toml")?
+            .to_string();
+
+        let node = graph.add_node(project_name_from_toml.clone());
+        node_map.insert(project_name_from_toml, node);
+        all_packages_data.insert(project_name_from_path, (forc_toml, toml_path));
+    }
+
+    for (project_name, (forc_toml, _)) in &all_packages_data {
+        if let Some(dependencies) = forc_toml.get("dependencies").and_then(|d| d.as_table()) {
+            let from_node = node_map[project_name];
+            for (dep_name, dep) in dependencies.iter() {
+                if let Some(dep_table) = dep.as_inline_table() {
+                    if dep_table.contains_key("path") {
+                        if let Some(&to_node) = node_map.get(dep_name) {
+                            graph.add_edge(to_node, from_node, ());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Find all projects that need to be published based on the seed projects.
+    let mut to_publish_names = HashSet::new();
+    for seed_name in &seed_projects {
+        if !node_map.contains_key(seed_name) {
+            println!(
+                "Warning: Specified project '{}' not found. Skipping.",
+                seed_name
+            );
+            continue;
+        }
+        let start_node = node_map[seed_name];
+        // DFS from the seed node finds all projects that depend on it.
+        let mut dfs = Dfs::new(&graph, start_node);
+        while let Some(nx) = dfs.next(&graph) {
+            to_publish_names.insert(graph[nx].clone());
+        }
+    }
+
+    if to_publish_names.is_empty() {
+        println!("No projects to publish after analyzing dependencies.");
+        return Ok(());
+    }
+
+    let sorted_indices = toposort(&graph, None).map_err(|cycle| {
+        let node_index = cycle.node_id();
+        let project_name = graph.node_weight(node_index).unwrap();
+        anyhow!(
+            "A cycle was detected in the dependency graph involving '{}'",
+            project_name
+        )
+    })?;
+
+    let sorted_projects: Vec<String> = sorted_indices
+        .iter()
+        .map(|&i| graph[i].clone())
+        .filter(|p| to_publish_names.contains(p))
+        .collect();
+
+    if sorted_projects.is_empty() {
+        println!("No projects to publish after filtering and sorting.");
+        return Ok(());
+    }
+
+    println!("Publishing order determined:");
+    println!(" -> {}", sorted_projects.join(" -> "));
+    println!("{}", "-".repeat(30));
+
+    for project_name in sorted_projects {
+        println!("Publishing {}...", project_name);
+        let project_dir = standards_dir.join(&project_name);
+
+        let output = Command::new("forc")
+            .arg("publish")
+            .arg("--registry-url")
+            .arg("http://localhost:8080")
+            .current_dir(&project_dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("Failed to execute 'forc publish'")?;
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        if !output.status.success() {
+            if stderr.contains("already exists") {
+                println!("{} version already published, skipping.", project_name);
+            } else {
+                eprintln!("Error publishing {}:", project_name);
+                eprintln!("{}", stderr);
+                return Err(anyhow!("Failed to publish {}", project_name));
+            }
+        } else {
+            println!("Successfully published {}", project_name);
+        }
+
+        // Clone the version string to release the immutable borrow on `all_packages_data`,
+        // allowing us to pass it mutably to `update_dependents`.
+        let published_version = all_packages_data[project_name.as_str()]
+            .0["project"]["version"]
+            .as_str()
+            .context("Could not find project version in Forc.toml")?
+            .to_string();
+        update_dependents(&project_name, &published_version, &mut all_packages_data)?;
+    }
+
+    println!("{}", "-".repeat(30));
+    println!("All standards published successfully!");
+
+    Ok(())
+}
+
+fn find_sway_projects(directory: &Path) -> Result<Vec<PathBuf>> {
+    let mut projects = vec![];
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() && entry.file_name().to_string_lossy().starts_with("src") {
+            projects.push(path);
+        }
+    }
+    Ok(projects)
+}
+
+fn update_dependents(
+    published_package_name: &str,
+    published_version: &str,
+    all_packages_data: &mut BTreeMap<String, (DocumentMut, PathBuf)>,
+) -> Result<()> {
+    for (package_name, (data, toml_path)) in all_packages_data.iter_mut() {
+        let mut dirty = false;
+        if let Some(dep) = data["dependencies"].get_mut(published_package_name) {
+            if let Some(dep_table) = dep.as_inline_table_mut() {
+                if dep_table.get("path").is_some() {
+                    println!(
+                        "Updating dependency '{}' in {}'s Forc.toml",
+                        published_package_name, package_name
+                    );
+                    dep_table.remove("path");
+                    dep_table.insert("version", published_version.into());
+                    dirty = true;
+                }
+            }
+        }
+
+        if dirty {
+            let new_toml_content = data.to_string();
+            fs::write(toml_path, new_toml_content).with_context(|| {
+                format!("Failed to write updated Forc.toml for {}", package_name)
+            })?;
+        }
+    }
+    Ok(())
+}

--- a/.github/workflows/publish-standards.yaml
+++ b/.github/workflows/publish-standards.yaml
@@ -5,113 +5,82 @@ on:
     branches:
       - release
     paths:
-      - 'standards/**/Forc.toml'  # Only trigger when Forc.toml changes
+      - 'standards/**/Forc.toml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
-  REGISTRY: ghcr.io
   RUST_VERSION: 1.84.0
   FORC_VERSION: 0.68.7
   CORE_VERSION: 0.43.2
+  # A list of all standard projects, used by the detection job.
+  PROJECTS: '["src3", "src5", "src6", "src7", "src10", "src11", "src12", "src14", "src15", "src16", "src17", "src20"]'
 
 jobs:
-  verify-branch:
-      runs-on: ubuntu-latest
-      outputs:
-        is-release: ${{ steps.check-branch.outputs.is-release }}
-      steps:
-        - name: Check current branch
-          id: check-branch
-          run: |
-            if [ "${{ github.ref_name }}" = "release" ]; then
-              echo "is-release=true" >> $GITHUB_OUTPUT
-            else
-              echo "is-release=false" >> $GITHUB_OUTPUT
-            fi
-
-  detect-version-change:
+  detect-changes:
     runs-on: ubuntu-latest
-    needs: verify-branch
-    if: needs.verify-branch.outputs.is-release == 'true'
-    strategy:
-          matrix:
-            project:
-              [
-                "src3",
-                "src5",
-                "src6",
-                "src7",
-                "src10",
-                "src11",
-                "src12",
-                "src14",
-                "src15",
-                "src16",
-                "src17",
-                "src20",
-              ]
+    outputs:
+      changed_projects: ${{ steps.changes.outputs.changed_projects }}
+      has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
-      - name: Checkout repository (with previous commit)
+      - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2  # Required to access previous commit
+          fetch-depth: 2 # Required to access the previous commit
 
-      - name: Get current version
-        id: current-version
+      - name: Detect changed projects
+        id: changes
         run: |
-          grep -m1 '^version =' standards/${{ matrix.project }}/Forc.toml | cut -d '"' -f2 > current-version.txt
-          if [ "$(wc -c < "current-version.txt")" -eq 0 ]; then 
-              exit 1
+          PROJECT_LIST=$(echo $PROJECTS | jq -r '.[]')
+          CHANGED_PROJECTS=""
+          for project in $PROJECT_LIST; do
+            CURRENT_VERSION=$(grep -m1 '^version =' "standards/$project/Forc.toml" | cut -d '"' -f2)
+            PREVIOUS_VERSION=$(git show HEAD^:"standards/$project/Forc.toml" 2>/dev/null | grep -m1 '^version =' | cut -d '"' -f2 || echo "0.0.0")
+            if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+              echo "Version changed for $project: $PREVIOUS_VERSION -> $CURRENT_VERSION"
+              CHANGED_PROJECTS="$CHANGED_PROJECTS $project"
+            fi
+          done
+          CHANGED_PROJECTS=$(echo "$CHANGED_PROJECTS" | xargs)
+          echo "changed_projects=$CHANGED_PROJECTS" >> $GITHUB_OUTPUT
+          if [ -z "$CHANGED_PROJECTS" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
           else
-              echo "CURRENT_VERSION=$(cat current-version.txt)" >> $GITHUB_ENV
+            echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
-
-      - name: Get previous version
-        id: previous-version
-        run: |
-          git show HEAD^:standards/${{ matrix.project }}/Forc.toml > previous.toml 2>/dev/null || touch previous.toml
-          grep -m1 '^version =' previous.toml | cut -d '"' -f2 > previous-version.txt
-          if [ "$(wc -c < "previous-version.txt")" -eq 0 ]; then 
-              echo "PREVIOUS_VERSION=0.0.0" >> $GITHUB_ENV
-          else
-              echo "PREVIOUS_VERSION=$(cat previous-version.txt)" >> $GITHUB_ENV
-          fi
-
-      - name: Compare versions
-        id: version-check
-        run: |
-          if [ "${{ env.CURRENT_VERSION }}" != "${{ env.PREVIOUS_VERSION }}" ]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
+  
+  publish-standards:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        if: steps.version-check.outputs.changed == 'true'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-          components: rustfmt
 
-      - name: Init cache
-        if: steps.version-check.outputs.changed == 'true'
+      - name: Init Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          key: publisher-build
+          workspaces: .github/publisher -> target
 
       - name: Install Fuel toolchain
-        if: steps.version-check.outputs.changed == 'true'
         uses: FuelLabs/action-fuel-toolchain@v0.6.0
         with:
           name: my-toolchain
           components: forc@${{ env.FORC_VERSION }}, fuel-core@${{ env.CORE_VERSION }}
 
+      - name: Build Publisher
+        run: cargo build --release --manifest-path .github/publisher/Cargo.toml
+
       - name: Publish Standards
-        if: steps.version-check.outputs.changed == 'true'
-        run: |
-          cd standards/${{ matrix.project }}
-          forc publish
+        run: ./.github/publisher/target/release/publisher ${{ needs.detect-changes.outputs.changed_projects }}
         env:
           FORC_PUB_TOKEN: ${{ secrets.FORCPUB_TOKEN }}    

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # will have compiled files and executables
 /target/
 
+.github/publisher/target/
+
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
 Cargo.lock


### PR DESCRIPTION
A deployment script that first does a topological sort to understand deplyoment order and proceeds to deploy packages, once a package is deployed with version `A` all, its dependents will be updated to point to the newly updated package. 



We might need to add some sleep time in between deployments to ensure everything lands, locally it seems it is not necessary but let's keep that in mind.