### PR TITLE
use rust edition 2021 instead of 2024 for publisher

### DIFF
--- a/.github/publisher/Cargo.toml
+++ b/.github/publisher/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "publisher"
 version = "0.0.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
## Type of change

The build publisher step was [failing](https://github.com/FuelLabs/sway-standards/actions/runs/15558334743/job/43804298565) due to the rust edition being set to 2024. This changes is to 2021 so the CI step can pass. 


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.
