### PR TITLE
Add README.md to standards

### DIFF
--- a/standards/src10/README.md
+++ b/standards/src10/README.md
@@ -1,0 +1,169 @@
+# SRC-10: Native Bridge
+
+The following standard allows for the implementation of a standard API for Native Bridges using the Sway Language. The standardized design has the bridge contract send a message to the origin chain to register which token it accepts to prevent a loss of funds.
+
+## Motivation
+
+A standard interface for bridges intends to provide a safe and efficient bridge between the settlement or canonical chain and the Fuel Network.
+
+## Prior Art
+
+The standard is centered on Fuel’s [Bridge Architecture](https://github.com/FuelLabs/fuel-bridge/blob/main/docs/ARCHITECTURE.md). Fuel's bridge system is built on a message protocol that allows to send (and receive) messages between entities located in two different blockchains.
+
+The following standard takes reference from the [`FungibleBridge`](https://github.com/FuelLabs/fuel-bridge/blob/3971081850e7961d9b649edda4cad8a848ee248e/packages/fungible-token/bridge-fungible-token/src/interface.sw#L22) ABI defined in the fuel-bridge repository.
+
+## Specification
+
+The following functions MUST be implemented to follow the SRC-10; Native Bridge Standard:
+
+### Required Functions
+
+**`fn process_message(message_index: u64)`**
+
+The `process_message()` function accepts incoming deposit messages from the canonical chain and issues the corresponding bridged asset.
+
+- This function MUST parse a message at the given `message_index` index.
+- This function SHALL mint an asset that follows the [SRC-8; Bridged Asset Standard](https://docs.fuel.network/docs/sway-standards/src-8-bridged-asset/).
+- This function SHALL issue a refund if there is an error in the bridging process.
+
+**`fn withdraw(to_address: b256)`**
+
+The `withdraw()` function accepts and burns a bridged Native Asset on Fuel and sends a message to the bridge contract on the canonical chain to release the originally deposited tokens to the `to_address` address.
+
+- This function SHALL send a message to the bridge contract to release the bridged tokens to the `to_address` address on the canonical chain.
+- This function MUST ensure the asset's `AssetId` sent in the transaction matches a bridged asset.
+- This function SHALL burn all coins sent in the transaction.
+
+**`fn claim_refund(to_address: b256, token_address: b256, token_id: b256, gateway_contract: b256)`**
+
+The `claim_refund()` function is called if something goes wrong in the bridging process and an error occurs. It sends a message to the `gateway_contract` contract on the canonical chain to release the `token_address` token with token id `token_id` to the `to_address` address.
+
+- This function SHALL send a message to the `gateway_contract` contract to release the `token_address` token with id `token_id` to the `to_address` address on the canonical chain.
+- This function MUST ensure a refund was issued.
+
+### Required Data Types
+
+#### `DepositType`
+
+The `DepositType` enum describes whether the bridged deposit is made to a address, contract, or contract and contains additional metadata. There MUST be the following variants in the `DepositType` enum:
+
+**`Address`: `()`**
+
+The `Address` variant MUST represent when the deposit is made to an address on the Fuel chain.
+
+**`Contract`: `()`**
+
+The `Contract` variant MUST represent when the deposit is made to an contract on the Fuel chain.
+
+**`ContractWithData`: `()`**
+
+The `ContractWithData` variant MUST represent when the deposit is made to an contract and contains additional metadata for the Fuel chain.
+
+##### Example Deposit Type
+
+```sway
+pub enum DepositType {
+    Address: (),
+    Contract: (),
+    ContractWithData: (),
+}
+```
+
+#### `DepositMessage`
+
+The following describes a struct that encapsulates various deposit message metadata to a single type. There MUST be the following fields in the `DepositMessage` struct:
+
+**`amount`: `u256`**
+
+The `amount` field MUST represent the number of tokens.
+
+**`from`: `b256`**
+
+The `from` field MUST represent the bridging user’s address on the canonical chain.
+
+**`to`: `Identity`**
+
+The `to` field MUST represent the bridging target destination `Address` or `ContractId` on the Fuel Chain.
+
+**`token_address`: `b256`**
+
+The `token_address` field MUST represent the bridged token's address on the canonical chain.
+
+**`token_id`: `b256`**
+
+The `token_id` field MUST represent the token's ID on the canonical chain. The `b256::zero()` MUST be used if this is a fungible token and no token ID exists.
+
+**`decimals`: `u8`**
+
+The `decimals` field MUST represent the bridged token's decimals on the canonical chain.
+
+**`deposit_type`: `DepositType`**
+
+The `deposit_type` field MUST represent the type of bridge deposit made on the canonical chain.
+
+##### Example Deposit Message
+
+```sway
+pub struct DepositMessage {
+    pub amount: b256,
+    pub from: b256,
+    pub to: Identity,
+    pub token_address: b256,
+    pub token_id: b256,
+    pub decimals: u8,
+    pub deposit_type: DepositType,
+}
+```
+
+#### `MetadataMessage`
+
+The following describes a struct that encapsulates the metadata of token on the canonical chain to a single type. There MUST be the following fields in the `MetadataMessage` struct:
+
+**`token_address`: `b256`**
+
+The `token_address` field MUST represent the bridged token's address on the canonical chain.
+
+**`token_id`: `b256`**
+
+The `token_id` field MUST represent the token's ID on the canonical chain. The `b256::zero()` MUST be used if this is a fungible token and no token ID exists.
+
+**`name`: `String`**
+
+The `name` field MUST represent the bridged token's name field on the canonical chain.
+
+**`symbol`: `String`**
+
+The `symbol` field MUST represent the bridged token's symbol field on the canonical chain.
+
+##### Example Metadata Message
+
+```sway
+pub struct MetadataMessage {
+    pub token_address: b256,
+    pub token_id: b256,
+    pub name: String,
+    pub symbol: String,
+}
+```
+
+## Required Standards
+
+Any contract that implements the SRC-10; Native Bridge Standard MUST implement the [SRC-8; Bridged Asset Standard](https://docs.fuel.network/docs/sway-standards/src-8-bridged-asset/) for all bridged assets.
+
+## Rationale
+
+The SRC-10; Native Bridge Standard is designed to standardize the native bridge interface between all Fuel instances.
+
+## Backwards Compatibility
+
+This standard is compatible with the SRC-20 and SRC-8 standards.
+
+## Example ABI
+
+```sway
+abi SRC10 {
+     fn process_message(message_index: u64);
+     fn withdraw(to_address: b256);
+     fn claim_refund(to_address: b256, token_address: b256, token_id: b256, gateway_contract: b256);
+}
+```

--- a/standards/src11/README.md
+++ b/standards/src11/README.md
@@ -1,0 +1,315 @@
+# SRC-11: Security Information
+
+The following standard allows for contract creators to make communication information readily available to everyone, with the primary purpose of allowing white hat hackers to coordinate a bug-fix or securing of funds.
+
+## Motivation
+
+White hat hackers may find bugs or exploits in contracts that they want to report to the project for safeguarding of funds. It is not immediately obvious from a `ContractId`, who the right person to contact is. This standard aims to make the process of bug reporting as smooth as possible.
+
+## Prior Art
+
+The [`security.txt`](https://github.com/neodyme-labs/solana-security-txt) library for Solana has explored this idea. This standard takes inspiration from the library, with some changes.
+
+## Specification
+
+### Security Information Type
+
+The following describes the `SecurityInformation` type.
+
+- The struct MAY contain `None` for `Option<T>` type fields, if they are deemed unnecessary.
+- The struct MUST NOT contain empty `String` or `Vec` fields.
+- The struct MAY contain a URL or the information directly for the following fields: `project_url`, `policy`, `encryption`, `source_code`, `auditors`, `acknowledgments`, `additional_information`.
+- The struct MUST contain the information directly for the following fields: `name`, `contact_information`, `preferred_languages`, `source_release`, and `source_revision`.
+- The struct MUST contain at least one item in the `preferred_languages` field's `Vec`, if it is not `None`. Furthermore, the string should only contain the [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) language code and nothing else.
+- The struct MUST contain at least one item in the `contact_information` field's `Vec`. Furthermore, the string should follow the following format `<contact_type>:<contact_information>`. Where `contact_type` describes the method of contact (e.g. `email` or `discord`) and `contact_information` describes the information needed to contact (e.g. `example@example.com` or `@EXAMPLE`).
+
+#### `name: String`
+
+The name of the project that the contract is associated with.
+
+#### `project_url: Option<String>`
+
+The website URL of the project that the contract is associated with.
+
+#### `contact_information: Vec<String>`
+
+A list of contact information to contact developers of the project. Should be in the format `<contact_type>:<contact_information>`. You should include contact types that will not change over time.
+
+#### `policy: String`
+
+Text describing the project's security policy, or a link to it. This should describe what kind of bounties your project offers and the terms under which you offer them.
+
+#### `preferred_languages: Option<Vec<String>>`
+
+A list of preferred languages [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes).
+If the field is not `None`, it MUST contain at least one item.
+
+#### `encryption: Option<String>`
+
+A PGP public key block (or similar) or a link to one.
+
+#### `source_code: Option<String>`
+
+A URL to the project's source code.
+
+#### `source_release: Option<String>`
+
+The release identifier of this build, ideally corresponding to a tag on git that can be rebuilt to reproduce the same binary. 3rd party build verification tools will use this tag to identify a matching GitHub release.
+
+#### `source_revision: Option<String>`
+
+The revision identifier of this build, usually a git commit hash that can be rebuilt to reproduce the same binary. 3rd party build verification tools will use this tag to identify a matching GitHub release.
+
+#### `auditors: Option<Vec<String>>`
+
+A list of people or entities that audited this smart contract, or links to pages where audit reports are hosted. Note that this field is self-reported by the author of the program and might not be accurate.
+
+#### `acknowledgments: Option<String>`
+
+Text containing acknowledgments to security researchers who have previously found vulnerabilities in the project, or a link to it.
+
+#### `additional_information: Option<String>`
+
+Text containing any additional information you want to provide, or a link to it.
+
+### Required Functions
+
+The following function MUST be implemented to follow the SRC-11 standard.
+
+#### `fn security_information() -> SecurityInformation;`
+
+This function takes no input parameters and returns a struct containing contact information for the project owners, information regarding the bug bounty program, other information related to security, and any other information that the developers find relevant.
+
+- This function MUST return accurate and up to date information.
+- This function's return values MUST follow the specification for the `SecurityInformation` type.
+- This function MUST NOT revert under any circumstances.
+
+## Rationale
+
+The return structure discussed covers most information that may want to be conveyed regarding the security of the contract, with an additional field to convey any additional information. This should allow easy communication between the project owners and any white hat hackers if necessary.
+
+## Backwards Compatibility
+
+This standard does not face any issues with backward compatibility.
+
+## Security Considerations
+
+The information is entirely self reported and as such might not be accurate. Accuracy of information cannot be enforced and as such, anyone using this information should be aware of that.
+
+## Example ABI
+
+```sway
+abi SRC11 {
+    #[storage(read)]
+    fn security_information() -> SecurityInformation;
+}
+```
+
+## Example Implementation
+
+### Hard coded information
+
+A basic implementation of the security information standard demonstrating how to hardcode information to be returned.
+
+```sway
+contract;
+
+use src11::{SecurityInformation, SRC11};
+
+use std::{string::String, vec::Vec};
+
+/// The name of the project
+const NAME: str[7] = __to_str_array("Example");
+/// The URL of the project
+const PROJECT_URL: str[19] = __to_str_array("https://example.com");
+/// The contact information of the project
+const CONTACT1: str[25] = __to_str_array("email:example@example.com");
+const CONTACT2: str[41] = __to_str_array("link:https://example.com/security_contact");
+const CONTACT3: str[20] = __to_str_array("discord:example#1234");
+/// The security policy of the project
+const POLICY: str[35] = __to_str_array("https://example.com/security_policy");
+/// The preferred languages of the project
+const PREFERRED_LANGUAGES1: str[2] = __to_str_array("en");
+const PREFERRED_LANGUAGES2: str[2] = __to_str_array("ja");
+const PREFERRED_LANGUAGES3: str[2] = __to_str_array("zh");
+const PREFERRED_LANGUAGES4: str[2] = __to_str_array("hi");
+/// The encryption key of the project
+const ENCRYPTION: str[751] = __to_str_array(
+    "-----BEGIN PGP PUBLIC KEY BLOCK-----
+Comment: Alice's OpenPGP certificate
+Comment: https://www.ietf.org/id/draft-bre-openpgp-samples-01.html
+
+mDMEXEcE6RYJKwYBBAHaRw8BAQdArjWwk3FAqyiFbFBKT4TzXcVBqPTB3gmzlC/U
+b7O1u120JkFsaWNlIExvdmVsYWNlIDxhbGljZUBvcGVucGdwLmV4YW1wbGU+iJAE
+ExYIADgCGwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AWIQTrhbtfozp14V6UTmPy
+MVUMT0fjjgUCXaWfOgAKCRDyMVUMT0fjjukrAPoDnHBSogOmsHOsd9qGsiZpgRnO
+dypvbm+QtXZqth9rvwD9HcDC0tC+PHAsO7OTh1S1TC9RiJsvawAfCPaQZoed8gK4
+OARcRwTpEgorBgEEAZdVAQUBAQdAQv8GIa2rSTzgqbXCpDDYMiKRVitCsy203x3s
+E9+eviIDAQgHiHgEGBYIACAWIQTrhbtfozp14V6UTmPyMVUMT0fjjgUCXEcE6QIb
+DAAKCRDyMVUMT0fjjlnQAQDFHUs6TIcxrNTtEZFjUFm1M0PJ1Dng/cDW4xN80fsn
+0QEA22Kr7VkCjeAEC08VSTeV+QFsmz55/lntWkwYWhmvOgE=
+=iIGO
+-----END PGP PUBLIC KEY BLOCK-----",
+);
+/// The URL of the project's source code
+const SOURCE_CODE: str[31] = __to_str_array("https://github.com/example/test");
+/// The release identifier of this build
+const SOURCE_RELEASE: str[6] = __to_str_array("v1.0.0");
+/// The revision identifier of this build
+const SOURCE_REVISION: str[12] = __to_str_array("a1b2c3d4e5f6");
+/// The URL of the project's auditors
+const AUDITORS: str[28] = __to_str_array("https://example.com/auditors");
+/// The URL of the project's acknowledgements
+const ACKNOWLEDGEMENTS: str[36] = __to_str_array("https://example.com/acknowledgements");
+/// The URL of the project's additional information
+const ADDITIONAL_INFORMATION: str[42] = __to_str_array("https://example.com/additional_information");
+
+impl SRC11 for Contract {
+    #[storage(read)]
+    fn security_information() -> SecurityInformation {
+        let mut contact_information = Vec::new();
+        contact_information.push(String::from_ascii_str(from_str_array(CONTACT1)));
+        contact_information.push(String::from_ascii_str(from_str_array(CONTACT2)));
+        contact_information.push(String::from_ascii_str(from_str_array(CONTACT3)));
+
+        let mut preferred_languages = Vec::new();
+        preferred_languages.push(String::from_ascii_str(from_str_array(PREFERRED_LANGUAGES1))); // English
+        preferred_languages.push(String::from_ascii_str(from_str_array(PREFERRED_LANGUAGES2))); // Japanese
+        preferred_languages.push(String::from_ascii_str(from_str_array(PREFERRED_LANGUAGES3))); // Chinese
+        preferred_languages.push(String::from_ascii_str(from_str_array(PREFERRED_LANGUAGES4))); // Hindi
+        let mut auditors = Vec::new();
+        auditors.push(String::from_ascii_str(from_str_array(AUDITORS)));
+
+        SecurityInformation {
+            name: String::from_ascii_str(from_str_array(NAME)),
+            project_url: Some(String::from_ascii_str(from_str_array(PROJECT_URL))),
+            contact_information: contact_information,
+            policy: String::from_ascii_str(from_str_array(POLICY)),
+            preferred_languages: Some(preferred_languages),
+            encryption: Some(String::from_ascii_str(from_str_array(ENCRYPTION))),
+            source_code: Some(String::from_ascii_str(from_str_array(SOURCE_CODE))),
+            source_release: Some(String::from_ascii_str(from_str_array(SOURCE_RELEASE))),
+            source_revision: Some(String::from_ascii_str(from_str_array(SOURCE_REVISION))),
+            auditors: Some(auditors),
+            acknowledgments: Some(String::from_ascii_str(from_str_array(ACKNOWLEDGEMENTS))),
+            additional_information: Some(String::from_ascii_str(from_str_array(ADDITIONAL_INFORMATION))),
+        }
+    }
+}
+```
+
+### Variable information
+
+A basic implementation of the security information standard demonstrating how to return variable information that can be edited to keep it up to date. In this example only the contact_information field is variable, but the same method can be applied to any field which you wish to update.
+
+```sway
+contract;
+
+use src11::{SecurityInformation, SRC11};
+
+use std::{storage::{storage_string::*, storage_vec::*}, string::String, vec::Vec};
+
+/// The name of the project
+const NAME: str[7] = __to_str_array("Example");
+/// The URL of the project
+const PROJECT_URL: str[19] = __to_str_array("https://example.com");
+/// The security policy of the project
+const POLICY: str[35] = __to_str_array("https://example.com/security_policy");
+/// The preferred languages of the project
+const PREFERRED_LANGUAGES1: str[2] = __to_str_array("en");
+const PREFERRED_LANGUAGES2: str[2] = __to_str_array("ja");
+const PREFERRED_LANGUAGES3: str[2] = __to_str_array("zh");
+const PREFERRED_LANGUAGES4: str[2] = __to_str_array("hi");
+/// The encryption key of the project
+const ENCRYPTION: str[751] = __to_str_array(
+    "-----BEGIN PGP PUBLIC KEY BLOCK-----
+Comment: Alice's OpenPGP certificate
+Comment: https://www.ietf.org/id/draft-bre-openpgp-samples-01.html
+
+mDMEXEcE6RYJKwYBBAHaRw8BAQdArjWwk3FAqyiFbFBKT4TzXcVBqPTB3gmzlC/U
+b7O1u120JkFsaWNlIExvdmVsYWNlIDxhbGljZUBvcGVucGdwLmV4YW1wbGU+iJAE
+ExYIADgCGwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AWIQTrhbtfozp14V6UTmPy
+MVUMT0fjjgUCXaWfOgAKCRDyMVUMT0fjjukrAPoDnHBSogOmsHOsd9qGsiZpgRnO
+dypvbm+QtXZqth9rvwD9HcDC0tC+PHAsO7OTh1S1TC9RiJsvawAfCPaQZoed8gK4
+OARcRwTpEgorBgEEAZdVAQUBAQdAQv8GIa2rSTzgqbXCpDDYMiKRVitCsy203x3s
+E9+eviIDAQgHiHgEGBYIACAWIQTrhbtfozp14V6UTmPyMVUMT0fjjgUCXEcE6QIb
+DAAKCRDyMVUMT0fjjlnQAQDFHUs6TIcxrNTtEZFjUFm1M0PJ1Dng/cDW4xN80fsn
+0QEA22Kr7VkCjeAEC08VSTeV+QFsmz55/lntWkwYWhmvOgE=
+=iIGO
+-----END PGP PUBLIC KEY BLOCK-----",
+);
+/// The URL of the project's source code
+const SOURCE_CODE: str[31] = __to_str_array("https://github.com/example/test");
+/// The release identifier of this build
+const SOURCE_RELEASE: str[6] = __to_str_array("v1.0.0");
+/// The revision identifier of this build
+const SOURCE_REVISION: str[12] = __to_str_array("a1b2c3d4e5f6");
+/// The URL of the project's auditors
+const AUDITORS: str[28] = __to_str_array("https://example.com/auditors");
+/// The URL of the project's acknowledgements
+const ACKNOWLEDGEMENTS: str[36] = __to_str_array("https://example.com/acknowledgements");
+/// The URL of the project's additional information
+const ADDITIONAL_INFORMATION: str[42] = __to_str_array("https://example.com/additional_information");
+
+storage {
+    /// The contact information for the security contact.
+    contact_information: StorageVec<StorageString> = StorageVec {},
+}
+
+abi StorageInformation {
+    #[storage(read, write)]
+    fn store_contact_information(input: String);
+}
+
+impl StorageInformation for Contract {
+    #[storage(read, write)]
+    fn store_contact_information(input: String) {
+        storage.contact_information.push(StorageString {});
+        let storage_string = storage.contact_information.get(storage.contact_information.len() - 1).unwrap();
+        storage_string.write_slice(input);
+    }
+}
+
+#[storage(read)]
+fn get_contact_information() -> Vec<String> {
+    let mut contact_information = Vec::new();
+
+    let mut i = 0;
+    while i < storage.contact_information.len() {
+        let storage_string = storage.contact_information.get(i).unwrap();
+        contact_information.push(storage_string.read_slice().unwrap());
+        i += 1;
+    }
+
+    contact_information
+}
+
+impl SRC11 for Contract {
+    #[storage(read)]
+    fn security_information() -> SecurityInformation {
+        let mut preferred_languages = Vec::new();
+        preferred_languages.push(String::from_ascii_str(from_str_array(PREFERRED_LANGUAGES1))); // English
+        preferred_languages.push(String::from_ascii_str(from_str_array(PREFERRED_LANGUAGES2))); // Japanese
+        preferred_languages.push(String::from_ascii_str(from_str_array(PREFERRED_LANGUAGES3))); // Chinese
+        preferred_languages.push(String::from_ascii_str(from_str_array(PREFERRED_LANGUAGES4))); // Hindi
+        let mut auditors = Vec::new();
+        auditors.push(String::from_ascii_str(from_str_array(AUDITORS)));
+
+        SecurityInformation {
+            name: String::from_ascii_str(from_str_array(NAME)),
+            project_url: Some(String::from_ascii_str(from_str_array(PROJECT_URL))),
+            // Use stored variable contact information instead of hardcoded contact information.
+            contact_information: get_contact_information(),
+            policy: String::from_ascii_str(from_str_array(POLICY)),
+            preferred_languages: Some(preferred_languages),
+            encryption: Some(String::from_ascii_str(from_str_array(ENCRYPTION))),
+            source_code: Some(String::from_ascii_str(from_str_array(SOURCE_CODE))),
+            source_release: Some(String::from_ascii_str(from_str_array(SOURCE_RELEASE))),
+            source_revision: Some(String::from_ascii_str(from_str_array(SOURCE_REVISION))),
+            auditors: Some(auditors),
+            acknowledgments: Some(String::from_ascii_str(from_str_array(ACKNOWLEDGEMENTS))),
+            additional_information: Some(String::from_ascii_str(from_str_array(ADDITIONAL_INFORMATION))),
+        }
+    }
+}
+```

--- a/standards/src12/README.md
+++ b/standards/src12/README.md
@@ -1,0 +1,415 @@
+# SRC-12: Contract Factory
+
+The following standard allows for the implementation of a standard ABI for Contract Factories using the Sway Language. The standardized design designates how verification of newly deployed child contracts are handled.
+
+## Motivation
+
+A standard interface for Contract Factories provides a safe and effective method of ensuring contracts can verify the validity of another contract as a child of a factory. This is critical on the Fuel Network as contracts cannot deploy other contracts and verification must be done after deployment.
+
+## Prior Art
+
+A Contract Factory is a design where a template contract is used and deployed repeatedly with different configurations. These configurations are often minor changes such as pointing to a different asset. All base functionality remains the same.
+
+On Fuel, contracts cannot deploy other contracts. As a result, a Contract Factory on Fuel must register and verify that the bytecode root of a newly deployed child contract matches the expected bytecode root.
+
+When changing something such as a configurable in Sway, the bytecode root is recalculated. The [Bytecode Library](https://docs.fuel.network/docs/sway-libs/bytecode/) has been developed to calculate the bytecode root of a contract with different configurables.
+
+## Specification
+
+The following functions MUST be implemented to follow the SRC-12; Contract Factory Standard:
+
+### Required Functions
+
+#### `fn register_contract(child_contract: ContractId, configurables: Option<Vec<(u64, Vec<u8>)>>) -> Result<b256, str>`
+
+The `register_contract()` function verifies that a newly deployed contract is the child of a contract factory.
+
+- This function MUST verify that the bytecode root of the `child_contract` contract matches the expected bytecode root.
+- This function MUST calculate the bytecode root IF `configurables` is `Some`.
+- This function MUST not revert.
+- This function MUST return a `Result` containing the `b256` bytecode root of the newly registered contract or an `str` error message.
+- This function MAY add arbitrary conditions checking a contract factory child’s validity, such as verifying storage variables or initialized values.
+
+#### `fn is_valid(child_contract: ContractId) -> bool`
+
+The `is_valid()` function returns a boolean representing the state of whether a contract is registered as a valid child of the contract factory.
+
+- This function MUST return `true` if this is a valid and registered child, otherwise `false`.
+
+#### `fn factory_bytecode_root() -> Option<b256>`
+
+The `factory_bytecode_root()` function returns the bytecode root of the default template contract.
+
+- This function MUST return the bytecode root of the template contract.
+
+### Optional Functions
+
+The following are functions that may enhance the use of the SRC-12 standard but ARE NOT required.
+
+#### `fn get_contract_id(configurables: Option<Vec<(u64, Vec<u8>)>>) -> Option<ContractId>`
+
+The `get_contract_id()` function returns a registered contract factory child contract with specific implementation details specified by `configurables`.
+
+This function MUST return `Some(ContractId)` IF a contract that follows the specified `configurables` has been registered with the SRC-12 Contract Factory contract, otherwise `None`.
+
+## Rationale
+
+The SRC-12; Contract Factory Standard is designed to standardize the contract factory design implementation interface between all Fuel instances.
+
+## Backwards Compatibility
+
+There are no other standards that the SRC-12 requires compatibility.
+
+## Security Considerations
+
+This standard takes into consideration child contracts that are deployed with differentiating configurable values, however individual contract behaviours may be dependent on storage variables. As storage variables may change after the contract has been registered with the SRC-12 compliant contract, the standard suggests to check these values upon registration however it is not enforced.
+
+## Example ABI
+
+```sway
+abi SRC12 {
+    #[storage(read, write)]
+    fn register_contract(child_contract: ContractId, configurables: Option<Vec<(u64, Vec<u8>)>>) -> Result<b256, str>;
+    #[storage(read)]
+    fn is_valid(child_contract: ContractId) -> bool;
+    #[storage(read)]
+    fn factory_bytecode_root() -> Option<b256>;
+}
+
+abi SRC12_Extension {
+    #[storage(read)]
+    fn get_contract_id(configurables: Option<Vec<(u64, Vec<u8>)>>) -> Option<ContractId>;
+}
+```
+
+## Example Implementation
+
+### With Configurables
+
+Example of the SRC-12 implementation where contract deployments contain configurable values that differentiate the bytecode root from other contracts with the same bytecode.
+
+```sway
+contract;
+
+mod utils;
+
+use utils::{_compute_bytecode_root, _swap_configurables};
+use src12::*;
+use std::{external::bytecode_root, hash::{Hash, sha256}, storage::storage_vec::*};
+
+configurable {
+    TEMPLATE_BYTECODE_ROOT: b256 = b256::zero(),
+}
+
+storage {
+    /// Contracts that have registered with this contract.
+    registered_contracts: StorageMap<ContractId, bool> = StorageMap {},
+    /// Maps the hash digest of configurables to the contract id.
+    contract_configurables: StorageMap<b256, ContractId> = StorageMap {},
+    /// The template contract's bytecode
+    bytecode: StorageVec<u8> = StorageVec {},
+}
+
+abi MyRegistryContract {
+    #[storage(read, write)]
+    fn set_bytecode(bytecode: Vec<u8>);
+}
+
+impl MyRegistryContract for Contract {
+    /// Special helper function to store the template contract's bytecode
+    ///
+    /// # Additional Information
+    ///
+    /// Real world implementations should apply restrictions on this function such that it cannot
+    /// be changed by anyone or can only be changed once.
+    #[storage(read, write)]
+    fn set_bytecode(bytecode: Vec<u8>) {
+        storage.bytecode.store_vec(bytecode);
+    }
+}
+
+impl SRC12 for Contract {
+    /// Verifies that a newly deployed contract is the child of a contract factory and registers it.
+    ///
+    /// # Additional Information
+    ///
+    /// This example does not check whether a contract has already been registered and will overwrite any values.
+    ///
+    /// # Arguments
+    ///
+    /// * `child_contract`: [ContractId] - The deployed factory child contract of which to verify the bytecode root.
+    /// * `configurables`: [Option<ContractConfigurables>] - The configurables value set for the `child_contract`.
+    ///
+    /// # Returns
+    ///
+    /// * [Result<BytecodeRoot, str>] - Either the bytecode root of the newly registered contract or a `str` error message.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Writes: `2`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src12::SRC12;
+    ///
+    /// fn foo(my_src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
+    ///     let src_12_contract_abi = abi(SRC12, my_src_12_contract.bits());
+    ///     src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
+    ///     assert(src_12_contract_abi.is_valid(my_deployed_contract));
+    /// }
+    /// ```
+    #[storage(read, write)]
+    fn register_contract(
+        child_contract: ContractId,
+        configurables: Option<ContractConfigurables>,
+    ) -> Result<BytecodeRoot, str> {
+        let returned_root = bytecode_root(child_contract);
+
+        // If there are no configurables just use the default template
+        let computed_root = match configurables {
+            Some(config) => {
+                let bytecode = storage.bytecode.load_vec();
+                compute_bytecode_root(bytecode, config)
+            },
+            None => {
+                TEMPLATE_BYTECODE_ROOT
+            }
+        };
+
+        // Verify the roots match
+        if returned_root != computed_root {
+            return Result::Err(
+                "The deployed contract's bytecode root and expected contract bytecode root do not match",
+            );
+        }
+
+        storage.registered_contracts.insert(child_contract, true);
+        storage
+            .contract_configurables
+            .insert(sha256(configurables.unwrap_or(Vec::new())), child_contract);
+
+        return Result::Ok(computed_root)
+    }
+
+    /// Returns a boolean representing the state of whether a contract is a valid child of the contract factory.
+    ///
+    /// # Arguments
+    ///
+    /// * `child_contract`: [ContractId] - The deployed factory child contract of which to check the registry status.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - `true` if the contract has registered and is valid, otherwise `false`.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src12::SRC12;
+    ///
+    /// fn foo(my_src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
+    ///     let src_12_contract_abi = abi(SRC12, my_src_12_contract.bits());
+    ///     src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
+    ///     assert(src_12_contract_abi.is_valid(my_deployed_contract));
+    /// }
+    /// ```
+    #[storage(read)]
+    fn is_valid(child_contract: ContractId) -> bool {
+        storage.registered_contracts.get(child_contract).try_read().unwrap_or(false)
+    }
+
+    /// Returns the bytecode root of the default template contract.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<BytecodeRoot>] - The bytecode root of the default template contract.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src12::SRC12;
+    ///
+    /// fn foo(my_src_12_contract: ContractId) {
+    ///     let src_12_contract_abi = abi(SRC12, my_src_12_contract.bits());
+    ///     let root = src_12_contract_abi.factory_bytecode_root();
+    ///     assert(root.unwrap() != b256::zero());
+    /// }
+    /// ```
+    #[storage(read)]
+    fn factory_bytecode_root() -> Option<BytecodeRoot> {
+        Some(TEMPLATE_BYTECODE_ROOT)
+    }
+}
+
+impl SRC12_Extension for Contract {
+    /// Return a registered contract factory child contract with specific implementation details specified by it's configurables.
+    ///
+    /// # Arguments
+    ///
+    /// * `configurables`: [Option<ContractConfigurables>] - The configurables value set for the `child_contract`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<ContractId>] - The id of the contract which has registered with the specified configurables.
+    ///
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src12::SRC12_Extension;
+    ///
+    /// fn foo(my_src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
+    ///     let src_12_contract_abi = abi(SRC12_Extension, my_src_12_contract.bits());
+    ///     src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
+    ///     let result_contract_id = src_12_contract_abi.get_contract_id(my_configurables);
+    ///     assert(result_contract_id.unwrap() == my_deployed_contract);
+    /// }
+    /// ```
+    #[storage(read)]
+    fn get_contract_id(configurables: Option<ContractConfigurables>) -> Option<ContractId> {
+        storage.contract_configurables.get(sha256(configurables.unwrap_or(Vec::new()))).try_read()
+    }
+}
+
+/// This function is copied and can be imported from the Sway Libs Bytecode Library.
+/// https://github.com/FuelLabs/sway-libs/tree/master/libs/bytecode
+fn compute_bytecode_root(bytecode: Vec<u8>, configurables: Vec<(u64, Vec<u8>)>) -> b256 {
+    let mut bytecode_slice = bytecode.as_raw_slice();
+    _swap_configurables(bytecode_slice, configurables);
+    _compute_bytecode_root(bytecode_slice)
+}
+```
+
+### Without Configurables
+
+Example of the SRC-12 implementation where all contract deployments are identical and thus have the same bytecode and root.
+
+```sway
+contract;
+
+use src12::*;
+use std::{external::bytecode_root, hash::Hash};
+
+configurable {
+    TEMPLATE_BYTECODE_ROOT: b256 = b256::zero(),
+}
+
+storage {
+    /// Contracts that have registered with this contract.
+    registered_contracts: StorageMap<ContractId, bool> = StorageMap {},
+}
+
+impl SRC12 for Contract {
+    /// Verifies that a newly deployed contract is the child of a contract factory and registers it.
+    ///
+    /// # Additional Information
+    ///
+    /// This example does not check whether a contract has already been registered and will overwrite any values.
+    ///
+    /// # Arguments
+    ///
+    /// * `child_contract`: [ContractId] - The deployed factory child contract of which to verify the bytecode root.
+    /// * `configurables`: [Option<ContractConfigurables>] - The configurables value set for the `child_contract`.
+    ///
+    /// # Returns
+    ///
+    /// * [Result<BytecodeRoot, str>] - Either the bytecode root of the newly registered contract or a `str` error message.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Writes: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src12::SRC12;
+    ///
+    /// fn foo(my_src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
+    ///     let src_12_contract_abi = abi(SRC12, my_src_12_contract.bits());
+    ///     src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
+    ///     assert(src_12_contract_abi.is_valid(my_deployed_contract));
+    /// }
+    /// ```
+    #[storage(read, write)]
+    fn register_contract(
+        child_contract: ContractId,
+        configurables: Option<ContractConfigurables>,
+    ) -> Result<BytecodeRoot, str> {
+        if configurables.is_some() {
+            return Result::Err(
+                "This SRC-12 implementation only registers contracts without configurable values",
+            );
+        }
+
+        let returned_root = bytecode_root(child_contract);
+        if returned_root != TEMPLATE_BYTECODE_ROOT {
+            return Result::Err(
+                "The deployed contract's bytecode root and template contract bytecode root do not match",
+            );
+        }
+
+        storage.registered_contracts.insert(child_contract, true);
+        return Result::Ok(returned_root)
+    }
+
+    /// Returns a boolean representing the state of whether a contract is a valid child of the contract factory.
+    ///
+    /// # Arguments
+    ///
+    /// * `child_contract`: [ContractId] - The deployed factory child contract of which to check the registry status.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - `true` if the contract has registered and is valid, otherwise `false`.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src12::SRC12;
+    ///
+    /// fn foo(my_src_12_contract: ContractId, my_deployed_contract: ContractId, my_configurables: Option<ContractConfigurables>) {
+    ///     let src_12_contract_abi = abi(SRC12, my_src_12_contract.bits());
+    ///     src_12_contract_abi.register_contract(my_deployed_contract, my_configurables);
+    ///     assert(src_12_contract_abi.is_valid(my_deployed_contract));
+    /// }
+    /// ```
+    #[storage(read)]
+    fn is_valid(child_contract: ContractId) -> bool {
+        storage.registered_contracts.get(child_contract).try_read().unwrap_or(false)
+    }
+
+    /// Returns the bytecode root of the default template contract.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<BytecodeRoot>] - The bytecode root of the default template contract.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src12::SRC12;
+    ///
+    /// fn foo(my_src_12_contract: ContractId) {
+    ///     let src_12_contract_abi = abi(SRC12, my_src_12_contract.bits());
+    ///     let root = src_12_contract_abi.factory_bytecode_root();
+    ///     assert(root.unwrap() != b256::zero());
+    /// }
+    /// ```
+    #[storage(read)]
+    fn factory_bytecode_root() -> Option<BytecodeRoot> {
+        Some(TEMPLATE_BYTECODE_ROOT)
+    }
+}
+```

--- a/standards/src14/README.md
+++ b/standards/src14/README.md
@@ -1,0 +1,197 @@
+# SRC-14: Simple Upgradeable Proxies
+
+The following proposes a standard for simple upgradeable proxies.
+
+## Motivation
+
+We seek to standardize a proxy implementation to improve developer experience and enable tooling to automatically deploy or update proxies as needed.
+
+## Prior Art
+
+[This OpenZeppelin blog post](https://blog.openzeppelin.com/the-state-of-smart-contract-upgrades#proxies-and-implementations) is a good survey of the state of the art at this time.
+
+Proxy designs fall into three essential categories:
+
+1. Immutable proxies which are lightweight clones of other contracts but can't change targets
+2. Upgradeable proxies such as [UUPS](https://eips.ethereum.org/EIPS/eip-1822) which store a target in storage and delegate all calls to it
+3. [Diamonds](https://eips.ethereum.org/EIPS/eip-2535) which are both upgradeable and can point to multiple targets on a per method basis
+
+This document falls in the second category. We want to standardize the implementation of simple upgradeable pass-through contracts.
+
+The FuelVM provides an `LDC` instruction that is used by Sway's `std::execution::run_external` to provide a similar behavior to EVM's `delegatecall` and execute instructions from another contract while retaining one's own storage context. This is the intended means of implementation of this standard.
+
+## Specification
+
+### Required Behavior
+
+The proxy contract MUST maintain the address of its target in its storage at slot `0x7bb458adc1d118713319a5baa00a2d049dd64d2916477d2688d76970c898cd55` (equivalent to `sha256("storage_SRC14_0")`).
+It SHOULD base other proxy specific storage fields in the `SRC14` namespace to avoid collisions with target storage.
+It MAY have its storage definition overlap with that of its target if necessary.
+
+The proxy contract MUST delegate any method call not part of its interface to the target contract.
+
+This delegation MUST retain the storage context of the proxy contract.
+
+### Required Public Functions
+
+The following functions MUST be implemented by a proxy contract to follow the SRC-14 standard:
+
+#### `fn set_proxy_target(new_target: ContractId);`
+
+If a valid call is made to this function it MUST change the target contract of the proxy to `new_target`.
+This method SHOULD implement access controls such that the target can only be changed by a user that possesses the right permissions (typically the proxy owner).
+
+#### `fn proxy_target() -> Option<ContractId>;`
+
+This function MUST return the target contract of the proxy as `Some`. If no proxy is set then `None` MUST be returned.
+
+### Optional Public Functions
+
+The following functions are RECOMMENDED to be implemented by a proxy contract to follow the SRC-14 standard:
+
+#### `fn proxy_owner() -> State;`
+
+This function SHALL return the current state of ownership for the proxy contract where the `State` is either `Uninitialized`, `Initialized`, or `Revoked`. `State` is defined in the [SRC-5; Ownership Standard](https://docs.fuel.network/docs/sway-standards/src-5-ownership/).
+
+## Rationale
+
+This standard is meant to provide simple upgradeability, it is deliberately minimalistic and does not provide the level of functionality of diamonds.
+
+Unlike in [UUPS](https://eips.ethereum.org/EIPS/eip-1822), this standard requires that the upgrade function is part of the proxy and not its target.
+This prevents irrecoverable updates if a proxy is made to point to another proxy and no longer has access to upgrade logic.
+
+## Backwards Compatibility
+
+SRC-14 is intended to be compatible with SRC-5 and other standards of contract functionality.
+
+As it is the first attempt to standardize proxy implementation, we do not consider interoperability with other proxy standards.
+
+## Security Considerations
+
+Permissioning proxy target changes is the primary consideration here.
+Use of the [SRC-5; Ownership Standard](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) is discouraged. If both the target and proxy contracts implement the [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) standard, the `owner()` function in the target contract is unreachable through the proxy contract. Use of the `proxy_owner()` function in the proxy contract should be used instead.
+
+## Example ABI
+
+```sway
+abi SRC14 {
+    #[storage(read, write)]
+    fn set_proxy_target(new_target: ContractId);
+    #[storage(read)]
+    fn proxy_target() -> Option<ContractId>;
+}
+
+abi SRC14Extension {
+    #[storage(read)]
+    fn proxy_owner() -> State;
+}
+```
+
+## Example Implementation
+
+### Minimal Proxy
+
+Example of a minimal SRC-14 implementation with no access control.
+
+```sway
+contract;
+
+use std::execution::run_external;
+use src14::{SRC14, SRC14_TARGET_STORAGE};
+
+storage {
+    SRC14 {
+        /// The [ContractId] of the target contract.
+        ///
+        /// # Additional Information
+        ///
+        /// `target` is stored at sha256("storage_SRC14_0")
+        target in 0x7bb458adc1d118713319a5baa00a2d049dd64d2916477d2688d76970c898cd55: ContractId = ContractId::zero(),
+    },
+}
+
+impl SRC14 for Contract {
+    #[storage(read, write)]
+    fn set_proxy_target(new_target: ContractId) {
+        storage::SRC14.target.write(new_target);
+    }
+
+    #[storage(read)]
+    fn proxy_target() -> Option<ContractId> {
+        storage::SRC14.target.try_read()
+    }
+}
+
+#[fallback]
+#[storage(read)]
+fn fallback() {
+    // pass through any other method call to the target
+    run_external(storage::SRC14.target.read())
+}
+```
+
+### Owned Proxy
+
+Example of a SRC-14 implementation that also implements `proxy_owner()`.
+
+```sway
+contract;
+
+use std::execution::run_external;
+use src5::{AccessError, State};
+use src14::{SRC14, SRC14_TARGET_STORAGE, SRC14Extension};
+
+/// The owner of this contract at deployment.
+#[allow(dead_code)]
+const INITIAL_OWNER: Identity = Identity::Address(Address::zero());
+
+storage {
+    SRC14 {
+        /// The [ContractId] of the target contract.
+        ///
+        /// # Additional Information
+        ///
+        /// `target` is stored at sha256("storage_SRC14_0")
+        target in 0x7bb458adc1d118713319a5baa00a2d049dd64d2916477d2688d76970c898cd55: ContractId = ContractId::zero(),
+        /// The [State] of the proxy owner.
+        owner: State = State::Initialized(INITIAL_OWNER),
+    },
+}
+
+impl SRC14 for Contract {
+    #[storage(read, write)]
+    fn set_proxy_target(new_target: ContractId) {
+        only_owner();
+        storage::SRC14.target.write(new_target);
+    }
+
+    #[storage(read)]
+    fn proxy_target() -> Option<ContractId> {
+        storage::SRC14.target.try_read()
+    }
+}
+
+impl SRC14Extension for Contract {
+    #[storage(read)]
+    fn proxy_owner() -> State {
+        storage::SRC14.owner.read()
+    }
+}
+
+#[fallback]
+#[storage(read)]
+fn fallback() {
+    // pass through any other method call to the target
+    run_external(storage::SRC14.target.read())
+}
+
+#[storage(read)]
+fn only_owner() {
+    require(
+        storage::SRC14
+            .owner
+            .read() == State::Initialized(msg_sender().unwrap()),
+        AccessError::NotOwner,
+    );
+}
+```

--- a/standards/src15/README.md
+++ b/standards/src15/README.md
@@ -1,0 +1,376 @@
+# SRC-15: Off-Chain Native Asset Metadata
+
+The following standard attempts to define arbitrary offchain metadata for any [Native Asset](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) that is not required by other contracts onchain, in a stateless manner. Any contract that implements the SRC-15 standard MUST implement the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard.
+
+> **NOTE** If data is  needed onchain, use the [SRC-7; Onchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/).
+
+## Motivation
+
+The SRC-15 standard seeks to enable data-rich assets on the Fuel Network while maintaining a stateless solution. All metadata queries are done off-chain using the indexer.
+
+## Prior Art
+
+The SRC-7 standard exists prior to the SRC-15 standard and is a stateful solution. The SRC-15 builds off the SRC-7 standard by using the `Metadata` enum however provides a stateless solution.
+
+The use of generic metadata was originally found in the Sway-Lib's [NFT Library](https://github.com/FuelLabs/sway-libs/tree/v0.12.0/libs/nft) which did not use Fuel's [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets). This library has since been deprecated.
+
+A previous definition for a metadata standard was written in the original edit of the now defunct [SRC-721](https://github.com/FuelLabs/sway-standards/issues/2). This has since been replaced with the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard as `SubId` was introduced to enable multiple assets to be minted from a single contract.
+
+## Specification
+
+### Metadata Type
+
+The `Metadata` enum from the SRC-7 standard is also used to represent the metadata in the SRC-15 standard.
+
+### Logging
+
+The following logs MUST be implemented and emitted to follow the SRC-15 standard. Logging MUST be emitted from the contract which minted the asset.
+
+#### SRC15MetadataEvent
+
+The `SRC15MetadataEvent` MUST be emitted at least once for each distinct piece of metadata and each distinct asset. The latest emitted `SRC15MetadataEvent` is determined to be the current metadata.
+
+There SHALL be the following fields in the `SRC15MetadataEvent` struct:
+
+* `asset`: The `asset` field SHALL be used for the corresponding `AssetId` for the metadata.
+* `metadata`: The `metadata` field SHALL be used for the corresponding `Metadata` which represents the metadata of the asset.
+
+Example:
+
+```sway
+pub struct SRC15MetadataEvent {
+    pub asset: AssetId,
+    pub metadata: Metadata,
+}
+```
+
+#### SRC15GlobalMetadataEvent
+
+The `SRC15GlobalMetadataEvent` MUST be emitted at least once for each distinct piece of metadata for *all* assets minted by a contract. The latest emitted `SRC15GlobalMetadataEvent` is determined to be the current metadata.
+
+There SHALL be the following fields in the `SRC15GlobalMetadataEvent` struct:
+
+* `metadata`: The `metadata` field SHALL be used for the corresponding `Metadata` which represents the metadata associated with all assets minted by the contract.
+
+Example:
+
+```sway
+pub struct SRC15GlobalMetadataEvent {
+    pub metadata: Metadata,
+}
+```
+
+## Rationale
+
+The SRC-15 standard allows for data-rich assets in a stateless manner by associating an asset with some metadata that may later be fetched by the indexer.
+
+## Backwards Compatibility
+
+This standard is compatible with Fuel's [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) and the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard. This standard is also compatible with the SRC-7 standard which defines a stateful solution. It also maintains compatibility with existing standards in other ecosystems.
+
+## Security Considerations
+
+When indexing for SRC-15 metadata, developers should confirm that the contract that emitted the `SRC15MetadataEvent` is also the contract that minted the asset that the metadata associates with. Additionally, restrictions via access control on who may emit the Metadata should be considered.
+
+## Example Implementation
+
+### Single Native Asset
+
+Example of the SRC-15 implementation where metadata exists for only a single asset with one `SubId`.
+
+```sway
+contract;
+
+use src15::SRC15MetadataEvent;
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use src7::Metadata;
+use std::string::String;
+configurable {
+    /// The total supply of coins for the asset minted by this contract.
+    TOTAL_SUPPLY: u64 = 100_000_000,
+    /// The decimals of the asset minted by this contract.
+    DECIMALS: u8 = 9u8,
+    /// The name of the asset minted by this contract.
+    NAME: str[7] = __to_str_array("MyAsset"),
+    /// The symbol of the asset minted by this contract.
+    SYMBOL: str[5] = __to_str_array("MYTKN"),
+    /// The metadata for the "social:x" key.
+    SOCIAL_X: str[12] = __to_str_array("fuel_network"),
+    /// The metadata for the "site:forum" key.
+    SITE_FORUM: str[27] = __to_str_array("https://forum.fuel.network/"),
+    /// The metadata for the "attr:health" key.
+    ATTR_HEALTH: u64 = 100,
+}
+abi EmitSRC15Events {
+    fn emit_src15_events();
+}
+impl EmitSRC15Events for Contract {
+    fn emit_src15_events() {
+        // NOTE: There are no checks for if the caller has permissions to emit the metadata.
+        // NOTE: Nothing is stored in storage and there is no method to retrieve the configurables.
+        let asset = AssetId::default();
+        let metadata_1 = Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X)));
+        let metadata_2 = Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM)));
+        let metadata_3 = Metadata::Int(ATTR_HEALTH);
+        SRC15MetadataEvent::new(asset, metadata_1).log();
+        SRC15MetadataEvent::new(asset, metadata_2).log();
+        SRC15MetadataEvent::new(asset, metadata_3).log();
+    }
+}
+// SRC15 extends SRC20, so this must be included
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        1
+    }
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        if asset == AssetId::default() {
+            Some(TOTAL_SUPPLY)
+        } else {
+            None
+        }
+    }
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        if asset == AssetId::default() {
+            Some(String::from_ascii_str(from_str_array(NAME)))
+        } else {
+            None
+        }
+    }
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        if asset == AssetId::default() {
+            Some(String::from_ascii_str(from_str_array(SYMBOL)))
+        } else {
+            None
+        }
+    }
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        if asset == AssetId::default() {
+            Some(DECIMALS)
+        } else {
+            None
+        }
+    }
+}
+abi EmitSRC20Events {
+    fn emit_src20_events();
+}
+impl EmitSRC20Events for Contract {
+    fn emit_src20_events() {
+        // Metadata that is stored as a configurable must be emitted once.
+        let asset = AssetId::default();
+        let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, TOTAL_SUPPLY, sender).log();
+    }
+}
+```
+
+### Multi Native Asset
+
+Example of the SRC-15 implementation where metadata exists for multiple assets with differing `SubId` values.
+
+```sway
+contract;
+
+use src15::SRC15MetadataEvent;
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use src7::Metadata;
+use std::{hash::Hash, storage::storage_string::*, string::String};
+// In this example, all assets minted from this contract have the same decimals, name, and symbol
+configurable {
+    /// The decimals of every asset minted by this contract.
+    DECIMALS: u8 = 0u8,
+    /// The name of every asset minted by this contract.
+    NAME: str[7] = __to_str_array("MyAsset"),
+    /// The symbol of every asset minted by this contract.
+    SYMBOL: str[5] = __to_str_array("MYAST"),
+    /// The metadata for the "social:x" key.
+    SOCIAL_X: str[12] = __to_str_array("fuel_network"),
+    /// The metadata for the "site:forum" key.
+    SITE_FORUM: str[27] = __to_str_array("https://forum.fuel.network/"),
+}
+storage {
+    /// The total number of distinguishable assets this contract has minted.
+    total_assets: u64 = 0,
+    /// The total supply of a particular asset.
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+}
+abi EmitSRC15Events {
+    #[storage(read)]
+    fn emit_src15_events(asset: AssetId, svg_image: String, health_attribute: u64);
+}
+impl EmitSRC15Events for Contract {
+    #[storage(read)]
+    fn emit_src15_events(asset: AssetId, svg_image: String, health_attribute: u64) {
+        // NOTE: There are no checks for if the caller has permissions to emit the metadata
+        // NOTE: Nothing is stored in storage and there is no method to retrieve the configurables.
+
+        // If this asset does not exist, revert
+        if storage.total_supply.get(asset).try_read().is_none() {
+            revert(0);
+        }
+        let metadata_1 = Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X)));
+        let metadata_2 = Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM)));
+        let metadata_3 = Metadata::String(svg_image);
+        let metadata_4 = Metadata::Int(health_attribute);
+        SRC15MetadataEvent::new(asset, metadata_1).log();
+        SRC15MetadataEvent::new(asset, metadata_2).log();
+        SRC15MetadataEvent::new(asset, metadata_3).log();
+        SRC15MetadataEvent::new(asset, metadata_4).log();
+    }
+}
+// SRC15 extends SRC20, so this must be included
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        storage.total_assets.read()
+    }
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        storage.total_supply.get(asset).try_read()
+    }
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(String::from_ascii_str(from_str_array(NAME))),
+            None => None,
+        }
+    }
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(String::from_ascii_str(from_str_array(SYMBOL))),
+            None => None,
+        }
+    }
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(DECIMALS),
+            None => None,
+        }
+    }
+}
+abi EmitSRC20Data {
+    fn emit_src20_data(asset: AssetId, total_supply: u64);
+}
+impl EmitSRC20Data for Contract {
+    fn emit_src20_data(asset: AssetId, supply: u64) {
+        // NOTE: There are no checks for if the caller has permissions to update the metadata
+        let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, supply, sender).log();
+    }
+}
+```
+
+### Global
+
+Example of the SRC-15 implementation where global metadata exists for all assets.
+
+```sway
+contract;
+
+use src15::SRC15GlobalMetadataEvent;
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use src7::Metadata;
+use std::{hash::Hash, storage::storage_string::*, string::String};
+// In this example, all assets minted from this contract have the same decimals, name, and symbol
+configurable {
+    /// The decimals of every asset minted by this contract.
+    DECIMALS: u8 = 0u8,
+    /// The name of every asset minted by this contract.
+    NAME: str[7] = __to_str_array("MyAsset"),
+    /// The symbol of every asset minted by this contract.
+    SYMBOL: str[5] = __to_str_array("MYAST"),
+    /// The metadata for the "social:x" key.
+    SOCIAL_X: str[12] = __to_str_array("fuel_network"),
+    /// The metadata for the "site:forum" key.
+    SITE_FORUM: str[27] = __to_str_array("https://forum.fuel.network/"),
+}
+storage {
+    /// The total number of distinguishable assets this contract has minted.
+    total_assets: u64 = 0,
+    /// The total supply of a particular asset.
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+}
+abi EmitSRC15Events {
+    #[storage(read)]
+    fn emit_src15_events(svg_image: String, health_attribute: u64);
+}
+impl EmitSRC15Events for Contract {
+    #[storage(read)]
+    fn emit_src15_events(svg_image: String, health_attribute: u64) {
+        // NOTE: There are no checks for if the caller has permissions to emit the metadata
+        // NOTE: Nothing is stored in storage and there is no method to retrieve the configurables.
+        let metadata_1 = Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X)));
+        let metadata_2 = Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM)));
+        let metadata_3 = Metadata::String(svg_image);
+        let metadata_4 = Metadata::Int(health_attribute);
+        SRC15GlobalMetadataEvent::new(metadata_1).log();
+        SRC15GlobalMetadataEvent::new(metadata_2).log();
+        SRC15GlobalMetadataEvent::new(metadata_3).log();
+        SRC15GlobalMetadataEvent::new(metadata_4).log();
+    }
+}
+// SRC15 extends SRC20, so this must be included
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        storage.total_assets.read()
+    }
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        storage.total_supply.get(asset).try_read()
+    }
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(String::from_ascii_str(from_str_array(NAME))),
+            None => None,
+        }
+    }
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(String::from_ascii_str(from_str_array(SYMBOL))),
+            None => None,
+        }
+    }
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(DECIMALS),
+            None => None,
+        }
+    }
+}
+abi EmitSRC20Data {
+    fn emit_src20_data(asset: AssetId, total_supply: u64);
+}
+impl EmitSRC20Data for Contract {
+    fn emit_src20_data(asset: AssetId, supply: u64) {
+        // NOTE: There are no checks for if the caller has permissions to update the metadata
+        let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, supply, sender).log();
+    }
+}
+```

--- a/standards/src16/README.md
+++ b/standards/src16/README.md
@@ -1,0 +1,572 @@
+# SRC-16: Typed Structured Data
+
+The following standard sets out to standardize encoding and hashing of typed structured data. This enables secure off-chain message signing with human-readable data structures.
+
+## Motivation
+
+As the Fuel ecosystem expands, there's an increasing need for applications to handle complex, human-readable data structures rather than raw bytes. When users sign messages or transactions, they should be able to clearly understand what they're signing, whether it's a simple asset transfer, or a complex DeFi interaction. Without a standard method for hashing structured data, developers risk implementing their own solutions, which could lead to confusion or compromise security. This standard provides a secure and consistent way to handle encoding and hashing of structured data, ensuring both safety and usability within ecosystem.
+
+This standard aims to:
+
+* Provide a secure, standardized method for hashing structured data
+* Enable clear presentation of structured data for user verification during signing
+* Support complex data types that mirror Sway structs
+* Enable domain separation to prevent cross-protocol replay attacks
+* Define a consistent encoding scheme for structured data types
+* Remain stateless, not requiring any storage attributes to enable use across all Fuel program types.
+
+## Prior Art
+
+This standard uses ideas from [Ethereum's EIP-712 standard](https://eips.ethereum.org/EIPS/eip-712), adapting its concepts for the Fuel ecosystem. EIP-712 has proven successful in enabling secure structured data signing for applications like the various browser based wallets and signers that are utilized throughout various DeFi protocols.
+
+## Specification
+
+### Definition of Typed Structured Data 𝕊
+
+The set of structured data 𝕊 consists of all instances of struct types that can be composed from the following types:
+
+Atomic Types:
+
+```sway
+u8 to u256
+bool
+b256 (hash)
+```
+
+Dynamic Types:
+
+```sway
+Bytes   // Variable-length byte sequences
+String  // Variable-length strings
+```
+
+Reference Types:
+
+Arrays (both fixed size and dynamic)
+Structs (reference to other struct types)
+
+Example struct definition:
+
+```sway
+struct Mail {
+    from: Address,
+    to: Address,
+    contents: String,
+}
+```
+
+### Domain Separator Encoding
+
+The domain separator provides context for the signing operation, preventing cross-protocol replay attacks. It is computed as hash_struct(domain) where domain is defined as:
+
+```sway
+pub struct SRC16Domain {
+    name: String,                   // The protocol name (e.g., "MyProtocol")
+    version: String,                // The protocol version (e.g., "1")
+    chain_id: u64,                  // The Fuel chain ID
+    verifying_contract: ContractId, // The contract id that will verify the signature
+}
+```
+
+The `chain_id` field is a u64 that must be encoded by left-padding with zeros and packed in big-endian order to fill a 32-byte value.
+
+The domain separator encoding follows this scheme:
+
+* Add SRC16_DOMAIN_TYPE_HASH
+* Add Keccak256 hash of name string
+* Add Keccak256 hash of version string
+* Add chain ID as 32-byte big-endian
+* Add verifying contract id as 32 bytes
+
+## Type Encoding
+
+Each struct type is encoded as name ‖ "(" ‖ member₁ ‖ "," ‖ member₂ ‖ "," ‖ … ‖ memberₙ ")" where each member is written as type ‖ " " ‖ name.
+
+Example:
+
+```sway
+Mail(address from,address to,string contents)
+```
+
+## Data Encoding
+
+### Definition of hash_struct
+
+The hash_struct function is defined as:
+
+hash_struct(s : 𝕊) = keccak256(type_hash ‖ encode_data(s))
+where:
+
+* type_hash = keccak256(encode_type(type of s))
+* ‖ represents byte concatenation
+* encode_type and encode_data are defined below
+
+### Definition of encode_data
+
+The encoding of a struct instance is enc(value₁) ‖ enc(value₂) ‖ … ‖ enc(valueₙ), the concatenation of the encoded member values in the order they appear in the type. Each encoded member value is exactly 32 bytes long.
+
+The values are encoded as follows:
+
+Atomic Values:
+
+* Boolean false and true are encoded as u64 values 0 and 1, padded to 32 bytes
+* `Address`, `ContractId`, `Identity`, and `b256` are encoded directly as 32 bytes
+* Unsigned Integer values (u8 to u256) are encoded as big-endian bytes, padded to 32 bytes
+
+Dynamic Types:
+
+* `Bytes` and `String` are encoded as their Keccak256 hash
+
+Reference Types:
+
+* Arrays (both fixed and dynamic) are encoded as the Keccak256 hash of their concatenated encodings
+* Struct values are encoded recursively as hash_struct(value)
+
+The implementation of `TypedDataHash` for `𝕊` SHALL utilize the `DataEncoder` for encoding each element of the struct based on its type.
+
+## Final Message Encoding
+
+The encoding of structured data follows this pattern:
+
+encode(domain_separator : 𝔹²⁵⁶, message : 𝕊) = "\x19\x01" ‖ `domain_separator` ‖ `hash_struct`(message)
+
+where:
+
+* \x19\x01 is a constant prefix
+* ‖ represents byte concatenation
+* `domain_separator` is the 32-byte hash of the domain parameters
+* `hash_struct`(message) is the 32-byte hash of the structured data
+
+## Example implementation
+
+```sway
+const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
+
+impl TypedDataHash for Mail {
+
+    fn type_hash() -> b256 {
+        MAIL_TYPE_HASH
+    }
+
+    fn struct_hash(self) -> b256 {
+        let mut encoded = Bytes::new();
+        encoded.append(
+            MAIL_TYPE_HASH.to_be_bytes()
+        );
+        encoded.append(
+            DataEncoder::encode_address(self.from).to_be_bytes()
+        );
+        encoded.append(
+            DataEncoder::encode_address(self.to).to_be_bytes()
+        );
+        encoded.append(
+            DataEncoder::encode_string(self.contents).to_be_bytes()
+        );
+
+        keccak256(encoded)
+    }
+}
+```
+
+## Rationale
+
+* Domain separators provides protocol-specific context to prevent signature replay across different protocols and chains.
+* Type hashes ensure type safety and prevent collisions between different data structures
+* The encoding scheme is designed to be deterministic and injective
+* The standard maintains compatibility with existing Sway types and practices
+
+## Backwards Compatibility
+
+This standard is compatible with existing Sway data structures and can be implemented alongside other Fuel standards. It does not conflict with existing signature verification methods.
+
+### Type System Compatibility Notes
+
+When implementing SRC16 in relation to EIP712, the following type mappings and considerations apply:
+
+#### String Encoding
+
+* Both standards use the same String type and encoding
+* SRC16 specifically uses String type only (not Sway's `str` or `str[]`)
+* String values are encoded identically in both standards using keccak256 hash
+
+#### Fixed Bytes
+
+* EIP712's `bytes32` maps directly to Sway's `b256`
+* Encoded using `encode_b256` in the `DataEncoder`
+* Both standards handle 32-byte values identically
+* Smaller fixed byte arrays (`bytes1` to `bytes31`) are not supported in SRC16
+
+#### Address Types
+
+* EIP712 uses 20-byte Ethereum addresses
+* When encoding an EIP712 address, SRC16:
+  * Takes only rightmost 20 bytes from a 32-byte Fuel Address
+  * Pads with zeros on the left for EIP712 compatibility
+  * Example: Fuel `Address` of 32 bytes becomes rightmost 20 bytes in EIP712 encoding
+
+#### ContractId Handling
+
+* `ContractId` is unique to Fuel/SRC16 (no equivalent in EIP712)
+* When encoding for EIP712 compatibility:
+  * Uses rightmost 20 bytes of `ContractId`
+  * Particularly important in domain separators where EIP712 expects a 20-byte address
+
+#### Domain Separator Compatibility
+
+```sway
+// SRC16 Domain (Fuel native)
+pub struct SRC16Domain {
+    name: String,                   // Same as EIP712
+    version: String,                // Same as EIP712
+    chain_id: u64,                  // Fuel chain ID
+    verifying_contract: ContractId, // Full 32-byte ContractId
+}
+
+// EIP712 Domain (Ethereum compatible)
+pub struct EIP712Domain {
+    name: String,
+    version: String,
+    chain_id: u256,
+    verifying_contract: b256,      // Only rightmost 20 bytes used
+}
+```
+
+Note on `verifying_contract` field; When implementing EIP712 compatibility within SRC16, the `verifying_contract` address in the `EIP712Domain` must be constructed by taking only the rightmost 20 bytes from either a Fuel `ContractId`. This ensures proper compatibility with Ethereum's 20-byte addressing scheme in the domain separator.
+
+```sway
+// Example ContractId conversion:
+// Fuel ContractId (32 bytes):
+//   0x000000000000000000000000a2233d3bf2aa3f0cbbe824eb04afc1acc84c364c
+//                            └─────────────── 20 bytes ───────────────┘
+//
+// EIP712 Address (20 bytes):
+//   0xa2233d3bf2aa3f0cbbe824eb04afc1acc84c364c
+//    └─────────────── 20 bytes ───────────────┘
+```
+
+Note on EIP712 Domain Separator `salt`; Within EIP712 the field `salt` is an optional field to be used at the discretion of the protocol designer. Within SRC16 the `EIP712Domain` does not use the `salt` field. The other fields in `EIP712Domain` are mandatory within SRC16.
+
+## Security Considerations
+
+### Replay Attacks
+
+Implementations must ensure signatures cannot be replayed across:
+
+Different chains (prevented by chain_id)
+Different protocols (prevented by domain separator)
+Different contracts (prevented by verifying_contract)
+
+### Type Safety
+
+Implementations must validate all type information and enforce strict encoding rules to prevent type confusion attacks.
+
+## Example Implementation
+
+Example of the SRC16 implementation where a contract utilizes the encoding scheme to produce a typed structured data hash of the Mail type.
+
+```sway
+contract;
+
+use src16::{
+    DataEncoder,
+    DomainHash,
+    SRC16,
+    SRC16Base,
+    SRC16Domain,
+    SRC16Encode,
+    SRC16Payload,
+    TypedDataHash,
+};
+use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
+
+configurable {
+    /// The name of the signing domain.
+    DOMAIN: str[8] = __to_str_array("MyDomain"),
+    /// The current major version for the signing domain.
+    VERSION: str[1] = __to_str_array("1"),
+    /// The active chain ID where the signing is intended to be used. Cast to u256 in domain_hash
+    CHAIN_ID: u64 = 9889u64,
+}
+
+/// A demo struct representing a mail message
+pub struct Mail {
+    /// The sender's address
+    pub from: Address,
+    /// The recipient's address
+    pub to: Address,
+    /// The message contents
+    pub contents: String,
+}
+
+/// The Keccak256 hash of the type Mail as UTF8 encoded bytes.
+///
+/// "Mail(address from,address to,string contents)"
+///
+/// 536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f
+///
+const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
+
+impl TypedDataHash for Mail {
+    fn type_hash() -> b256 {
+        MAIL_TYPE_HASH
+    }
+
+    fn struct_hash(self) -> b256 {
+        let mut encoded = Bytes::new();
+        // Add the Mail type hash.
+        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        // Use the DataEncoder to encode each field for known types
+        encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
+        encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
+        encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
+
+        keccak256(encoded)
+    }
+}
+
+/// Implement the encode function for Mail using SRC16Payload
+///
+/// # Additional Information
+///
+/// 1. Get the encodeData hash of the Mail typed data using
+///    <Mail>..struct_hash();
+/// 2. Obtain the payload to by populating the SRC16Payload struct
+///    with the domain separator and data_hash from the previous step.
+/// 3. Obtain the final_hash [Some(b256)] or None using the function
+///    SRC16Payload::encode_hash()
+///
+impl SRC16Encode<Mail> for Mail {
+    fn encode(s: Mail) -> b256 {
+        // encodeData hash
+        let data_hash = s.struct_hash();
+        // setup payload
+        let payload = SRC16Payload {
+            domain: _get_domain_separator(),
+            data_hash: data_hash,
+        };
+
+        // Get the final encoded hash
+        match payload.encode_hash() {
+            Some(hash) => hash,
+            None => revert(0),
+        }
+    }
+}
+
+impl SRC16Base for Contract {
+    fn domain_separator_hash() -> b256 {
+        _get_domain_separator().domain_hash()
+    }
+
+    fn data_type_hash() -> b256 {
+        MAIL_TYPE_HASH
+    }
+}
+
+impl SRC16 for Contract {
+    fn domain_separator() -> SRC16Domain {
+        _get_domain_separator()
+    }
+}
+
+abi MailMe {
+    fn send_mail_get_hash(from_addr: Address, to_addr: Address, contents: String) -> b256;
+}
+
+impl MailMe for Contract {
+    /// Sends a some mail and returns its encoded hash
+    ///
+    /// # Arguments
+    ///
+    /// * `from_addr`: [Address] - The sender's address
+    /// * `to_addr`: [Address] - The recipient's address
+    /// * `contents`: [String] - The message contents
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The encoded hash of the mail data
+    ///
+    fn send_mail_get_hash(from_addr: Address, to_addr: Address, contents: String) -> b256 {
+        // Create the mail struct from data passed in call
+        let some_mail = Mail {
+            from: from_addr,
+            to: to_addr,
+            contents: contents,
+        };
+
+        Mail::encode(some_mail)
+    }
+}
+
+/// A program specific implementation to get the Fuel SRC16Domain
+///
+/// In a Contract the ContractID can be obtain with ContractId::this()
+///
+/// In a Predicate or Script it is at the implementors discretion to
+/// use the code root if they wish to contrain the validation to a
+/// specifc program.
+///
+fn _get_domain_separator() -> SRC16Domain {
+    SRC16Domain::new(
+        String::from_ascii_str(from_str_array(DOMAIN)),
+        String::from_ascii_str(from_str_array(VERSION)),
+        CHAIN_ID,
+        ContractId::this(),
+    )
+}
+```
+
+```sway
+contract;
+
+use src16::{
+    DataEncoder,
+    DomainHash,
+    EIP712,
+    EIP712Domain,
+    SRC16Base,
+    SRC16Encode,
+    SRC16Payload,
+    TypedDataHash,
+};
+use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
+
+configurable {
+    /// The name of the signing domain.
+    DOMAIN: str[8] = __to_str_array("MyDomain"),
+    /// The current major version for the signing domain.
+    VERSION: str[1] = __to_str_array("1"),
+    /// The active chain ID where the signing is intended to be used. Cast to u256 in domain_hash
+    CHAIN_ID: u64 = 9889u64,
+}
+
+/// A demo struct representing a mail message
+pub struct Mail {
+    /// The sender's address
+    pub from: b256,
+    /// The recipient's address
+    pub to: b256,
+    /// The message contents
+    pub contents: String,
+}
+
+/// The Keccak256 hash of the type Mail as UTF8 encoded bytes.
+///
+/// "Mail(bytes32 from,bytes32 to,string contents)"
+///
+/// cfc972d321844e0304c5a752957425d5df13c3b09c563624a806b517155d7056
+///
+const MAIL_TYPE_HASH: b256 = 0xcfc972d321844e0304c5a752957425d5df13c3b09c563624a806b517155d7056;
+
+impl TypedDataHash for Mail {
+    fn type_hash() -> b256 {
+        MAIL_TYPE_HASH
+    }
+
+    fn struct_hash(self) -> b256 {
+        let mut encoded = Bytes::new();
+
+        // Add the Mail type hash.
+        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        // Use the DataEncoder to encode each field for known types
+        encoded.append(DataEncoder::encode_b256(self.from).to_be_bytes());
+        encoded.append(DataEncoder::encode_b256(self.to).to_be_bytes());
+        encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
+
+        keccak256(encoded)
+    }
+}
+
+/// Implement the encode function for Mail using SRC16Payload
+///
+/// # Additional Information
+///
+/// 1. Get the encodeData hash of the Mail typed data using
+///    <Mail>..struct_hash();
+/// 2. Obtain the payload to by populating the SRC16Payload struct
+///    with the domain separator and data_hash from the previous step.
+/// 3. Obtain the final_hash [Some(b256)] or None using the function
+///    SRC16Payload::encode_hash()
+///
+impl SRC16Encode<Mail> for Mail {
+    fn encode(s: Mail) -> b256 {
+        // encodeData hash
+        let data_hash = s.struct_hash();
+        // setup payload
+        let payload = SRC16Payload {
+            domain: _get_domain_separator(),
+            data_hash: data_hash,
+        };
+
+        // Get the final encoded hash
+        match payload.encode_hash() {
+            Some(hash) => hash,
+            None => revert(0),
+        }
+    }
+}
+
+impl SRC16Base for Contract {
+    fn domain_separator_hash() -> b256 {
+        _get_domain_separator().domain_hash()
+    }
+
+    fn data_type_hash() -> b256 {
+        MAIL_TYPE_HASH
+    }
+}
+
+impl EIP712 for Contract {
+    fn domain_separator() -> EIP712Domain {
+        _get_domain_separator()
+    }
+}
+
+abi MailMe {
+    fn send_mail_get_hash(from_addr: b256, to_addr: b256, contents: String) -> b256;
+}
+
+impl MailMe for Contract {
+    /// Sends a some mail and returns its encoded hash
+    ///
+    /// # Arguments
+    ///
+    /// * `from_addr`: [b256] - The sender's address
+    /// * `to_addr`: [b256] - The recipient's address
+    /// * `contents`: [String] - The message contents
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The encoded hash of the mail data
+    ///
+    fn send_mail_get_hash(from_addr: b256, to_addr: b256, contents: String) -> b256 {
+        // Create the mail struct from data passed in call
+        let some_mail = Mail {
+            from: from_addr,
+            to: to_addr,
+            contents: contents,
+        };
+
+        Mail::encode(some_mail)
+    }
+}
+
+/// A program specific implementation to get the Ethereum EIP712Domain
+///
+/// In a Contract the ContractID can be obtain with ContractId::this()
+///
+/// In a Predicate or Script it is at the implementors discretion to
+/// use the code root if they wish to contrain the validation to a
+/// specifc program.
+///
+fn _get_domain_separator() -> EIP712Domain {
+    EIP712Domain::new(
+        String::from_ascii_str(from_str_array(DOMAIN)),
+        String::from_ascii_str(from_str_array(VERSION)),
+        (asm(r1: (0, 0, 0, CHAIN_ID)) {
+                r1: u256
+            }),
+        ContractId::this(),
+    )
+}
+```

--- a/standards/src17/README.md
+++ b/standards/src17/README.md
@@ -1,0 +1,251 @@
+# SRC-17: Naming Verification Standard
+
+The following standard defines a naming verification standard for onchain identities using offchain data.
+
+## Motivation
+
+A standard interface for names on Fuel allows external applications to verify and determine the resolver of a name, whether that be decentralized exchanges frontends, wallets, explorers, or other infrastructure providers.
+
+## Prior Art
+
+A number of existing name service platforms already existed prior to the development of this standard. Notably the most well-known on the Ethereum Blockchain is the [Ethereum Name Service(ENS)](https://ens.domains/). This domain service has a major influence on other name services across multiple platforms. ENS pioneered name service platforms and this standard takes some inspiration from their resolver design.
+
+On Fuel, we have 2 existing name service platforms. These are [Bako ID](https://www.bako.id/) and [Fuel Name Service(FNS)](https://fuelname.com/). This standard was developed in close collaboration with these two platforms to ensure compatibility and ease of upgrade.
+
+## Specification
+
+### Type Aliases
+
+#### `AltBn128Proof` Type Alias
+
+The following describes a type alias for AltBn128 proofs. The `AltBn128Proof` SHALL be defined as the fixed length array `[u8; 288]`.
+
+```sway
+pub type AltBn128Proof = [u8; 288];
+```
+
+#### `SparseMerkleProof` Type Alias
+
+The following describes a type alias for Sparse Merkle Tree proofs. The `SparseMerkleProof` SHALL be defined as the `Proof` type from the Sway-Libs Sparse Merkle Tree Library.
+
+```sway
+pub type SparseMerkleProof = Proof;
+```
+
+### Enums
+
+#### `SRC17VerificationError` Enum
+
+The following describes an enum that is used when verification of a name fails. There SHALL be the following variants in the `SRC17VerificationError` type:
+
+##### `VerificationFailed`
+
+The `VerificationFailed` variant SHALL be used when verification of a name fails for ANY reason.
+
+```sway
+pub enum SRC17VerificationError {
+    VerificationFailed: (),
+}
+```
+
+#### `SRC17Proof` Enum
+
+The following describes an enum that wraps various proof types into a single input type. There SHALL be the following variants in the `SRC17Proof` type:
+
+##### `AltBn128Proof`
+
+The `AltBn128Proof` variant SHALL be used for AltBn128 proofs.
+
+##### `SparseMerkleProof`
+
+The `SparseMerkleProof` variant SHALL be used for Sparse Merkle Tree proofs.
+
+```sway
+pub enum SRC17Proof {
+    AltBn128Proof: AltBn128Proof,
+    SparseMerkleProof: SparseMerkleProof,
+}
+```
+
+### Required Public Functions
+
+The following functions MUST be implemented to follow the SRC-17 standard:
+
+#### `fn verify(proof: SRC17Proof, name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) -> Result<(), SRC17VerificationError>`
+
+- This function MUST return `Ok(())` if the proof verification was successful. Otherwise, it MUST return `Err(SRC17VerificationError::VerificationFailed)`.
+- The `proof` argument MUST be an `SRC17Proof` which proves the `name`, `asset`, `resolver`, and `metadata` are valid and included in the data.
+- The `name` argument MUST the corresponding `String` for the onchain human-readable identity.
+- The `resolver` argument MUST be the identity which the name is pointing to.
+- The `asset` argument MUST be the asset that represents ownership of a name.
+- The `metadata` argument MUST contain `Some` bytes associated with the name or MUST be `None`.
+
+### Logging
+
+The following logs MUST be implemented and emitted to follow the SRC-17 standard. Logs MUST be emitted if there are changes that update ANY proof.
+
+#### SRC17NameEvent
+
+The `SRC17NameEvent` MUST be emitted when ANY data changes occur.
+
+There SHALL be the following fields in the `SRC17UpdateEvent` struct:
+
+- `name`: The `name` field SHALL be used for the corresponding `String` which represents the name.
+- `resolver`: The `resolver` field SHALL be used for the corresponding `Identity` to which the name points.
+- `asset`: The `asset` field SHALL be used for the corresponding `AssetId` that represents ownership of a name.
+- `metadata`: The `metadata` field MUST contain `Some` bytes associated with the name or MUST be `None`.
+
+Example:
+
+```sway
+pub struct SRC17NameEvent {
+    pub name: String,
+    pub resolver: Identity,
+    pub asset: AssetId,
+    pub metadata: Option<Bytes>
+}
+```
+
+## Rationale
+
+The development and implementation of this standard should enable the verification of names for infrastructure providers such as explorers, wallets, and more. Standardizing the verification method and leaving the implementation up to interpretation shall leave room for experimentation and differentiating designs between projects.
+
+Additionally, the use of proofs should reduce the onchain footprint and minimize state. This standard notably has no expiry, a feature of most name service platforms. Should a project wish to implement an expiry, it should be included as part of the metadata.
+
+## Backwards Compatibility
+
+This standard is compatible with the existing name standards in the Fuel ecosystem, namely Bako ID and Fuel Name Service(FNS). There are no other standards that require compatibility.
+
+## Security Considerations
+
+This standard does not introduce any security concerns, as it does not call external contracts, nor does it define any mutations of the contract state.
+
+## Example ABI
+
+```sway
+pub type AltBn128Proof = [u8; 288];
+pub type SparseMerkleProof = Proof;
+
+pub enum SRC17Proof {
+    AltBn128Proof: AltBn128Proof,
+    SparseMerkleProof: SparseMerkleProof,
+}
+
+pub enum SRC17VerificationError {
+    VerificationFailed: (),
+}
+
+abi SRC17 {
+    #[storage(read)]
+    fn verify(proof: SRC17Proof, name: String, resolver: Identity, asset: AssetId, metadata: Option<Bytes>) -> Result<(), SRC17VerificationError>;
+}
+```
+
+## Example Implementation
+
+### Sparse Merkle Verification Example
+
+An example of the SRC-17 implementation where a Sparse Merkle Tree is used to verify the validity of names. In the example, the `name` is the key in the Sparse Merkle Tree and the `asset`, `resolver`, and `metadata` are the data which make up the leaf. The example supports both inclusion and exclusion proofs. If an AltBn128 proof is provided instead, the verification fails.
+
+```sway
+contract;
+
+use std::{bytes::Bytes, hash::{Hash, sha256}, string::String};
+use src17::{
+    AltBn128Proof,
+    SparseMerkleProof,
+    SRC17,
+    SRC17NameEvent,
+    SRC17Proof,
+    SRC17VerificationError,
+};
+use merkle::{common::MerkleRoot, sparse::MerkleTreeKey};
+
+storage {
+    merkle_root: MerkleRoot = MerkleRoot::zero(),
+}
+
+impl SRC17 for Contract {
+    #[storage(read)]
+    fn verify(
+        proof: SRC17Proof,
+        name: String,
+        resolver: Identity,
+        asset: AssetId,
+        metadata: Option<Bytes>,
+    ) -> Result<(), SRC17VerificationError> {
+        match proof {
+            SRC17Proof::AltBn128Proof(_) => Err(SRC17VerificationError::VerificationFailed),
+            SRC17Proof::SparseMerkleProof(proof) => {
+                let key: MerkleTreeKey = sha256(name);
+
+                match proof {
+                    SparseMerkleProof::Inclusion => {
+                        // Combine the resolver, asset, and metadata into to a single Byte array.
+                        let mut leaf_bytes = Bytes::new();
+                        leaf_bytes.append(resolver.bits().into());
+                        leaf_bytes.append(asset.bits().into());
+                        match metadata {
+                            Some(metadata_bytes) => {
+                                leaf_bytes.append(metadata_bytes);
+                            },
+                            None => (),
+                        }
+
+                        if proof.verify(storage.merkle_root.read(), key, Some(leaf_bytes))
+                        {
+                            Ok(())
+                        } else {
+                            Err(SRC17VerificationError::VerificationFailed)
+                        }
+                    },
+                    SparseMerkleProof::Exclusion => {
+                        if proof.verify(storage.merkle_root.read(), key, None) {
+                            Ok(())
+                        } else {
+                            Err(SRC17VerificationError::VerificationFailed)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+abi UpdateData {
+    fn data_updated(
+        name: String,
+        resolver: Identity,
+        asset: AssetId,
+        metadata: Option<Bytes>,
+    );
+}
+
+impl UpdateData for Contract {
+    fn data_updated(
+        name: String,
+        resolver: Identity,
+        asset: AssetId,
+        metadata: Option<Bytes>,
+    ) {
+        // NOTE: There are no checks for whether someone has the permission to do this. 
+        // It is suggested to add some administrative controls such as the Sway-Libs Ownership Library.
+        let event = SRC17NameEvent::new(name, resolver, asset, metadata);
+        event.log();
+    }
+}
+
+abi SetupExample {
+    #[storage(write)]
+    fn initialize(root: MerkleRoot);
+}
+
+impl SetupExample for Contract {
+    #[storage(write)]
+    fn initialize(root: MerkleRoot) {
+        // NOTE: There are no checks for whether someone has the permission to do this. 
+        // It is suggested to add some administrative controls such as the Sway-Libs Ownership Library.
+        storage.merkle_root.write(root);
+    }
+}
+```

--- a/standards/src20/README.md
+++ b/standards/src20/README.md
@@ -1,0 +1,598 @@
+# SRC-20: Native Asset
+
+The following standard allows for the implementation of a standard API for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) using the Sway Language. This standard provides basic functionality as well as on-chain metadata for other applications to use.
+
+## Motivation
+
+A standard interface for [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) on Fuel allows external applications to interact with the native asset, whether that be decentralized exchanges, wallets, or Fuel's [Scripts](https://docs.fuel.network/docs/sway/sway-program-types/scripts/) and [Predicates](https://docs.fuel.network/docs/sway/sway-program-types/predicates/).
+
+## Prior Art
+
+The SRC-20 Native Asset Standard naming pays homage to the [ERC-20 Token Standard](https://eips.ethereum.org/EIPS/eip-20) seen on Ethereum. While there is functionality we may use as a reference, it is noted that Fuel's [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) are fundamentally different than Ethereum's tokens.
+
+There has been a discussion of the Fungible Token Standard on the [Fuel Forum](https://forum.fuel.network/). This discussion can be found [here](https://forum.fuel.network/t/src-20-fungible-token-standard/186).
+
+There has also been a Fungible Token Standard and Non-Fungible Token Standard implementations added to the [Sway-Libs](https://github.com/FuelLabs/sway-libs) repository before the creation of the [Sway-Standards](https://github.com/FuelLabs/sway-standards) repository. The introduction of this standard in the [Sway-Standards](https://github.com/FuelLabs/sway-standards) repository will deprecate the Sway-Libs Fungible Token Standard.
+
+## Specification
+
+### Required Public Functions
+
+The following functions MUST be implemented to follow the SRC-20 standard:
+
+#### `fn total_assets() -> u64`
+
+This function MUST return the total number of individual assets for a contract.
+
+#### `fn total_supply(asset: AssetId) -> Option<u64>`
+
+This function MUST return the total supply of coins for an asset. This function MUST return `Some` for any assets minted by the contract.
+
+#### `fn name(asset: AssetId) -> Option<String>`
+
+This function MUST return the name of the asset, such as “Ether”. This function MUST return `Some` for any assets minted by the contract.
+
+#### `fn symbol(asset: AssetId) -> Option<String>`
+
+This function must return the symbol of the asset, such as “ETH”. This function MUST return `Some` for any assets minted by the contract.
+
+#### `fn decimals(asset: AssetId) -> Option<u8>`
+
+This function must return the number of decimals the asset uses - e.g. 8, which means to divide the coin amount by 100000000 to get its user representation. This function MUST return `Some` for any assets minted by the contract.
+
+### Non-Fungible Asset Restrictions
+
+Non-Fungible Tokens (NFT) or Non-Fungible Assets on Fuel are Native Assets and thus follow the same standard as Fungible Native Assets with some restrictions. For a Native Asset on Fuel to be deemed an NFT, the following must be applied:
+
+* Non-Fungible Assets SHALL have a total supply of one per asset.
+* Non-Fungible Assets SHALL have a decimal of `0u8`.
+
+### Logging
+
+The following logs MUST be implemented and emitted to follow the SRC-20 standard.
+
+* IF a value is updated via a function call, a log MUST be emitted.
+* IF a value is embedded in a contract as a constant, configurable, or other manner, an event MUST be emitted at least once.
+
+#### SetNameEvent
+
+The `SetNameEvent` MUST be emitted when the name of an asset has updated.
+
+There SHALL be the following fields in the `SetNameEvent` struct:
+
+* `asset`: The `asset` field SHALL be used for the corresponding `AssetId` of the asset has been updated.
+* `name`: The `name` field SHALL be used for the corresponding `Option<String>` which represents the name of the asset.
+* `sender`: The `sender` field SHALL be used for the corresponding `Identity` which made the function call that has updated the name of the asset.
+
+Example:
+
+```sway
+pub struct SetNameEvent {
+    pub asset: AssetId,
+    pub name: Option<String>,
+    pub sender: Identity,
+}
+```
+
+#### SetSymbolEvent
+
+The `SetSymbolEvent` MUST be emitted when the symbol of an asset has updated.
+
+There SHALL be the following fields in the `SetSymbolEvent` struct:
+
+* `asset`: The `asset` field SHALL be used for the corresponding `AssetId` of the asset has been updated.
+* `symbol`: The `symbol` field SHALL be used for the corresponding `Option<String>` which represents the symbol of the asset.
+* `sender`: The `sender` field SHALL be used for the corresponding `Identity` which made the function call that has updated the symbol of the asset.
+
+Example:
+
+```sway
+pub struct SetSymbolEvent {
+    pub asset: AssetId,
+    pub symbol: Option<String>,
+    pub sender: Identity,
+}
+```
+
+#### SetDecimalsEvent
+
+The `SetDecimalsEvent` MUST be emitted when the decimals of an asset has updated.
+
+There SHALL be the following fields in the `SetDecimalsEvent` struct:
+
+* `asset`: The `asset` field SHALL be used for the corresponding `AssetId` of the asset has been updated.
+* `decimals`: The `decimals` field SHALL be used for the corresponding `u8` which represents the decimals of the asset.
+* `sender`: The `sender` field SHALL be used for the corresponding `Identity` which made the function call that has updated the decimals of the asset.
+
+Example:
+
+```sway
+pub struct SetDecimalsEvent {
+    pub asset: AssetId,
+    pub decimals: u8,
+    pub sender: Identity,
+}
+```
+
+#### UpdateTotalSupplyEvent
+
+The `UpdateTotalSupplyEvent` MUST be emitted when the total supply of an asset has updated.
+
+There SHALL be the following fields in the `UpdateTotalSupplyEvent` struct:
+
+* `asset`: The `asset` field SHALL be used for the corresponding `AssetId` of the asset has been updated.
+* `supply`: The `supply` field SHALL be used for the corresponding `u64` which represents the total supply of the asset.
+* `sender`: The `sender` field SHALL be used for the corresponding `Identity` which made the function call that has updated the total supply of the asset.
+
+Example:
+
+```sway
+pub struct UpdateTotalSupplyEvent {
+    pub asset: AssetId,
+    pub supply: u64,
+    pub sender: Identity,
+}
+```
+
+## Rationale
+
+As the SRC-20 Native Asset Standard leverages Native Assets on Fuel, we do not require the implementation of certain functions such as transfer or approval. This is done directly within the FuelVM and there is no smart contract that requires updating of balances. As Fuel is UTXO based, any transfer events may be indexed on transaction receipts.
+
+Following this, we have omitted the inclusion of any transfer functions or events. The provided specification outlines only the functions necessary to implement fully functional native assets on the Fuel Network. Additional functionality and properties may be added as needed.
+
+## Backwards Compatibility
+
+This standard is compatible with Fuel's [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets). There are no other standards that require compatibility.
+
+## Security Considerations
+
+This standard does not introduce any security concerns, as it does not call external contracts, nor does it define any mutations of the contract state.
+
+## Example ABI
+
+```sway
+abi SRC20 {
+    #[storage(read)]
+    fn total_assets() -> u64;
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64>;
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String>;
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String>;
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8>;
+}
+```
+
+## Example Implementation
+
+### Single Native Asset
+
+Example of the SRC-20 implementation where a contract contains a single asset with one `SubId`. This implementation is recommended for users that intend to deploy a single asset with their contract.
+
+```sway
+contract;
+
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use std::{auth::msg_sender, string::String};
+
+configurable {
+    /// The total supply of coins for the asset minted by this contract.
+    TOTAL_SUPPLY: u64 = 100_000_000,
+    /// The decimals of the asset minted by this contract.
+    DECIMALS: u8 = 9u8,
+    /// The name of the asset minted by this contract.
+    NAME: str[7] = __to_str_array("MyAsset"),
+    /// The symbol of the asset minted by this contract.
+    SYMBOL: str[5] = __to_str_array("MYTKN"),
+}
+
+impl SRC20 for Contract {
+    /// Returns the total number of individual assets minted by a contract.
+    ///
+    /// # Additional Information
+    ///
+    /// For this single asset contract, this is always one.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The number of assets that this contract has minted.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src20::SRC20;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let src_20_abi = abi(SRC20, contract_id);
+    ///     let assets = src_20_abi.total_assets();
+    ///     assert(assets == 1);
+    /// }
+    /// ```
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        1
+    }
+
+    /// Returns the total supply of coins for the asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset of which to query the total supply, this should be the default `SubId`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<u64>] - The total supply of an `asset`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src20::SRC20;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let src_20_abi = abi(SRC20, contract_id);
+    ///     let supply = src_20_abi.total_supply(DEFAULT_SUB_ID);
+    ///     assert(supply.unwrap() != 0);
+    /// }
+    /// ```
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        if asset == AssetId::default() {
+            Some(TOTAL_SUPPLY)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the name of the asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset of which to query the name, this should be the default `SubId`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<String>] - The name of `asset`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src20::SRC20;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let src_20_abi = abi(SRC20, contract_id);
+    ///     let name = src_20_abi.name(DEFAULT_SUB_ID);
+    ///     assert(name.is_some());
+    /// }
+    /// ```
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        if asset == AssetId::default() {
+            Some(String::from_ascii_str(from_str_array(NAME)))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the symbol of the asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset of which to query the symbol, this should be the default `SubId`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<String>] - The symbol of `asset`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src20::SRC20;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let src_20_abi = abi(SRC20, contract_id);
+    ///     let symbol = src_20_abi.symbol(DEFAULT_SUB_ID);
+    ///     assert(symbol.is_some());
+    /// }
+    /// ```
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        if asset == AssetId::default() {
+            Some(String::from_ascii_str(from_str_array(SYMBOL)))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the number of decimals the asset uses.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset of which to query the decimals, this should be the default `SubId`.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<u8>] - The decimal precision used by `asset`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src20::SRC20;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let src_20_abi = abi(SRC20, contract_id);
+    ///     let decimals = src_20_abi.decimals(DEFAULT_SUB_ID);
+    ///     assert(decimals.unwrap() == 9u8);
+    /// }
+    /// ```
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        if asset == AssetId::default() {
+            Some(DECIMALS)
+        } else {
+            None
+        }
+    }
+}
+
+abi EmitSRC20Events {
+    fn emit_src20_events();
+}
+
+impl EmitSRC20Events for Contract {
+    fn emit_src20_events() {
+        // Metadata that is stored as a configurable should only be emitted once.
+        let asset = AssetId::default();
+        let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
+
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, TOTAL_SUPPLY, sender).log();
+    }
+}
+```
+
+### Multi Native Asset
+
+Example of the SRC-20 implementation where a contract contains multiple assets with differing `SubId`s. This implementation is recommended for users that intend to deploy multiple assets with their contract.
+
+```sway
+contract;
+
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use std::{hash::Hash, storage::storage_string::*, string::String};
+
+storage {
+    /// The total number of distinguishable assets minted by this contract.
+    total_assets: u64 = 0,
+    /// The total supply of coins for a specific asset minted by this contract.
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+    /// The name of a specific asset minted by this contract.
+    name: StorageMap<AssetId, StorageString> = StorageMap {},
+    /// The symbol of a specific asset minted by this contract.
+    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
+    /// The decimals of a specific asset minted by this contract.
+    decimals: StorageMap<AssetId, u8> = StorageMap {},
+}
+
+impl SRC20 for Contract {
+    /// Returns the total number of individual assets minted  by this contract.
+    ///
+    /// # Additional Information
+    ///
+    /// For this single asset contract, this is always one.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The number of assets that this contract has minted.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src20::SRC20;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let src_20_abi = abi(SRC20, contract_id);
+    ///     let assets = src_20_abi.total_assets();
+    ///     assert(assets == 1);
+    /// }
+    /// ```
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        storage.total_assets.read()
+    }
+
+    /// Returns the total supply of coins for an asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset of which to query the total supply.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<u64>] - The total supply of an `asset`.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src20::SRC20;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let src_20_abi = abi(SRC20, contract_id);
+    ///     let supply = src_20_abi.total_supply(DEFAULT_SUB_ID);
+    ///     assert(supply.unwrap() != 0);
+    /// }
+    /// ```
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        storage.total_supply.get(asset).try_read()
+    }
+
+    /// Returns the name of an asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset of which to query the name.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<String>] - The name of `asset`.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src20::SRC20;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let src_20_abi = abi(SRC20, contract_id);
+    ///     let name = src_20_abi.name(DEFAULT_SUB_ID);
+    ///     assert(name.is_some());
+    /// }
+    /// ```
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        storage.name.get(asset).read_slice()
+    }
+
+    /// Returns the symbol of am asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset of which to query the symbol.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<String>] - The symbol of `asset`.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src20::SRC20;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let src_20_abi = abi(SRC20, contract_id);
+    ///     let symbol = src_20_abi.symbol(DEFAULT_SUB_ID);
+    ///     assert(symbol.is_some());
+    /// }
+    /// ```
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        storage.symbol.get(asset).read_slice()
+    }
+
+    /// Returns the number of decimals an asset uses.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset of which to query the decimals.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<u8>] - The decimal precision used by `asset`.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src20::SRC20;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let src_20_abi = abi(SRC20, contract_id);
+    ///     let decimals = src_20_abi.decimals(DEFAULT_SUB_ID);
+    ///     assert(decimals.unwrap() == 9u8);
+    /// }
+    /// ```
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        storage.decimals.get(asset).try_read()
+    }
+}
+
+abi SetSRC20Data {
+    #[storage(read, write)]
+    fn set_src20_data(
+        asset: AssetId,
+        total_supply: u64,
+        name: Option<String>,
+        symbol: Option<String>,
+        decimals: u8,
+    );
+}
+
+impl SetSRC20Data for Contract {
+    #[storage(read, write)]
+    fn set_src20_data(
+        asset: AssetId,
+        supply: u64,
+        name: Option<String>,
+        symbol: Option<String>,
+        decimals: u8,
+    ) {
+        // NOTE: There are no checks for if the caller has permissions to update the metadata
+        // If this asset does not exist, revert
+        if storage.total_supply.get(asset).try_read().is_none() {
+            revert(0);
+        }
+        let sender = msg_sender().unwrap();
+
+        match name {
+            Some(unwrapped_name) => {
+                storage.name.get(asset).write_slice(unwrapped_name);
+                SetNameEvent::new(asset, name, sender).log();
+            },
+            None => {
+                let _ = storage.name.get(asset).clear();
+                SetNameEvent::new(asset, name, sender).log();
+            }
+        }
+
+        match symbol {
+            Some(unwrapped_symbol) => {
+                storage.symbol.get(asset).write_slice(unwrapped_symbol);
+                SetSymbolEvent::new(asset, symbol, sender).log();
+            },
+            None => {
+                let _ = storage.symbol.get(asset).clear();
+                SetSymbolEvent::new(asset, symbol, sender).log();
+            }
+        }
+
+        storage.decimals.get(asset).write(decimals);
+        SetDecimalsEvent::new(asset, decimals, sender).log();
+
+        storage.total_supply.get(asset).write(supply);
+        TotalSupplyEvent::new(asset, supply, sender).log();
+    }
+}
+```

--- a/standards/src3/README.md
+++ b/standards/src3/README.md
@@ -1,0 +1,471 @@
+# SRC-3: Minting and Burning Native Assets
+
+The following standard enables the minting and burning of native assets for any fungible assets within the Sway Language. It seeks to define mint and burn functions defined separately from the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard.
+
+## Motivation
+
+The intent of this standard is to separate the extensions of minting and burning from the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard.
+
+## Prior Art
+
+Minting and burning were initially added to the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard.
+
+## Specification
+
+### Required Public Functions
+
+The following functions MUST be implemented to follow the SRC-3 standard:
+
+#### `fn mint(recipient: Identity, sub_id: Option<SubId>, amount: u64)`
+
+This function MUST mint `amount` coins with a sub-identifier and transfer them to the `recipient`.
+This function MUST use the `sub_id` as the sub-identifier IF `sub_id` is `Some`, otherwise this function MUST assign a `SubId` if the `sub_id` argument is `None`.
+This function MAY contain arbitrary conditions for minting, and revert if those conditions are not met.
+
+##### Mint Arguments
+
+* `recipient` - The `Identity` to which the newly minted asset is transferred to.
+* `sub_id` - The sub-identifier of the asset to mint. If this is `None`, a `SubId` MUST be assigned.
+* `amount` - The quantity of coins to mint.
+
+#### `fn burn(sub_id: SubId, amount: u64)`
+
+This function MUST burn `amount` coins with the sub-identifier `sub_id` and MUST ensure the `AssetId` of the asset is the sha-256 hash of `(ContractId, SubId)` for the implementing contract.
+This function MUST ensure at least `amount` coins have been transferred to the implementing contract.
+This function MUST update the total supply defined in the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard.
+This function MAY contain arbitrary conditions for burning, and revert if those conditions are not met.
+
+##### Burn Arguments
+
+* `sub_id` - The sub-identifier of the asset to burn.
+* `amount` - The quantity of coins to burn.
+
+## Rationale
+
+This standard has been added to enable compatibility between applications and allow minting and burning native assets per use case. This standard has been separated from the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard to allow for the minting and burning for all fungible assets, irrelevant of whether they are [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) or not.
+
+## Backwards Compatibility
+
+This standard is compatible with Fuel's [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) ensuring its compatibility with the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard.
+
+## Security Considerations
+
+This standard may introduce security considerations if no checks are implemented to ensure the calling of the `mint()` function is deemed valid or permitted. Checks are highly encouraged.
+The burn function may also introduce a security consideration if the total supply within the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard is not modified.
+
+## Example ABI
+
+```sway
+abi SRC3 {
+    #[storage(read, write)]
+    fn mint(recipient: Identity, sub_id: Option<SubId>, amount: u64);
+    #[payable]
+    #[storage(read, write)]
+    fn burn(sub_id: SubId, amount: u64);
+}
+```
+
+## Example Implementation
+
+### Single Native Asset
+
+Example of the SRC-3 implementation where a contract only mints a single asset with one `SubId`.
+
+```sway
+contract;
+
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use src3::SRC3;
+use std::{
+    asset::{
+        burn,
+        mint_to,
+    },
+    auth::msg_sender,
+    call_frames::msg_asset_id,
+    constants::DEFAULT_SUB_ID,
+    context::msg_amount,
+    string::String,
+};
+
+configurable {
+    /// The decimals of the asset minted by this contract.
+    DECIMALS: u8 = 9u8,
+    /// The name of the asset minted by this contract.
+    NAME: str[7] = __to_str_array("MyAsset"),
+    /// The symbol of the asset minted by this contract.
+    SYMBOL: str[5] = __to_str_array("MYTKN"),
+}
+
+storage {
+    /// The total supply of the asset minted by this contract.
+    total_supply: u64 = 0,
+}
+
+impl SRC3 for Contract {
+    /// Unconditionally mints new assets using the default SubId.
+    ///
+    /// # Arguments
+    ///
+    /// * `recipient`: [Identity] - The user to which the newly minted asset is transferred to.
+    /// * `sub_id`: [SubId] - The default SubId.
+    /// * `amount`: [u64] - The quantity of coins to mint.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    /// * Writes: `1`
+    ///
+    /// # Reverts
+    ///
+    /// * When the `sub_id` is not the default SubId.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src3::SRC3;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let contract_abi = abi(SRC3, contract);
+    ///     contract_abi.mint(Identity::ContractId(contract_id), Some(DEFAULT_SUB_ID), 100);
+    /// }
+    /// ```
+    #[storage(read, write)]
+    fn mint(recipient: Identity, sub_id: Option<SubId>, amount: u64) {
+        require(
+            sub_id
+                .is_some() && sub_id
+                .unwrap() == DEFAULT_SUB_ID,
+            "Incorrect Sub Id",
+        );
+
+        // Increment total supply of the asset and mint to the recipient.
+        let new_supply = amount + storage.total_supply.read();
+        storage.total_supply.write(new_supply);
+
+        mint_to(recipient, DEFAULT_SUB_ID, amount);
+
+        TotalSupplyEvent::new(AssetId::default(), new_supply, msg_sender().unwrap())
+            .log();
+    }
+
+    /// Unconditionally burns assets sent with the default SubId.
+    ///
+    /// # Arguments
+    ///
+    /// * `sub_id`: [SubId] - The default SubId.
+    /// * `amount`: [u64] - The quantity of coins to burn.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    /// * Writes: `1`
+    ///
+    /// # Reverts
+    ///
+    /// * When the `sub_id` is not the default SubId.
+    /// * When the transaction did not include at least `amount` coins.
+    /// * When the transaction did not include the asset minted by this contract.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src3::SRC3;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId, asset_id: AssetId) {
+    ///     let contract_abi = abi(SRC3, contract_id);
+    ///     contract_abi {
+    ///         gas: 10000,
+    ///         coins: 100,
+    ///         asset_id: asset_id,
+    ///     }.burn(DEFAULT_SUB_ID, 100);
+    /// }
+    /// ```
+    #[payable]
+    #[storage(read, write)]
+    fn burn(sub_id: SubId, amount: u64) {
+        require(sub_id == DEFAULT_SUB_ID, "Incorrect Sub Id");
+        require(msg_amount() >= amount, "Incorrect amount provided");
+        require(
+            msg_asset_id() == AssetId::default(),
+            "Incorrect asset provided",
+        );
+
+        // Decrement total supply of the asset and burn.
+        let new_supply = storage.total_supply.read() - amount;
+        storage.total_supply.write(new_supply);
+
+        burn(DEFAULT_SUB_ID, amount);
+
+        TotalSupplyEvent::new(AssetId::default(), new_supply, msg_sender().unwrap())
+            .log();
+    }
+}
+
+// SRC3 extends SRC20, so this must be included
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        1
+    }
+
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        if asset == AssetId::default() {
+            Some(storage.total_supply.read())
+        } else {
+            None
+        }
+    }
+
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        if asset == AssetId::default() {
+            Some(String::from_ascii_str(from_str_array(NAME)))
+        } else {
+            None
+        }
+    }
+
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        if asset == AssetId::default() {
+            Some(String::from_ascii_str(from_str_array(SYMBOL)))
+        } else {
+            None
+        }
+    }
+
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        if asset == AssetId::default() {
+            Some(DECIMALS)
+        } else {
+            None
+        }
+    }
+}
+
+abi EmitSRC20Events {
+    fn emit_src20_events();
+}
+
+impl EmitSRC20Events for Contract {
+    fn emit_src20_events() {
+        // Metadata that is stored as a configurable should only be emitted once.
+        let asset = AssetId::default();
+        let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
+
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+    }
+}
+```
+
+### Multi Native Asset
+
+Example of the SRC-3 implementation where a contract mints multiple assets with differing `SubId` values.
+
+```sway
+contract;
+
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use src3::SRC3;
+use std::{
+    asset::{
+        burn,
+        mint_to,
+    },
+    auth::msg_sender,
+    call_frames::msg_asset_id,
+    constants::DEFAULT_SUB_ID,
+    context::msg_amount,
+    hash::Hash,
+    storage::storage_string::*,
+    string::String,
+};
+
+// In this example, all assets minted from this contract have the same decimals, name, and symbol
+configurable {
+    /// The decimals of every asset minted by this contract.
+    DECIMALS: u8 = 9u8,
+    /// The name of every asset minted by this contract.
+    NAME: str[12] = __to_str_array("ExampleAsset"),
+    /// The symbol of every asset minted by this contract.
+    SYMBOL: str[2] = __to_str_array("EA"),
+}
+
+storage {
+    /// The total number of distinguishable assets this contract has minted.
+    total_assets: u64 = 0,
+    /// The total supply of a particular asset.
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+}
+
+impl SRC3 for Contract {
+    /// Unconditionally mints new assets using the `sub_id` sub-identifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `recipient`: [Identity] - The user to which the newly minted asset is transferred to.
+    /// * `sub_id`: [Option<SubId>] - The sub-identifier of the newly minted asset.
+    /// * `amount`: [u64] - The quantity of coins to mint.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `2`
+    /// * Writes: `2`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src3::SRC3;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let contract_abi = abi(SRC3, contract_id);
+    ///     contract_abi.mint(Identity::ContractId(contract_id), Some(DEFAULT_SUB_ID), 100);
+    /// }
+    /// ```
+    #[storage(read, write)]
+    fn mint(recipient: Identity, sub_id: Option<SubId>, amount: u64) {
+        let sub_id = match sub_id {
+            Some(s) => s,
+            None => DEFAULT_SUB_ID,
+        };
+        let asset_id = AssetId::new(ContractId::this(), sub_id);
+
+        // If this SubId is new, increment the total number of distinguishable assets this contract has minted.
+        let asset_supply = storage.total_supply.get(asset_id).try_read();
+        match asset_supply {
+            None => {
+                storage.total_assets.write(storage.total_assets.read() + 1)
+            },
+            _ => {},
+        }
+
+        // Increment total supply of the asset and mint to the recipient.
+        let new_supply = amount + asset_supply.unwrap_or(0);
+        storage.total_supply.insert(asset_id, new_supply);
+
+        mint_to(recipient, sub_id, amount);
+
+        TotalSupplyEvent::new(asset_id, new_supply, msg_sender().unwrap())
+            .log();
+    }
+
+    /// Unconditionally burns assets sent with the `sub_id` sub-identifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `sub_id`: [SubId] - The sub-identifier of the asset to burn.
+    /// * `amount`: [u64] - The quantity of coins to burn.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    /// * Writes: `1`
+    ///
+    /// # Reverts
+    ///
+    /// * When the transaction did not include at least `amount` coins.
+    /// * When the asset included in the transaction does not have the SubId `sub_id`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src3::SRC3;
+    /// use std::constants::DEFAULT_SUB_ID;
+    ///
+    /// fn foo(contract_id: ContractId, asset_id: AssetId) {
+    ///     let contract_abi = abi(SRC3, contract_id);
+    ///     contract_abi {
+    ///         gas: 10000,
+    ///         coins: 100,
+    ///         asset_id: asset_id,
+    ///     }.burn(DEFAULT_SUB_ID, 100);
+    /// }
+    /// ```
+    #[payable]
+    #[storage(read, write)]
+    fn burn(sub_id: SubId, amount: u64) {
+        let asset_id = AssetId::new(ContractId::this(), sub_id);
+        require(msg_amount() == amount, "Incorrect amount provided");
+        require(msg_asset_id() == asset_id, "Incorrect asset provided");
+
+        // Decrement total supply of the asset and burn.
+        let new_supply = storage.total_supply.get(asset_id).read() - amount;
+        storage.total_supply.insert(asset_id, new_supply);
+
+        burn(sub_id, amount);
+
+        TotalSupplyEvent::new(asset_id, new_supply, msg_sender().unwrap())
+            .log();
+    }
+}
+
+// SRC3 extends SRC20, so this must be included
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        storage.total_assets.read()
+    }
+
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        storage.total_supply.get(asset).try_read()
+    }
+
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(String::from_ascii_str(from_str_array(NAME))),
+            None => None,
+        }
+    }
+
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(String::from_ascii_str(from_str_array(SYMBOL))),
+            None => None,
+        }
+    }
+
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(DECIMALS),
+            None => None,
+        }
+    }
+}
+
+abi SetSRC20Data {
+    #[storage(read)]
+    fn set_src20_data(asset: AssetId);
+}
+
+impl SetSRC20Data for Contract {
+    #[storage(read)]
+    fn set_src20_data(asset: AssetId) {
+        // NOTE: There are no checks for if the caller has permissions to update the metadata
+        // If this asset does not exist, revert
+        if storage.total_supply.get(asset).try_read().is_none() {
+            revert(0);
+        }
+        let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
+
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+    }
+}
+```

--- a/standards/src5/README.md
+++ b/standards/src5/README.md
@@ -1,0 +1,178 @@
+# SRC-5: Ownership
+
+The following standard intends to enable the use of administrators or owners in Sway contracts.
+
+## Motivation
+
+The standard seeks to provide a method for restricting access to particular users within a Sway contract.
+
+## Prior Art
+
+The [sway-libs](https://docs.fuel.network/docs/sway-libs/ownership/) repository contains a pre-existing Ownership library.
+
+Ownership libraries exist for other ecosystems such as OpenZeppelin's [Ownership library](https://docs.openzeppelin.com/contracts/2.x/api/ownership).
+
+## Specification
+
+### State
+
+There SHALL be 3 states for any library implementing an ownership module in the following order:
+
+#### `Uninitialized`
+
+The `Uninitialized` state SHALL be set as the initial state if no owner or admin is set. The `Uninitialized` state MUST be used when an owner or admin MAY be set in the future.
+
+#### `Initialized`
+
+The `Initialized` state SHALL be set as the state if an owner or admin is set with an associated `Identity` type.
+
+#### `Revoked`
+
+The `Revoked` state SHALL be set when there is no owner or admin and there SHALL NOT be one set in the future.
+
+Example:
+
+```sway
+pub enum State {
+    Uninitialized: (),
+    Initialized: Identity,
+    Revoked: (),
+}
+```
+
+### Functions
+
+The following functions MUST be implemented to follow the SRC-5 standard:
+
+#### `fn owner() -> State`
+
+This function SHALL return the current state of ownership for the contract where `State` is either `Uninitialized`, `Initialized`, or `Revoked`.
+
+### Errors
+
+There SHALL be error handling.
+
+#### `NotOwner`
+
+This error MUST be emitted when `only_owner()` reverts.
+
+## Rationale
+
+In order to provide a universal method of administrative capabilities, SRC-5 will further enable interoperability between applications and provide safeguards for smart contract security.
+
+## Backwards Compatibility
+
+The SRC-5 standard is compatible with the [sway-libs](https://github.com/FuelLabs/sway-libs) repository pre-existing Ownership library. Considerations should be made to best handle multiple owners or admins.
+
+There are no standards that SRC-5 requires to be compatible with.
+
+## Security Considerations
+
+The SRC-5 standard should help improve the security of Sway contracts and their interoperability.
+
+## Example ABI
+
+```sway
+abi SRC5 {
+    #[storage(read)]
+    fn owner() -> State;
+}
+```
+
+## Example Implementation
+
+### Uninitialized
+
+Example of the SRC-5 implementation where a contract does not have an owner set at compile time with the intent to set it during runtime.
+
+```sway
+contract;
+
+use src5::{SRC5, State};
+
+storage {
+    /// The owner in storage.
+    owner: State = State::Uninitialized,
+}
+
+impl SRC5 for Contract {
+    /// Returns the owner.
+    ///
+    /// # Return Values
+    ///
+    /// * [State] - Represents the state of ownership for this contract.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src5::SRC5;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let ownership_abi = abi(contract_id, SRC_5);
+    ///
+    ///     match ownership_abi.owner() {
+    ///         State::Uninitialized => log("The ownership is uninitialized"),
+    ///         _ => log("This example will never reach this statement"),
+    ///     }
+    /// }
+    /// ```
+    #[storage(read)]
+    fn owner() -> State {
+        storage.owner.read()
+    }
+}
+```
+
+### Initialized
+
+Example of the SRC-5 implementation where a contract has an owner set at compile time.
+
+```sway
+contract;
+
+use src5::{SRC5, State};
+
+/// The owner of this contract at deployment.
+#[allow(dead_code)]
+const INITIAL_OWNER: Identity = Identity::Address(Address::zero());
+
+storage {
+    /// The owner in storage.
+    owner: State = State::Initialized(INITIAL_OWNER),
+}
+
+impl SRC5 for Contract {
+    /// Returns the owner.
+    ///
+    /// # Return Values
+    ///
+    /// * [State] - Represents the state of ownership for this contract.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src5::SRC5;
+    ///
+    /// fn foo(contract_id: ContractId) {
+    ///     let ownership_abi = abi(contract_id, SRC_5);
+    ///
+    ///     match ownership_abi.owner() {
+    ///         State::Initialized(owner) => log("The ownership is initialized"),
+    ///         _ => log("This example will never reach this statement"),
+    ///     }
+    /// }
+    /// ```
+    #[storage(read)]
+    fn owner() -> State {
+        storage.owner.read()
+    }
+}
+```

--- a/standards/src6/README.md
+++ b/standards/src6/README.md
@@ -1,0 +1,1114 @@
+# SRC-6: Vault
+
+The following standard allows for the implementation of a standard API for asset vaults such as yield-bearing asset vaults or asset wrappers. This standard is an optional add-on to the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard.
+
+## Motivation
+
+Asset vaults allow users to own shares of variable amounts of assets, such as lending protocols which may have growing assets due to profits from interest. This pattern is highly useful and would greatly benefit from standardization.
+
+## Prior Art
+
+Asset vaults have been thoroughly explored on Ethereum and with [EIP 4626](https://eips.ethereum.org/EIPS/eip-4626) they have their own standard for it. However as Fuel's [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) are fundamentally different from Ethereum's ERC-20 tokens, the implementation will differ, but the interface may be used as a reference.
+
+## Specification
+
+### Required public functions
+
+The following functions MUST be implemented to follow the SRC-6 standard. Any contract that implements the SRC-6 standard MUST implement the SRC-20 standard.
+
+#### `fn deposit(receiver: Identity, vault_sub_id: SubId) -> u64`
+
+This function takes the `receiver` Identity and the SubId `vault_sub_id` of the sub-vault as an argument and returns the amount of shares minted to the `receiver`.
+
+- This function MUST allow for depositing of the underlying asset in exchange for pro-rata shares of the vault.
+- This function MAY reject arbitrary assets based on implementation and MUST revert if unaccepted assets are forwarded.
+- This function MAY reject any arbitrary `receiver` based on implementation and MUST revert in the case of a blacklisted or non-whitelisted `receiver`.
+- This function MUST mint an asset representing the pro-rata share of the vault, with the SubId of the `sha256((underlying_asset, vault_sub_id))` digest, where `underlying_asset` is the `AssetId` of the deposited asset and the `vault_sub_id` is the id of the vault.
+- This function MUST emit a `Deposit` log.
+- This function MUST return the amount of minted shares.
+
+#### `fn withdraw(receiver: Identity, underlying_asset: AssetId, vault_sub_id: SubId) -> u64`
+
+This function takes the `receiver` Identity, the `underlying_asset` `AssetId`, and the `vault_sub_id` of the sub vault, as arguments and returns the amount of assets transferred to the `receiver`.
+
+- This function MUST allow for redeeming of the vault shares in exchange for a pro-rata amount of the underlying assets.
+- This function MUST revert if any `AssetId` other than the `AssetId` representing the underlying asset's shares for the given sub vault at `vault_sub_id` is forwarded. (i.e. transferred share's `AssetId` must be equal to `AssetId::new(ContractId::this(), sha256((underlying_asset, vault_sub_id))`)
+- This function MUST burn the received shares.
+- This function MUST emit a `Withdraw` log.
+- This function MUST return amount of assets transferred to the receiver.
+
+#### `fn managed_assets(underlying_asset: AssetId, vault_sub_id: SubId) -> u64`
+
+This function returns the total assets under management by vault. Includes assets controlled by the vault but not directly possessed by vault. It takes the `underlying_asset` `AssetId` and the `vault_sub_id` of the sub vault as arguments and returns the total amount of assets of `AssetId` under management by vault.
+
+- This function MUST return total amount of assets of `underlying_asset` `AssetId` under management by vault.
+- This function MUST return 0 if there are no assets of `underlying_asset` `AssetId` under management by vault.
+- This function MUST NOT revert under any circumstances.
+
+#### `fn max_depositable(receiver: Identity, underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64>`
+
+This is a helper function for getting the maximum amount of assets that can be deposited. It takes the hypothetical `receiver` `Identity`, the `underlying_asset` `AssetId`, and the `vault_sub_id` `SubId` of the sub vault as an arguments and returns the maximum amount of assets that can be deposited into the contract, for the given asset.
+
+- This function MUST return the maximum amount of assets that can be deposited into the contract, for the given `underlying_asset`, if the given `vault_sub_id` vault exists.
+- This function MUST return an `Some(amount)` if the given `vault_sub_id` vault exists.
+- This function MUST return an `None` if the given `vault_sub_id` vault does not exist.
+- This function MUST account for both global and user specific limits. For example: if deposits are disabled, even temporarily, MUST return 0.
+
+#### `fn max_withdrawable(receiver: Identity, underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64>`
+
+This is a helper function for getting maximum withdrawable. It takes the hypothetical `receiver` `Identity`, the `underlying_asset` `AssetId`, and the `vault_sub_id` SubId of the sub vault as an argument and returns the maximum amount of assets that can be withdrawn from the contract, for the given asset.
+
+- This function MUST return the maximum amount of assets that can be withdrawn from the contract, for the given `underlying_asset`, if the given `vault_sub_id` vault exists.
+- This function MUST return an `Some(amount)` if the given `vault_sub_id` vault exists.
+- This function MUST return an `None` if the given `vault_sub_id` vault does not exist.
+- This function MUST account for global limits. For example: if withdrawals are disabled, even temporarily, MUST return 0.
+
+### Required logs
+
+The following logs MUST be emitted at the specified occasions.
+
+#### `Deposit`
+
+`caller` has called the `deposit()` method sending `deposited_amount` assets of the `underlying_asset` Asset to the subvault of `vault_sub_id`, in exchange for `minted_shares` shares sent to the receiver `receiver`.
+
+The `Deposit` struct MUST be logged whenever new shares are minted via the `deposit()` method.
+
+The `Deposit` log SHALL have the following fields.
+
+**`caller`: `Identity`**
+
+The `caller` field MUST represent the `Identity` which called the deposit function.
+
+**`receiver`: `Identity`**
+
+The `receiver` field MUST represent the `Identity` which received the vault shares.
+
+**`underlying_asset`: `AssetId`**
+
+The `underlying_asset` field MUST represent the `AssetId` of the asset which was deposited into the vault.
+
+**`vault_sub_id`: `SubId`**
+
+The `vault_sub_id` field MUST represent the `SubId` of the vault which was deposited into.
+
+**`deposited_amount`: `u64`**
+
+The `deposited_amount` field MUST represent the `u64` amount of assets deposited into the vault.
+
+**`minted_shares`: `u64`**
+
+The `minted_shares` field MUST represent the `u64` amount of shares minted.
+
+#### `Withdraw`
+
+`caller` has called the `withdraw()` method sending `burned_shares` shares in exchange for `withdrawn_amount` assets of the `underlying_asset` Asset from the subvault of `vault_sub_id` to the receiver `receiver`.
+
+The `Withdraw` struct MUST be logged whenever shares are redeemed for assets via the `withdraw()` method.
+
+The `Withdraw` log SHALL have the following fields.
+
+**`caller`: `Identity`**
+
+The `caller` field MUST represent the Identity which called the withdraw function.
+
+**`receiver`: `Identity`**
+
+The `receiver` field MUST represent the Identity which received the withdrawn assets.
+
+**`underlying_asset`: `AssetId`**
+
+The `underlying_asset` field MUST represent the `AssetId` of the asset that was withdrawn.
+
+**`vault_sub_id`: `SubId`**
+
+The `vault_sub_id` field MUST represent the SubId of the vault from which was withdrawn.
+
+**`withdrawn_amount`: `u64`**
+
+The `withdrawn_amount` field MUST represent the `u64` amount of coins withdrawn.
+
+**`burned_shares`: `u64`**
+
+The `burned_shares` field MUST represent the `u64` amount of shares burned.
+
+## Rationale
+
+The ABI discussed covers the known use cases of asset vaults while allowing safe implementations.
+
+## Backwards Compatibility
+
+This standard is fully compatible with the [SRC-20 standard](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/).
+
+## Security Considerations
+
+Incorrect implementation of asset vaults could allow attackers to steal underlying assets. It is recommended to properly audit any code using this standard to ensure exploits are not possible.
+
+## Example ABI
+
+```sway
+abi SRC6 {
+    #[payable]
+    #[storage(read, write)]
+    fn deposit(receiver: Identity, vault_sub_id: SubId) -> u64;
+
+    #[payable]
+    #[storage(read, write)]
+    fn withdraw(receiver: Identity, underlying_asset: AssetId, vault_sub_id: SubId) -> u64;
+
+    #[storage(read)]
+    fn managed_assets(underlying_asset: AssetId, vault_sub_id: SubId) -> u64;
+
+    #[storage(read)]
+    fn max_depositable(receiver: Identity, underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64>;
+
+    #[storage(read)]
+    fn max_withdrawable(underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64>;
+}
+```
+
+## Example Implementation
+
+### Multi Asset Vault
+
+A basic implementation of the vault standard that supports any number of sub vaults being created for every `AssetId`.
+
+```sway
+contract;
+
+use std::{
+    asset::transfer,
+    call_frames::msg_asset_id,
+    context::msg_amount,
+    hash::{
+        Hash,
+        sha256,
+    },
+    storage::storage_string::*,
+    string::String,
+};
+
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use src6::{Deposit, SRC6, Withdraw};
+
+pub struct VaultInfo {
+    /// Amount of assets currently managed by this vault
+    managed_assets: u64,
+    /// The vault_sub_id of this vault.
+    vault_sub_id: SubId,
+    /// The asset being managed by this vault
+    asset: AssetId,
+}
+
+storage {
+    /// Vault share AssetId -> VaultInfo.
+    vault_info: StorageMap<AssetId, VaultInfo> = StorageMap {},
+    /// Number of different assets managed by this contract.
+    total_assets: u64 = 0,
+    /// Total supply of shares for each asset.
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+    /// Asset name.
+    name: StorageMap<AssetId, StorageString> = StorageMap {},
+    /// Asset symbol.
+    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
+    /// Asset decimals.
+    decimals: StorageMap<AssetId, u8> = StorageMap {},
+}
+
+impl SRC6 for Contract {
+    #[payable]
+    #[storage(read, write)]
+    fn deposit(receiver: Identity, vault_sub_id: SubId) -> u64 {
+        let asset_amount = msg_amount();
+        require(asset_amount != 0, "ZERO_ASSETS");
+
+        let underlying_asset = msg_asset_id();
+        let (shares, share_asset, share_asset_vault_sub_id) = preview_deposit(underlying_asset, vault_sub_id, asset_amount);
+
+        _mint(receiver, share_asset, share_asset_vault_sub_id, shares);
+
+        let mut vault_info = match storage.vault_info.get(share_asset).try_read() {
+            Some(vault_info) => vault_info,
+            None => VaultInfo {
+                managed_assets: 0,
+                vault_sub_id,
+                asset: underlying_asset,
+            },
+        };
+        vault_info.managed_assets = vault_info.managed_assets + asset_amount;
+        storage.vault_info.insert(share_asset, vault_info);
+
+        Deposit::new(
+            msg_sender()
+                .unwrap(),
+            receiver,
+            underlying_asset,
+            vault_sub_id,
+            asset_amount,
+            shares,
+        )
+            .log();
+
+        shares
+    }
+
+    #[payable]
+    #[storage(read, write)]
+    fn withdraw(
+        receiver: Identity,
+        underlying_asset: AssetId,
+        vault_sub_id: SubId,
+    ) -> u64 {
+        let shares = msg_amount();
+        require(shares != 0, "ZERO_SHARES");
+
+        let (share_asset_id, share_asset_vault_sub_id) = vault_asset_id(underlying_asset, vault_sub_id);
+
+        require(msg_asset_id() == share_asset_id, "INVALID_ASSET_ID");
+        let assets = preview_withdraw(share_asset_id, shares);
+
+        let mut vault_info = storage.vault_info.get(share_asset_id).read();
+        vault_info.managed_assets = vault_info.managed_assets - shares;
+        storage.vault_info.insert(share_asset_id, vault_info);
+
+        _burn(share_asset_id, share_asset_vault_sub_id, shares);
+
+        transfer(receiver, underlying_asset, assets);
+
+        Withdraw::new(
+            msg_sender()
+                .unwrap(),
+            receiver,
+            underlying_asset,
+            vault_sub_id,
+            assets,
+            shares,
+        )
+            .log();
+
+        assets
+    }
+    #[storage(read)]
+    fn managed_assets(underlying_asset: AssetId, vault_sub_id: SubId) -> u64 {
+        let vault_share_asset = vault_asset_id(underlying_asset, vault_sub_id).0;
+        // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
+        managed_assets(vault_share_asset)
+    }
+
+    #[storage(read)]
+    fn max_depositable(
+        _receiver: Identity,
+        underlying_asset: AssetId,
+        vault_sub_id: SubId,
+    ) -> Option<u64> {
+        let vault_share_asset = vault_asset_id(underlying_asset, vault_sub_id).0;
+        // This is the max value of u64 minus the current managed_assets. Ensures that the sum will always be lower than u64::MAX.
+        match storage.vault_info.get(vault_share_asset).try_read() {
+            Some(vault_info) => Some(u64::max() - vault_info.managed_assets),
+            None => None,
+        }
+    }
+
+    #[storage(read)]
+    fn max_withdrawable(underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64> {
+        let vault_share_asset = vault_asset_id(underlying_asset, vault_sub_id).0;
+        // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, total_assets should be greater than max_withdrawable.
+        match storage.vault_info.get(vault_share_asset).try_read() {
+            Some(vault_info) => Some(vault_info.managed_assets),
+            None => None,
+        }
+    }
+}
+
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        storage.total_assets.try_read().unwrap_or(0)
+    }
+
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        storage.total_supply.get(asset).try_read()
+    }
+
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        storage.name.get(asset).read_slice()
+    }
+
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        storage.symbol.get(asset).read_slice()
+    }
+
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        storage.decimals.get(asset).try_read()
+    }
+}
+
+abi SetSRC20Data {
+    #[storage(read, write)]
+    fn set_src20_data(
+        asset: AssetId,
+        name: Option<String>,
+        symbol: Option<String>,
+        decimals: u8,
+    );
+}
+
+impl SetSRC20Data for Contract {
+    #[storage(read, write)]
+    fn set_src20_data(
+        asset: AssetId,
+        name: Option<String>,
+        symbol: Option<String>,
+        decimals: u8,
+    ) {
+        // NOTE: There are no checks for if the caller has permissions to update the metadata
+        // If this asset does not exist, revert
+        if storage.total_supply.get(asset).try_read().is_none() {
+            revert(0);
+        }
+        let sender = msg_sender().unwrap();
+
+        match name {
+            Some(unwrapped_name) => {
+                storage.name.get(asset).write_slice(unwrapped_name);
+                SetNameEvent::new(asset, name, sender).log();
+            },
+            None => {
+                let _ = storage.name.get(asset).clear();
+                SetNameEvent::new(asset, name, sender).log();
+            }
+        }
+
+        match symbol {
+            Some(unwrapped_symbol) => {
+                storage.symbol.get(asset).write_slice(unwrapped_symbol);
+                SetSymbolEvent::new(asset, symbol, sender).log();
+            },
+            None => {
+                let _ = storage.symbol.get(asset).clear();
+                SetSymbolEvent::new(asset, symbol, sender).log();
+            }
+        }
+
+        storage.decimals.get(asset).write(decimals);
+        SetDecimalsEvent::new(asset, decimals, sender).log();
+    }
+}
+
+/// Returns the vault shares assetid and subid for the given assets assetid and the vaults sub id
+fn vault_asset_id(asset: AssetId, vault_sub_id: SubId) -> (AssetId, SubId) {
+    let share_asset_vault_sub_id = sha256((asset, vault_sub_id));
+    let share_asset_id = AssetId::new(ContractId::this(), share_asset_vault_sub_id);
+    (share_asset_id, share_asset_vault_sub_id)
+}
+
+#[storage(read)]
+fn managed_assets(vault_share_asset_id: AssetId) -> u64 {
+    match storage.vault_info.get(vault_share_asset_id).try_read() {
+        Some(vault_info) => vault_info.managed_assets,
+        None => 0,
+    }
+}
+
+#[storage(read)]
+fn preview_deposit(
+    underlying_asset: AssetId,
+    vault_sub_id: SubId,
+    assets: u64,
+) -> (u64, AssetId, SubId) {
+    let (share_asset_id, share_asset_vault_sub_id) = vault_asset_id(underlying_asset, vault_sub_id);
+
+    let shares_supply = storage.total_supply.get(share_asset_id).try_read().unwrap_or(0);
+    if shares_supply == 0 {
+        (assets, share_asset_id, share_asset_vault_sub_id)
+    } else {
+        (
+            assets * shares_supply / managed_assets(share_asset_id),
+            share_asset_id,
+            share_asset_vault_sub_id,
+        )
+    }
+}
+
+#[storage(read)]
+fn preview_withdraw(share_asset_id: AssetId, shares: u64) -> u64 {
+    let supply = storage.total_supply.get(share_asset_id).read();
+    if supply == shares {
+        managed_assets(share_asset_id)
+    } else {
+        shares * (managed_assets(share_asset_id) / supply)
+    }
+}
+
+#[storage(read, write)]
+pub fn _mint(
+    recipient: Identity,
+    asset_id: AssetId,
+    vault_sub_id: SubId,
+    amount: u64,
+) {
+    use std::asset::mint_to;
+
+    let supply = storage.total_supply.get(asset_id).try_read();
+    // Only increment the number of assets minted by this contract if it hasn't been minted before.
+    if supply.is_none() {
+        storage.total_assets.write(storage.total_assets.read() + 1);
+    }
+    let new_supply = supply.unwrap_or(0) + amount;
+    storage.total_supply.insert(asset_id, new_supply);
+    mint_to(recipient, vault_sub_id, amount);
+    TotalSupplyEvent::new(asset_id, new_supply, msg_sender().unwrap())
+        .log();
+}
+
+#[storage(read, write)]
+pub fn _burn(asset_id: AssetId, vault_sub_id: SubId, amount: u64) {
+    use std::{asset::burn, context::this_balance};
+
+    require(
+        this_balance(asset_id) >= amount,
+        "BurnError::NotEnoughCoins",
+    );
+    // If we pass the check above, we can assume it is safe to unwrap.
+    let supply = storage.total_supply.get(asset_id).try_read().unwrap();
+    let new_supply = supply - amount;
+    storage.total_supply.insert(asset_id, new_supply);
+    burn(vault_sub_id, amount);
+    TotalSupplyEvent::new(asset_id, new_supply, msg_sender().unwrap())
+        .log();
+}
+```
+
+### Single Asset Vault
+
+A basic implementation of the vault standard demonstrating how to restrict deposits and withdrawals to a single `AssetId`.
+
+```sway
+contract;
+
+use std::{
+    asset::transfer,
+    call_frames::msg_asset_id,
+    context::msg_amount,
+    hash::{
+        Hash,
+        sha256,
+    },
+    storage::storage_string::*,
+    string::String,
+};
+
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use src6::{Deposit, SRC6, Withdraw};
+
+pub struct VaultInfo {
+    /// Amount of assets currently managed by this vault
+    managed_assets: u64,
+    /// The vault_sub_id of this vault.
+    vault_sub_id: SubId,
+    /// The asset being managed by this vault
+    asset: AssetId,
+}
+
+storage {
+    /// Vault share AssetId -> VaultInfo.
+    vault_info: StorageMap<AssetId, VaultInfo> = StorageMap {},
+    /// Number of different assets managed by this contract.
+    total_assets: u64 = 0,
+    /// Total supply of shares.
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+    /// Asset name.
+    name: StorageMap<AssetId, StorageString> = StorageMap {},
+    /// Asset symbol.
+    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
+    /// Asset decimals.
+    decimals: StorageMap<AssetId, u8> = StorageMap {},
+}
+
+impl SRC6 for Contract {
+    #[payable]
+    #[storage(read, write)]
+    fn deposit(receiver: Identity, vault_sub_id: SubId) -> u64 {
+        let asset_amount = msg_amount();
+        let underlying_asset = msg_asset_id();
+
+        require(underlying_asset == AssetId::base(), "INVALID_ASSET_ID");
+        let (shares, share_asset, share_asset_vault_sub_id) = preview_deposit(underlying_asset, vault_sub_id, asset_amount);
+        require(asset_amount != 0, "ZERO_ASSETS");
+
+        _mint(receiver, share_asset, share_asset_vault_sub_id, shares);
+
+        let mut vault_info = match storage.vault_info.get(share_asset).try_read() {
+            Some(vault_info) => vault_info,
+            None => VaultInfo {
+                managed_assets: 0,
+                vault_sub_id,
+                asset: underlying_asset,
+            },
+        };
+        vault_info.managed_assets = vault_info.managed_assets + asset_amount;
+        storage.vault_info.insert(share_asset, vault_info);
+
+        Deposit::new(
+            msg_sender()
+                .unwrap(),
+            receiver,
+            underlying_asset,
+            vault_sub_id,
+            asset_amount,
+            shares,
+        )
+            .log();
+
+        shares
+    }
+
+    #[payable]
+    #[storage(read, write)]
+    fn withdraw(
+        receiver: Identity,
+        underlying_asset: AssetId,
+        vault_sub_id: SubId,
+    ) -> u64 {
+        let shares = msg_amount();
+        require(shares != 0, "ZERO_SHARES");
+
+        let (share_asset_id, share_asset_vault_sub_id) = vault_asset_id(underlying_asset, vault_sub_id);
+
+        require(msg_asset_id() == share_asset_id, "INVALID_ASSET_ID");
+        let assets = preview_withdraw(share_asset_id, shares);
+
+        let mut vault_info = storage.vault_info.get(share_asset_id).read();
+        vault_info.managed_assets = vault_info.managed_assets - shares;
+        storage.vault_info.insert(share_asset_id, vault_info);
+
+        _burn(share_asset_id, share_asset_vault_sub_id, shares);
+
+        transfer(receiver, underlying_asset, assets);
+
+        Withdraw::new(
+            msg_sender()
+                .unwrap(),
+            receiver,
+            underlying_asset,
+            vault_sub_id,
+            assets,
+            shares,
+        )
+            .log();
+
+        assets
+    }
+
+    #[storage(read)]
+    fn managed_assets(underlying_asset: AssetId, vault_sub_id: SubId) -> u64 {
+        if underlying_asset == AssetId::base() {
+            let vault_share_asset = vault_asset_id(underlying_asset, vault_sub_id).0;
+            // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
+            managed_assets(vault_share_asset)
+        } else {
+            0
+        }
+    }
+
+    #[storage(read)]
+    fn max_depositable(
+        _receiver: Identity,
+        underlying_asset: AssetId,
+        vault_sub_id: SubId,
+    ) -> Option<u64> {
+        let vault_share_asset = vault_asset_id(underlying_asset, vault_sub_id).0;
+
+        match (
+            underlying_asset == AssetId::base(),
+            storage.vault_info.get(vault_share_asset).try_read(),
+        ) {
+            // This is the max value of u64 minus the current managed_assets. Ensures that the sum will always be lower than u64::MAX.
+            (true, Some(vault_info)) => Some(u64::max() - vault_info.managed_assets),
+            _ => None,
+        }
+    }
+
+    #[storage(read)]
+    fn max_withdrawable(underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64> {
+        let vault_share_asset = vault_asset_id(underlying_asset, vault_sub_id).0;
+
+        match (
+            underlying_asset == AssetId::base(),
+            storage.vault_info.get(vault_share_asset).try_read(),
+        ) {
+            // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
+            (true, Some(vault_info)) => Some(vault_info.managed_assets),
+            _ => None,
+        }
+    }
+}
+
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        storage.total_assets.try_read().unwrap_or(0)
+    }
+
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        storage.total_supply.get(asset).try_read()
+    }
+
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        storage.name.get(asset).read_slice()
+    }
+
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        storage.symbol.get(asset).read_slice()
+    }
+
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        storage.decimals.get(asset).try_read()
+    }
+}
+
+abi SetSRC20Data {
+    #[storage(read, write)]
+    fn set_src20_data(
+        asset: AssetId,
+        name: Option<String>,
+        symbol: Option<String>,
+        decimals: u8,
+    );
+}
+
+impl SetSRC20Data for Contract {
+    #[storage(read, write)]
+    fn set_src20_data(
+        asset: AssetId,
+        name: Option<String>,
+        symbol: Option<String>,
+        decimals: u8,
+    ) {
+        // NOTE: There are no checks for if the caller has permissions to update the metadata
+        // If this asset does not exist, revert
+        if storage.total_supply.get(asset).try_read().is_none() {
+            revert(0);
+        }
+        let sender = msg_sender().unwrap();
+
+        match name {
+            Some(unwrapped_name) => {
+                storage.name.get(asset).write_slice(unwrapped_name);
+                SetNameEvent::new(asset, name, sender).log();
+            },
+            None => {
+                let _ = storage.name.get(asset).clear();
+                SetNameEvent::new(asset, name, sender).log();
+            }
+        }
+
+        match symbol {
+            Some(unwrapped_symbol) => {
+                storage.symbol.get(asset).write_slice(unwrapped_symbol);
+                SetSymbolEvent::new(asset, symbol, sender).log();
+            },
+            None => {
+                let _ = storage.symbol.get(asset).clear();
+                SetSymbolEvent::new(asset, symbol, sender).log();
+            }
+        }
+
+        storage.decimals.get(asset).write(decimals);
+        SetDecimalsEvent::new(asset, decimals, sender).log();
+    }
+}
+
+/// Returns the vault shares assetid and subid for the given assets assetid and the vaults sub id
+fn vault_asset_id(underlying_asset: AssetId, vault_sub_id: SubId) -> (AssetId, SubId) {
+    let share_asset_vault_sub_id = sha256((underlying_asset, vault_sub_id));
+    let share_asset_id = AssetId::new(ContractId::this(), share_asset_vault_sub_id);
+    (share_asset_id, share_asset_vault_sub_id)
+}
+
+#[storage(read)]
+fn managed_assets(vault_share_asset_id: AssetId) -> u64 {
+    match storage.vault_info.get(vault_share_asset_id).try_read() {
+        Some(vault_info) => vault_info.managed_assets,
+        None => 0,
+    }
+}
+
+#[storage(read)]
+fn preview_deposit(
+    underlying_asset: AssetId,
+    vault_sub_id: SubId,
+    assets: u64,
+) -> (u64, AssetId, SubId) {
+    let (share_asset_id, share_asset_vault_sub_id) = vault_asset_id(underlying_asset, vault_sub_id);
+
+    let shares_supply = storage.total_supply.get(share_asset_id).try_read().unwrap_or(0);
+    if shares_supply == 0 {
+        (assets, share_asset_id, share_asset_vault_sub_id)
+    } else {
+        (
+            assets * shares_supply / managed_assets(share_asset_id),
+            share_asset_id,
+            share_asset_vault_sub_id,
+        )
+    }
+}
+
+#[storage(read)]
+fn preview_withdraw(share_asset_id: AssetId, shares: u64) -> u64 {
+    let supply = storage.total_supply.get(share_asset_id).read();
+    if supply == shares {
+        managed_assets(share_asset_id)
+    } else {
+        shares * (managed_assets(share_asset_id) / supply)
+    }
+}
+
+#[storage(read, write)]
+pub fn _mint(
+    recipient: Identity,
+    asset_id: AssetId,
+    vault_sub_id: SubId,
+    amount: u64,
+) {
+    use std::asset::mint_to;
+
+    let supply = storage.total_supply.get(asset_id).try_read();
+    // Only increment the number of assets minted by this contract if it hasn't been minted before.
+    if supply.is_none() {
+        storage.total_assets.write(storage.total_assets.read() + 1);
+    }
+    let new_supply = supply.unwrap_or(0) + amount;
+    storage.total_supply.insert(asset_id, new_supply);
+    mint_to(recipient, vault_sub_id, amount);
+    TotalSupplyEvent::new(asset_id, new_supply, msg_sender().unwrap())
+        .log();
+}
+
+#[storage(read, write)]
+pub fn _burn(asset_id: AssetId, vault_sub_id: SubId, amount: u64) {
+    use std::{asset::burn, context::this_balance};
+
+    require(
+        this_balance(asset_id) >= amount,
+        "BurnError::NotEnoughCoins",
+    );
+    // If we pass the check above, we can assume it is safe to unwrap.
+    let supply = storage.total_supply.get(asset_id).try_read().unwrap();
+    let new_supply = supply - amount;
+    storage.total_supply.insert(asset_id, new_supply);
+    burn(vault_sub_id, amount);
+    TotalSupplyEvent::new(asset_id, new_supply, msg_sender().unwrap())
+        .log();
+}
+```
+
+## Single Asset Single Sub Vault
+
+A basic implementation of the vault standard demonstrating how to restrict deposits and withdrawals to a single `AssetId`, and to a single Sub vault.
+
+```sway
+contract;
+
+use std::{
+    asset::transfer,
+    call_frames::msg_asset_id,
+    context::msg_amount,
+    hash::{
+        Hash,
+        sha256,
+    },
+    storage::storage_string::*,
+    string::String,
+};
+
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use src6::{Deposit, SRC6, Withdraw};
+
+configurable {
+    /// The only sub vault that can be deposited and withdrawn from this vault.
+    ACCEPTED_SUB_VAULT: SubId = SubId::zero(),
+    PRE_CALCULATED_SHARE_VAULT_SUB_ID: SubId = 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b,
+}
+
+storage {
+    /// The total amount of assets managed by this vault.
+    managed_assets: u64 = 0,
+    /// The total amount of shares minted by this vault.
+    total_supply: u64 = 0,
+    /// The name of a specific asset minted by this contract.
+    name: StorageString = StorageString {},
+    /// The symbol of a specific asset minted by this contract.
+    symbol: StorageString = StorageString {},
+    /// The decimals of a specific asset minted by this contract.
+    decimals: u8 = 9,
+}
+
+impl SRC6 for Contract {
+    #[payable]
+    #[storage(read, write)]
+    fn deposit(receiver: Identity, vault_sub_id: SubId) -> u64 {
+        require(vault_sub_id == ACCEPTED_SUB_VAULT, "INVALID_vault_sub_id");
+
+        let underlying_asset = msg_asset_id();
+        require(underlying_asset == AssetId::base(), "INVALID_ASSET_ID");
+
+        let asset_amount = msg_amount();
+        require(asset_amount != 0, "ZERO_ASSETS");
+        let shares = preview_deposit(asset_amount);
+
+        _mint(receiver, shares);
+
+        storage
+            .managed_assets
+            .write(storage.managed_assets.read() + asset_amount);
+
+        Deposit::new(
+            msg_sender()
+                .unwrap(),
+            receiver,
+            underlying_asset,
+            vault_sub_id,
+            asset_amount,
+            shares,
+        )
+            .log();
+
+        shares
+    }
+
+    #[payable]
+    #[storage(read, write)]
+    fn withdraw(
+        receiver: Identity,
+        underlying_asset: AssetId,
+        vault_sub_id: SubId,
+    ) -> u64 {
+        require(underlying_asset == AssetId::base(), "INVALID_ASSET_ID");
+        require(vault_sub_id == ACCEPTED_SUB_VAULT, "INVALID_vault_sub_id");
+
+        let shares = msg_amount();
+        require(shares != 0, "ZERO_SHARES");
+
+        let share_asset_id = vault_assetid();
+
+        require(msg_asset_id() == share_asset_id, "INVALID_ASSET_ID");
+        let assets = preview_withdraw(shares);
+
+        storage
+            .managed_assets
+            .write(storage.managed_assets.read() - shares);
+
+        _burn(share_asset_id, shares);
+
+        transfer(receiver, underlying_asset, assets);
+
+        Withdraw::new(
+            msg_sender()
+                .unwrap(),
+            receiver,
+            underlying_asset,
+            vault_sub_id,
+            assets,
+            shares,
+        )
+            .log();
+
+        assets
+    }
+
+    #[storage(read)]
+    fn managed_assets(underlying_asset: AssetId, vault_sub_id: SubId) -> u64 {
+        if underlying_asset == AssetId::base() && vault_sub_id == ACCEPTED_SUB_VAULT {
+            // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
+            storage.managed_assets.read()
+        } else {
+            0
+        }
+    }
+
+    #[storage(read)]
+    fn max_depositable(
+        _receiver: Identity,
+        underlying_asset: AssetId,
+        vault_sub_id: SubId,
+    ) -> Option<u64> {
+        if underlying_asset == AssetId::base() && vault_sub_id == ACCEPTED_SUB_VAULT {
+            // This is the max value of u64 minus the current managed_assets. Ensures that the sum will always be lower than u64::MAX.
+            Some(u64::max() - storage.managed_assets.read())
+        } else {
+            None
+        }
+    }
+
+    #[storage(read)]
+    fn max_withdrawable(underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64> {
+        if underlying_asset == AssetId::base() && vault_sub_id == ACCEPTED_SUB_VAULT {
+            // In this implementation managed_assets and max_withdrawable are the same. However in case of lending out of assets, managed_assets should be greater than max_withdrawable.
+            Some(storage.managed_assets.read())
+        } else {
+            None
+        }
+    }
+}
+
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        1
+    }
+
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        if asset == vault_assetid() {
+            Some(storage.total_supply.read())
+        } else {
+            None
+        }
+    }
+
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        if asset == vault_assetid() {
+            match storage.name.read_slice() {
+                Some(name) => Some(name),
+                None => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        if asset == vault_assetid() {
+            match storage.symbol.read_slice() {
+                Some(symbol) => Some(symbol),
+                None => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        if asset == vault_assetid() {
+            Some(storage.decimals.read())
+        } else {
+            None
+        }
+    }
+}
+
+abi SetSRC20Data {
+    #[storage(read, write)]
+    fn set_src20_data(
+        asset: AssetId,
+        name: Option<String>,
+        symbol: Option<String>,
+        decimals: u8,
+    );
+}
+
+impl SetSRC20Data for Contract {
+    #[storage(read, write)]
+    fn set_src20_data(
+        asset: AssetId,
+        name: Option<String>,
+        symbol: Option<String>,
+        decimals: u8,
+    ) {
+        // NOTE: There are no checks for if the caller has permissions to update the metadata
+        require(asset == vault_assetid(), "INVALID_ASSET_ID");
+        let sender = msg_sender().unwrap();
+
+        match name {
+            Some(unwrapped_name) => {
+                storage.name.write_slice(unwrapped_name);
+                SetNameEvent::new(asset, name, sender).log();
+            },
+            None => {
+                let _ = storage.name.clear();
+                SetNameEvent::new(asset, name, sender).log();
+            }
+        }
+
+        match symbol {
+            Some(unwrapped_symbol) => {
+                storage.symbol.write_slice(unwrapped_symbol);
+                SetSymbolEvent::new(asset, symbol, sender).log();
+            },
+            None => {
+                let _ = storage.symbol.clear();
+                SetSymbolEvent::new(asset, symbol, sender).log();
+            }
+        }
+
+        storage.decimals.write(decimals);
+        SetDecimalsEvent::new(asset, decimals, sender).log();
+    }
+}
+
+/// Returns the vault shares assetid for the given assets assetid and the vaults sub id
+fn vault_assetid() -> AssetId {
+    let share_asset_id = AssetId::new(ContractId::this(), PRE_CALCULATED_SHARE_VAULT_SUB_ID);
+    share_asset_id
+}
+
+#[storage(read)]
+fn preview_deposit(assets: u64) -> u64 {
+    let shares_supply = storage.total_supply.try_read().unwrap_or(0);
+    if shares_supply == 0 {
+        assets
+    } else {
+        assets * shares_supply / storage.managed_assets.try_read().unwrap_or(0)
+    }
+}
+
+#[storage(read)]
+fn preview_withdraw(shares: u64) -> u64 {
+    let supply = storage.total_supply.read();
+    if supply == shares {
+        storage.managed_assets.read()
+    } else {
+        shares * (storage.managed_assets.read() / supply)
+    }
+}
+
+#[storage(read, write)]
+pub fn _mint(recipient: Identity, amount: u64) {
+    use std::asset::mint_to;
+
+    let supply = storage.total_supply.read();
+    let new_supply = supply + amount;
+    storage.total_supply.write(new_supply);
+    mint_to(recipient, PRE_CALCULATED_SHARE_VAULT_SUB_ID, amount);
+    TotalSupplyEvent::new(vault_assetid(), new_supply, msg_sender().unwrap())
+        .log();
+}
+
+#[storage(read, write)]
+pub fn _burn(asset_id: AssetId, amount: u64) {
+    use std::{asset::burn, context::this_balance};
+
+    require(
+        this_balance(asset_id) >= amount,
+        "BurnError::NotEnoughCoins",
+    );
+    // If we pass the check above, we can assume it is safe to unwrap.
+    let supply = storage.total_supply.read();
+    let new_supply = supply - amount;
+    storage.total_supply.write(new_supply);
+    burn(PRE_CALCULATED_SHARE_VAULT_SUB_ID, amount);
+    TotalSupplyEvent::new(vault_assetid(), new_supply, msg_sender().unwrap())
+        .log();
+}
+```

--- a/standards/src7/README.md
+++ b/standards/src7/README.md
@@ -1,0 +1,453 @@
+# SRC-7: Onchain Native Asset Metadata
+
+The following standard attempts to define the retrieval of onchain arbitrary metadata for any [Native Asset](https://docs.fuel.network/docs/sway/blockchain-development/native_assets). This standard should be used if a stateful approach is needed. Any contract that implements the SRC-7 standard MUST implement the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard.
+
+> **NOTE** If data is not needed onchain, it is recommended to use the [SRC-15; Offchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-15-offchain-asset-metadata/).
+
+## Motivation
+
+The SRC-7 standard seeks to enable stateful data-rich assets on the Fuel Network while maintaining compatibility between multiple assets minted by the same contract. The standard ensures type safety with the use of an `enum` and an `Option`. All metadata queries are done through a single function to facilitate cross-contract calls.
+
+## Prior Art
+
+The use of generic metadata was originally found in the Sway-Lib's [NFT Library](https://github.com/FuelLabs/sway-libs/tree/v0.12.0/libs/nft) which did not use Fuel's [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets). This library has since been deprecated.
+
+A previous definition for a metadata standard was written in the original edit of the now defunct [SRC-721](https://github.com/FuelLabs/sway-standards/issues/2). This has since been replaced with the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard as `SubId` was introduced to enable multiple assets to be minted from a single contract.
+
+The standard takes inspiration from [ENS's public resolver](https://docs.ens.domains/contract-api-reference/publicresolver) with the use of a `String` as the key. This should enable human-readable keys to help minimize errors and enable the standardization of certain keys, such as "image" as opposed to an `enum` or `u64` representation of keys.
+
+We also take a look at existing common metadata practices such as [OpenSea's Metadata Standards](https://docs.opensea.io/docs/metadata-standards) and seek to stay backwards compatible with them while enabling more functionality. Through the combination of `String` keys and various return types, both pre-defined URIs or specific attributes may be stored and retrieved with the SRC-7 standard.
+
+## Specification
+
+### Metadata Type
+
+The following describes an enum that wraps various metadata types into a single return type. There SHALL be the following variants in the `Metadata` enum:
+
+#### `B256`
+
+The `B256` variant SHALL be used when the stored metadata for the corresponding `AssetId` and `Sting` key pair is of the `b256` type.
+
+#### `Bytes`
+
+The `Bytes` variant SHALL be used when the stored metadata for the corresponding `AssetId` and `String` key pair is of the `Bytes` type. The `Bytes` variant should be used when storing custom data such as but not limited to structs and enums.
+
+#### `Int`
+
+The `Int` variant SHALL be used when the stored metadata for the corresponding `AssetId` and `Sting` key pair is of the `u64` type.
+
+#### `String`
+
+The `String` variant SHALL be used when the stored metadata for the corresponding `AssetId` and `String` key pair is of the `String` type. The `String` variant MUST be used when a URI is required but MAY contain any arbitrary `String` data.
+
+### Required Functions
+
+#### `fn metadata(asset: AssetId, key: String) -> Option<Metadata>`
+
+This function MUST return valid metadata for the corresponding `asset` and `key`, where the data is either a `B256`, `Bytes`, `Int`, or `String` variant. If the asset does not exist or no metadata exists, the function MUST return `None`.
+
+### Logging
+
+The following logs MUST be implemented and emitted to follow the SRC-7 standard.
+
+* IF a value is updated via a function call, a log MUST be emitted.
+* IF a value is embedded in a contract as a constant, configurable, or other manner, an event MUST be emitted at least once.
+
+#### SetMetadataEvent
+
+The `SetMetadataEvent` MUST be emitted when the metadata of an asset has updated.
+
+There SHALL be the following fields in the `SetMetadataEvent` struct:
+
+* `asset`: The `asset` field SHALL be used for the corresponding `AssetId` for the asset that has been updated.
+* `metadata`: The `metadata` field SHALL be used for the corresponding `Option<Metadata>` which represents the metadata of the asset.
+* `key`: The `key` field SHALL be used for the corresponding `String` which represents the key used for storing the metadata.
+* `sender`: The `sender` field SHALL be used for the corresponding `Identity` which made the function call that has updated the metadata of the asset.
+
+Example:
+
+```sway
+pub struct SetMetadataEvent {
+    pub asset: AssetId,
+    pub metadata: Option<Metadata>,
+    pub key: String,
+    pub sender: Identity,
+}
+```
+
+## Rationale
+
+The SRC-7 standard should allow for stateful data-rich assets to interact with one another in a safe manner.
+
+## Backwards Compatibility
+
+This standard is compatible with Fuel's [Native Assets](https://docs.fuel.network/docs/sway/blockchain-development/native_assets) and the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard. It also maintains compatibility with existing standards in other ecosystems.
+
+## Security Considerations
+
+This standard does not introduce any security concerns, as it does not call external contracts, nor does it define any mutations of the contract state.
+
+## Example ABI
+
+```sway
+abi SRC7 {
+     #[storage(read)]
+     fn metadata(asset: AssetId, key: String) -> Option<Metadata>;
+}
+```
+
+## Example Implementation
+
+### Single Native Asset
+
+Example of the SRC-7 implementation where metadata exists for only a single asset with one `SubId`.
+
+```sway
+contract;
+
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use src7::{Metadata, SetMetadataEvent, SRC7};
+
+use std::string::String;
+
+configurable {
+    /// The total supply of coins for the asset minted by this contract.
+    TOTAL_SUPPLY: u64 = 100_000_000,
+    /// The decimals of the asset minted by this contract.
+    DECIMALS: u8 = 9u8,
+    /// The name of the asset minted by this contract.
+    NAME: str[7] = __to_str_array("MyAsset"),
+    /// The symbol of the asset minted by this contract.
+    SYMBOL: str[5] = __to_str_array("MYTKN"),
+    /// The metadata for the "social:x" key.
+    SOCIAL_X: str[12] = __to_str_array("fuel_network"),
+    /// The metadata for the "site:forum" key.
+    SITE_FORUM: str[27] = __to_str_array("https://forum.fuel.network/"),
+    /// The metadata for the "attr:health" key.
+    ATTR_HEALTH: u64 = 100,
+}
+
+impl SRC7 for Contract {
+    /// Returns metadata for the corresponding `asset` and `key`.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset of which to query the metadata.
+    /// * `key`: [String] - The key to the specific metadata.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<Metadata>] - `Some` metadata that corresponds to the `key` or `None`.
+    ///
+    /// # Reverts
+    ///
+    /// * When the AssetId provided does not match the default SubId.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src7::{SRC7, Metadata};
+    /// use std::string::String;
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId) {
+    ///     let contract_abi = abi(SRC7, contract_id);
+    ///     let key = String::from_ascii_str("social:x");
+    ///     let data = contract_abi.metadata(asset, key);
+    ///     assert(data.unwrap() == Metadata::String(String::from_ascii_str("fuel_network")));
+    /// }
+    /// ```
+    #[storage(read)]
+    fn metadata(asset: AssetId, key: String) -> Option<Metadata> {
+        require(asset == AssetId::default(), "Invalid AssetId provided");
+
+        if key == String::from_ascii_str("social:x") {
+            Some(Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X))))
+        } else if key == String::from_ascii_str("site:forum") {
+            Some(Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM))))
+        } else if key == String::from_ascii_str("attr:health") {
+            Some(Metadata::Int(ATTR_HEALTH))
+        } else {
+            None
+        }
+    }
+}
+
+abi EmitSRC7Events {
+    fn emit_src7_events();
+}
+
+impl EmitSRC7Events for Contract {
+    fn emit_src7_events() {
+        let asset = AssetId::default();
+        let sender = msg_sender().unwrap();
+        let metadata_1 = Some(Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X))));
+        let metadata_2 = Some(Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM))));
+        let metadata_3 = Some(Metadata::Int(ATTR_HEALTH));
+        let key_1 = String::from_ascii_str("social:x");
+        let key_2 = String::from_ascii_str("site:forum");
+        let key_3 = String::from_ascii_str("attr:health");
+
+        SetMetadataEvent::new(asset, metadata_1, key_1, sender)
+            .log();
+        SetMetadataEvent::new(asset, metadata_2, key_2, sender)
+            .log();
+        SetMetadataEvent::new(asset, metadata_3, key_3, sender)
+            .log();
+    }
+}
+
+// SRC7 extends SRC20, so this must be included
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        1
+    }
+
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        if asset == AssetId::default() {
+            Some(TOTAL_SUPPLY)
+        } else {
+            None
+        }
+    }
+
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        if asset == AssetId::default() {
+            Some(String::from_ascii_str(from_str_array(NAME)))
+        } else {
+            None
+        }
+    }
+
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        if asset == AssetId::default() {
+            Some(String::from_ascii_str(from_str_array(SYMBOL)))
+        } else {
+            None
+        }
+    }
+
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        if asset == AssetId::default() {
+            Some(DECIMALS)
+        } else {
+            None
+        }
+    }
+}
+
+abi EmitSRC20Events {
+    fn emit_src20_events();
+}
+
+impl EmitSRC20Events for Contract {
+    fn emit_src20_events() {
+        // Metadata that is stored as a configurable should only be emitted once.
+        let asset = AssetId::default();
+        let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
+
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, TOTAL_SUPPLY, sender).log();
+    }
+}
+```
+
+### Multi Native Asset
+
+Example of the SRC-7 implementation where metadata exists for multiple assets with differing `SubId` values.
+
+```sway
+contract;
+
+use src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
+use src7::{Metadata, SetMetadataEvent, SRC7};
+
+use std::{hash::Hash, storage::storage_string::*, string::String};
+
+// In this example, all assets minted from this contract have the same decimals, name, and symbol
+configurable {
+    /// The decimals of every asset minted by this contract.
+    DECIMALS: u8 = 0u8,
+    /// The name of every asset minted by this contract.
+    NAME: str[7] = __to_str_array("MyAsset"),
+    /// The symbol of every asset minted by this contract.
+    SYMBOL: str[5] = __to_str_array("MYAST"),
+    /// The metadata for the "social:x" key.
+    SOCIAL_X: str[12] = __to_str_array("fuel_network"),
+    /// The metadata for the "site:forum" key.
+    SITE_FORUM: str[27] = __to_str_array("https://forum.fuel.network/"),
+}
+
+storage {
+    /// The total number of distinguishable assets this contract has minted.
+    total_assets: u64 = 0,
+    /// The total supply of a particular asset.
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+    /// The metadata for the "image:svg" key.
+    svg_images: StorageMap<AssetId, StorageString> = StorageMap {},
+    /// The metadata for the "attr:health" key.
+    health_attributes: StorageMap<AssetId, u64> = StorageMap {},
+}
+
+impl SRC7 for Contract {
+    /// Returns metadata for the corresponding `asset` and `key`.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset of which to query the metadata.
+    /// * `key`: [String] - The key to the specific metadata.
+    ///
+    /// # Returns
+    ///
+    /// * [Option<Metadata>] - `Some` metadata that corresponds to the `key` or `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use src7::{SRC7, Metadata};
+    /// use std::string::String;
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId) {
+    ///     let contract_abi = abi(SRC7, contract_id);
+    ///     let key = String::from_ascii_str("social:x");
+    ///     let data = contract_abi.metadata(asset, key);
+    ///     assert(data.unwrap() == Metadata::String(String::from_ascii_str("fuel_network")));
+    /// }
+    /// ```
+    #[storage(read)]
+    fn metadata(asset: AssetId, key: String) -> Option<Metadata> {
+        // If this asset does not exist, return None
+        if storage.total_supply.get(asset).try_read().is_none() {
+            return None
+        }
+
+        if key == String::from_ascii_str("social:x") {
+            // The "social:x" for all assets minted by this contract are the same.
+            Some(Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X))))
+        } else if key == String::from_ascii_str("site:forum") {
+            // The "site:forums" for all assets minted by this contract are the same.
+            Some(Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM))))
+        } else if key == String::from_ascii_str("image:svg") {
+            // The SVG image is stored as a String in storage for each asset
+            let svg_image = storage.svg_images.get(asset).read_slice();
+
+            match svg_image {
+                Some(svg) => Some(Metadata::String(svg)),
+                None => None,
+            }
+        } else if key == String::from_ascii_str("attr:health") {
+            // The health attribute is stored as a u64 in storage for each asset
+            let health_attribute = storage.health_attributes.get(asset).try_read();
+
+            match health_attribute {
+                Some(health) => Some(Metadata::Int(health)),
+                None => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+
+abi SetSRC7Events {
+    #[storage(read, write)]
+    fn set_src7_events(asset: AssetId, svg_image: String, health_attribute: u64);
+}
+
+impl SetSRC7Events for Contract {
+    #[storage(read, write)]
+    fn set_src7_events(asset: AssetId, svg_image: String, health_attribute: u64) {
+        // NOTE: There are no checks for if the caller has permissions to update the metadata
+        // If this asset does not exist, revert
+        if storage.total_supply.get(asset).try_read().is_none() {
+            revert(0);
+        }
+
+        storage.svg_images.try_insert(asset, StorageString {});
+        storage.svg_images.get(asset).write_slice(svg_image);
+        storage.health_attributes.insert(asset, health_attribute);
+
+        let sender = msg_sender().unwrap();
+        let metadata_1 = Some(Metadata::String(String::from_ascii_str(from_str_array(SOCIAL_X))));
+        let metadata_2 = Some(Metadata::String(String::from_ascii_str(from_str_array(SITE_FORUM))));
+        let metadata_3 = Some(Metadata::String(svg_image));
+        let metadata_4 = Some(Metadata::Int(health_attribute));
+        let key_1 = String::from_ascii_str("social:x");
+        let key_2 = String::from_ascii_str("site:forum");
+        let key_3 = String::from_ascii_str("image:svg");
+        let key_4 = String::from_ascii_str("attr:health");
+
+        SetMetadataEvent::new(asset, metadata_1, key_1, sender)
+            .log();
+        SetMetadataEvent::new(asset, metadata_2, key_2, sender)
+            .log();
+        SetMetadataEvent::new(asset, metadata_3, key_3, sender)
+            .log();
+        SetMetadataEvent::new(asset, metadata_4, key_4, sender)
+            .log();
+    }
+}
+
+// SRC7 extends SRC20, so this must be included
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        storage.total_assets.read()
+    }
+
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        storage.total_supply.get(asset).try_read()
+    }
+
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(String::from_ascii_str(from_str_array(NAME))),
+            None => None,
+        }
+    }
+
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(String::from_ascii_str(from_str_array(SYMBOL))),
+            None => None,
+        }
+    }
+
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        match storage.total_supply.get(asset).try_read() {
+            Some(_) => Some(DECIMALS),
+            None => None,
+        }
+    }
+}
+
+abi SetSRC20Data {
+    fn set_src20_data(asset: AssetId, total_supply: u64);
+}
+
+impl SetSRC20Data for Contract {
+    fn set_src20_data(asset: AssetId, supply: u64) {
+        // NOTE: There are no checks for if the caller has permissions to update the metadata
+        let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
+
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, supply, sender).log();
+    }
+}
+```


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Adds README.md files to standards for forc.pub.

## Notes

- Once https://github.com/FuelLabs/sway/pull/7264 is resolved, the README.md will link to `docs/book`.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
