### PR TITLE
SRC14 & SRC15 v0.8.2 release

### DIFF
--- a/examples/src15-offchain-metadata/global/Forc.toml
+++ b/examples/src15-offchain-metadata/global/Forc.toml
@@ -7,4 +7,4 @@ name = "global_src15_asset"
 [dependencies]
 src15 = { path = "../../../standards/src15" }
 src20 = { path = "../../../standards/src20" }
-src7 = "0.8.0"
+src7 = "0.8.2"

--- a/examples/src15-offchain-metadata/multi_asset/Forc.toml
+++ b/examples/src15-offchain-metadata/multi_asset/Forc.toml
@@ -7,4 +7,4 @@ name = "multi_src15_asset"
 [dependencies]
 src15 = { path = "../../../standards/src15" }
 src20 = { path = "../../../standards/src20" }
-src7 = "0.8.0"
+src7 = "0.8.2"

--- a/examples/src15-offchain-metadata/single_asset/Forc.toml
+++ b/examples/src15-offchain-metadata/single_asset/Forc.toml
@@ -7,4 +7,4 @@ name = "single_src15_asset"
 [dependencies]
 src15 = { path = "../../../standards/src15" }
 src20 = { path = "../../../standards/src20" }
-src7 = "0.8.0"
+src7 = "0.8.2"

--- a/standards/src14/Forc.toml
+++ b/standards/src14/Forc.toml
@@ -3,7 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "src14.sw"
 license = "Apache-2.0"
 name = "src14"
-version = "0.8.1"
+version = "0.8.2"
 description = "The SRC-14 Standard proposes a standard for simple upgradeable proxies."
 homepage = "https://github.com/FuelLabs/sway-standards"
 repository = "https://github.com/FuelLabs/sway-standards"
@@ -13,4 +13,4 @@ categories = ["Standards", "Security", "Contracts"]
 keywords = ["standard", "library"]
 
 [dependencies]
-src5 = "0.8.0"
+src5 = "0.8.2"

--- a/standards/src15/Forc.toml
+++ b/standards/src15/Forc.toml
@@ -3,7 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "src15.sw"
 license = "Apache-2.0"
 name = "src15"
-version = "0.8.1"
+version = "0.8.2"
 description = "The SRC-15 Standard defines arbitrary metadata for any Native Asset that is not required by other contracts onchain, in a stateless manner."
 homepage = "https://github.com/FuelLabs/sway-standards"
 repository = "https://github.com/FuelLabs/sway-standards"
@@ -13,4 +13,4 @@ categories = ["Standards", "Metadata", "Native Assets"]
 keywords = ["standard", "library"]
 
 [dependencies]
-src7 = "0.8.0"
+src7 = "0.8.2"


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Release

## Changes

The following changes have been made:

- Creates a release forc SRC14 & SRC15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps SRC-14 and SRC-15 to v0.8.2 and aligns related dependencies and examples to `src5/src7` v0.8.2.
> 
> - **Release**:
>   - Bump `standards/src14` and `standards/src15` versions to `0.8.2`.
> - **Dependencies**:
>   - Update `standards/src14` dependency `src5` -> `0.8.2`.
>   - Update `standards/src15` dependency `src7` -> `0.8.2`.
>   - Update example projects to `src7` -> `0.8.2` in:
>     - `examples/src15-offchain-metadata/global/Forc.toml`
>     - `examples/src15-offchain-metadata/multi_asset/Forc.toml`
>     - `examples/src15-offchain-metadata/single_asset/Forc.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5009cf1fefe24e14f913264569ba3c12d681dc4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->