### PR TITLE
Fix typos in docs and standards' doc-comments

### DIFF
--- a/docs/src/src-10-native-bridge.md
+++ b/docs/src/src-10-native-bridge.md
@@ -45,7 +45,7 @@ The `claim_refund()` function is called if something goes wrong in the bridging 
 
 #### `DepositType`
 
-The `DepositType` enum describes whether the bridged deposit is made to a address, contract, or contract and contains additional metadata. There MUST be the following variants in the `DepositType` enum:
+The `DepositType` enum describes whether the bridged deposit is made to an address, contract, or contract and contains additional metadata. There MUST be the following variants in the `DepositType` enum:
 
 **`Address`: `()`**
 
@@ -53,11 +53,11 @@ The `Address` variant MUST represent when the deposit is made to an address on t
 
 **`Contract`: `()`**
 
-The `Contract` variant MUST represent when the deposit is made to an contract on the Fuel chain.
+The `Contract` variant MUST represent when the deposit is made to a contract on the Fuel chain.
 
 **`ContractWithData`: `()`**
 
-The `ContractWithData` variant MUST represent when the deposit is made to an contract and contains additional metadata for the Fuel chain.
+The `ContractWithData` variant MUST represent when the deposit is made to a contract and contains additional metadata for the Fuel chain.
 
 ##### Example Deposit Type
 

--- a/docs/src/src-2-inline-documentation.md
+++ b/docs/src/src-2-inline-documentation.md
@@ -272,7 +272,7 @@ Example:
 
 ### Other Sections
 
-If the above described sections are not relevant for the information that needs to documented, a custom section with a arbitrary `h1` header may be utilized.
+If the above described sections are not relevant for the information that needs to documented, a custom section with an arbitrary `h1` header may be utilized.
 
 Example:
 

--- a/docs/src/src-6-vault.md
+++ b/docs/src/src-6-vault.md
@@ -50,8 +50,8 @@ This function returns the total assets under management by vault. Includes asset
 This is a helper function for getting the maximum amount of assets that can be deposited. It takes the hypothetical `receiver` `Identity`, the `underlying_asset` `AssetId`, and the `vault_sub_id` `SubId` of the sub vault as an arguments and returns the maximum amount of assets that can be deposited into the contract, for the given asset.
 
 - This function MUST return the maximum amount of assets that can be deposited into the contract, for the given `underlying_asset`, if the given `vault_sub_id` vault exists.
-- This function MUST return an `Some(amount)` if the given `vault_sub_id` vault exists.
-- This function MUST return an `None` if the given `vault_sub_id` vault does not exist.
+- This function MUST return a `Some(amount)` if the given `vault_sub_id` vault exists.
+- This function MUST return a `None` if the given `vault_sub_id` vault does not exist.
 - This function MUST account for both global and user specific limits. For example: if deposits are disabled, even temporarily, MUST return 0.
 
 #### `fn max_withdrawable(receiver: Identity, underlying_asset: AssetId, vault_sub_id: SubId) -> Option<u64>`
@@ -59,8 +59,8 @@ This is a helper function for getting the maximum amount of assets that can be d
 This is a helper function for getting maximum withdrawable. It takes the hypothetical `receiver` `Identity`, the `underlying_asset` `AssetId`, and the `vault_sub_id` SubId of the sub vault as an argument and returns the maximum amount of assets that can be withdrawn from the contract, for the given asset.
 
 - This function MUST return the maximum amount of assets that can be withdrawn from the contract, for the given `underlying_asset`, if the given `vault_sub_id` vault exists.
-- This function MUST return an `Some(amount)` if the given `vault_sub_id` vault exists.
-- This function MUST return an `None` if the given `vault_sub_id` vault does not exist.
+- This function MUST return a `Some(amount)` if the given `vault_sub_id` vault exists.
+- This function MUST return a `None` if the given `vault_sub_id` vault does not exist.
 - This function MUST account for global limits. For example: if withdrawals are disabled, even temporarily, MUST return 0.
 
 ### Required logs

--- a/docs/src/src-8-bridged-asset.md
+++ b/docs/src/src-8-bridged-asset.md
@@ -28,7 +28,7 @@ Any bridged assets MUST use the name and symbol of the asset on the chain where 
 
 #### `bridged:chain`
 
-The key `bridged:chain` SHALL return an `String` variant of the chain ID where the asset was originally minted.
+The key `bridged:chain` SHALL return a `String` variant of the chain ID where the asset was originally minted.
 
 #### `bridged:address`
 

--- a/docs/src/src-9-metadata-keys.md
+++ b/docs/src/src-9-metadata-keys.md
@@ -196,11 +196,11 @@ The key `res:description` SHALL return a `String` variant describing the asset's
 
 #### `res:date`
 
-The key `res:date` SHALL return a `Int` variant of a UNIX timestamp.
+The key `res:date` SHALL return an `Int` variant of a UNIX timestamp.
 
 #### `res:block`
 
-The key `res:block` SHALL return a `Int` variant of a block number.
+The key `res:block` SHALL return an `Int` variant of a block number.
 
 ### Images
 

--- a/standards/src10/src/src10.sw
+++ b/standards/src10/src/src10.sw
@@ -8,11 +8,11 @@ pub enum DepositType {
     Address: (),
     /// The deposit was made to a Contract.
     Contract: (),
-    /// The deposit was made to a Contract and contains additioanl data for the Fuel chain.
+    /// The deposit was made to a Contract and contains additional data for the Fuel chain.
     ContractWithData: (),
 }
 
-/// Enscapsultes metadata sent between the canonical chain and Fuel when a deposit is made.
+/// Encapsulates metadata sent between the canonical chain and Fuel when a deposit is made.
 pub struct DepositMessage {
     /// The number of tokens.
     pub amount: b256,
@@ -510,7 +510,7 @@ impl MetadataMessage {
     ///
     /// # Returns
     ///
-    /// * [b256] - The token address for the metdata message.
+    /// * [b256] - The token address for the metadata message.
     ///
     /// # Examples
     ///
@@ -530,7 +530,7 @@ impl MetadataMessage {
     ///
     /// # Returns
     ///
-    /// * [b256] - The token id for the metdata message.
+    /// * [b256] - The token id for the metadata message.
     ///
     /// # Examples
     ///
@@ -550,7 +550,7 @@ impl MetadataMessage {
     ///
     /// # Returns
     ///
-    /// * [String] - The name for the metdata message.
+    /// * [String] - The name for the metadata message.
     ///
     /// # Examples
     ///
@@ -570,7 +570,7 @@ impl MetadataMessage {
     ///
     /// # Returns
     ///
-    /// * [String] - The symbol for the metdata message.
+    /// * [String] - The symbol for the metadata message.
     ///
     /// # Examples
     ///

--- a/standards/src11/src/src11.sw
+++ b/standards/src11/src/src11.sw
@@ -66,7 +66,7 @@ impl PartialEq for SecurityInformation {
             return false;
         }
 
-        // If both prefered languages info contain data, check each string
+        // If both preferred languages info contain data, check each string
         if self.preferred_languages.is_some() && other.preferred_languages.is_some() {
             let self_preferred_languages = self.preferred_languages.unwrap();
             let other_preferred_languages = self.preferred_languages.unwrap();

--- a/standards/src15/src/src15.sw
+++ b/standards/src15/src/src15.sw
@@ -24,7 +24,7 @@ impl SRC15MetadataEvent {
     /// # Arguments
     ///
     /// * `asset`: [AssetId] - The asset for which metadata is set.
-    /// * `metadata`: [Option<Metdata>] - The Metadata that is set.
+    /// * `metadata`: [Option<Metadata>] - The Metadata that is set.
     ///
     /// # Returns
     ///
@@ -128,7 +128,7 @@ impl SRC15GlobalMetadataEvent {
     ///
     /// # Arguments
     ///
-    /// * `metadata`: [Option<Metdata>] - The Metadata that is set.
+    /// * `metadata`: [Option<Metadata>] - The Metadata that is set.
     ///
     /// # Returns
     ///

--- a/standards/src20/src/src20.sw
+++ b/standards/src20/src/src20.sw
@@ -114,7 +114,7 @@ abi SRC20 {
     /// ```sway
     /// use src20::SRC20;
     ///
-    /// fn foo(contract_id: ContractId, asset: AssedId) {
+    /// fn foo(contract_id: ContractId, asset: AssetId) {
     ///     let contract_abi = abi(SRC20, contract_id.bits());
     ///     let decimals: Option<u8> = contract_abi.decimals(asset);
     ///     assert(decimals.unwrap() == 8u8);

--- a/standards/src6/src/src6.sw
+++ b/standards/src6/src/src6.sw
@@ -99,7 +99,7 @@ abi SRC6 {
     ///
     /// * If the asset is not supported by the contract.
     /// * If the amount of shares is zero.
-    /// * If the transferred shares do not corresspond to the given asset.
+    /// * If the transferred shares do not correspond to the given asset.
     /// * The user crosses any global or user specific withdrawal limits.
     ///
     /// # Examples

--- a/standards/src7/src/src7.sw
+++ b/standards/src7/src/src7.sw
@@ -91,7 +91,7 @@ impl SetMetadataEvent {
     /// # Arguments
     ///
     /// * `asset`: [AssetId] - The asset for which metadata is set.
-    /// * `metadata`: [Option<Metdata>] - The Metadata that is set.
+    /// * `metadata`: [Option<Metadata>] - The Metadata that is set.
     /// * `key`: [String] - The key used for the metadata.
     /// * `sender`: [Identity] - The caller that set the metadata.
     ///


### PR DESCRIPTION
## Type of change

- Fixing typos

## Changes

The following changes have been made:

- Fixed typos in `docs` and standard's doc-comments.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.