### PR TITLE
Bump `forc` version to 0.71.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.80.1
-  FORC_VERSION: 0.70.2
+  FORC_VERSION: 0.71.2
   CORE_VERSION: 0.44.0
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/.github/workflows/publish-standards.yaml
+++ b/.github/workflows/publish-standards.yaml
@@ -14,7 +14,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.84.0
-  FORC_VERSION: 0.70.2
+  FORC_VERSION: 0.71.2
   CORE_VERSION: 0.44.0
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yaml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-standards/actions/workflows/ci.yaml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.70.2" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.70.2-orange" />
+    <a href="https://crates.io/crates/forc/0.71.2" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.71.2-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-standards" />
@@ -184,7 +184,7 @@ Example of a minimal SRC-14 implementation with no access control.
 Example of a SRC-14 implementation that also implements [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/).
 
 > **Note**
-> All standards currently use `forc v0.70.2`.
+> The latest published versions of all standards use `forc v0.70.2`. The `master` branch is built against `forc v0.71.2`.
 
 <!-- TODO:
 ## Contributing

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@ Standards in this repository may be in various stages of development. Use of dra
 If you don't find what you're looking for, feel free to create an issue and propose a new standard!
 
 > **Note**
-> All standards currently use `forc v0.70.2`.
+> The latest published versions of all standards use `forc v0.70.2`. The `master` branch is built against `forc v0.71.2`.
 
 ## Using a standard
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,7 +36,7 @@ fi
 
 # The expected `forc` version. If the installed `forc` differs, a warning is
 # printed before and after building all the projects.
-FORC_VERSION="0.70.2"
+FORC_VERSION="0.71.2"
 
 SUBDIR="$1"
 LABEL="$2"

--- a/standards/src16/src/src16.sw
+++ b/standards/src16/src/src16.sw
@@ -83,6 +83,10 @@ pub const SRC16_DOMAIN_TYPE_HASH: b256 = 0x10f132d1adc99105bb9ad0d98956a93f35bda
 /// 5. add Verifying contract address as 32-bytes
 ///
 impl AbiEncode for SRC16Domain {
+    fn is_encode_trivial() -> bool {
+        false
+    }
+
     fn abi_encode(self, buffer: Buffer) -> Buffer {
         let buffer = SRC16_DOMAIN_TYPE_HASH.abi_encode(buffer);
         let buffer = keccak256(Bytes::from(self.name)).abi_encode(buffer);
@@ -172,11 +176,15 @@ pub const EIP712_DOMAIN_TYPE_HASH: b256 = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f
 /// 5. add Verifying contract address as 32-bytes
 ///
 impl AbiEncode for EIP712Domain {
+    fn is_encode_trivial() -> bool {
+        false
+    }
+
     fn abi_encode(self, buffer: Buffer) -> Buffer {
         let buffer = EIP712_DOMAIN_TYPE_HASH.abi_encode(buffer);
         let buffer = keccak256(Bytes::from(self.name)).abi_encode(buffer);
         let buffer = keccak256(Bytes::from(self.version)).abi_encode(buffer);
-        let buffer = (self.chain_id).abi_encode(buffer);
+        let buffer = self.chain_id.abi_encode(buffer);
         let buffer = self.verifying_contract.abi_encode(buffer);
         buffer
     }

--- a/standards/src17/src/src17.sw
+++ b/standards/src17/src/src17.sw
@@ -8,33 +8,6 @@ pub type AltBn128Proof = [u8; 288];
 /// Sparse Merkle Tree proof data.
 pub type SparseMerkleProof = Proof;
 
-#[cfg(experimental_const_generics = false)]
-impl AbiEncode for AltBn128Proof {
-    fn abi_encode(self, buffer: Buffer) -> Buffer {
-        let mut buffer = buffer;
-        let mut i = 0;
-        while i < 288 {
-            buffer = self[i].abi_encode(buffer);
-            i += 1;
-        };
-        buffer
-    }
-}
-
-#[cfg(experimental_const_generics = false)]
-impl AbiDecode for AltBn128Proof {
-    fn abi_decode(ref mut buffer: BufferReader) -> [u8; 288] {
-        let first: u8 = buffer.decode::<u8>();
-        let mut array = [first; 288];
-        let mut i = 1;
-        while i < 288 {
-            array[i] = buffer.decode::<u8>();
-            i += 1;
-        };
-        array
-    }
-}
-
 /// The error log used something in the SRC-17 verification process fails.
 pub enum SRC17VerificationError {
     /// Emitted when verification of a SRC-17 proof fails.


### PR DESCRIPTION
## Type of change

- `forc` version dump.

## Changes

- `FORC_VERSION` variable in all scripts set to 0.71.2
- `src16` and `src17` adjusted for const generics and trivial encoding/decoding.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.