### PR TITLE
Add benchmarking infrastructure and benchmarks for `src16`

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,298 @@
+# Benchmarks
+
+Sway has no native benchmarking support (there is no `forc bench`). These
+benchmarks are a lightweight, convention-based form of benchmarking built on top
+of Sway unit tests (`forc test`). `forc test` reports the gas consumed by
+each test, and we use that number, together with a per-benchmark *baseline*, to
+isolate the gas cost of the code under measurement.
+
+## Running
+
+Use the benchmark runner. It runs the tests, subtracts each benchmark's
+baseline, and prints the net costs (e.g. for SRC16):
+
+```sh
+just b -p benchmarks/src16 -f ascii
+# or, equivalently:
+./scripts/forc-bench.sh -p benchmarks/src16 -f ascii
+```
+
+The runner always builds in `--release` (benchmarks measure optimized code;
+debug numbers are not meaningful) and runs `forc test --terse` under the hood.
+Prefer it over a bare `forc test`, which reports per-test gas *before* the
+baseline subtraction.
+
+Pass one or more output formats with `-f`/`--format`:
+
+- `raw` — the raw `forc test` output, verbatim (per-test gas, source order).
+- `csv` — `bench,gas` CSV.
+- `ascii` — an ASCII `Bench | Gas` table.
+- `md` — a Markdown `Bench | Gas` table.
+- `json` — `[{"bench": "<group>::<name>", "gas": <gas>}, ...]`.
+
+Every format except `raw` reports the **net** cost, with benchmarks pretty-printed
+as `<group>::<name>` and sorted by that name. See
+`./scripts/forc-bench.sh --help` for all options (including `--experimental` /
+`--no-experimental`).
+
+### Convention checks
+
+Before reporting, the runner enforces the conventions described below and fails
+(exit code 3, offenders printed to stderr) if any are violated:
+
+- every `bench`/`baseline` test name is well-formed (a benchmark must be
+  `bench__<group>__<name>`; a baseline `baseline`, `baseline__<group>`, or
+  `baseline__<group>__<name>`);
+- every benchmark resolves to a baseline (some baseline must match, down to the
+  bare `baseline` fallback);
+- every `fixture_*` function is marked `#[inline(never)]`.
+
+This keeps a malformed name or a forgotten attribute from silently corrupting a
+measurement.
+
+### What the reported gas means
+
+The net cost of a benchmark is:
+
+```
+cost(bench__<x>) = gas(bench__<x>) - gas(<the matching baseline>)
+```
+
+The subtraction removes the unavoidable overhead of building the inputs
+(fixtures) and of "keeping" the result (see [Keeping results](#keeping-results)),
+leaving only the gas of the operation under measurement. The runner does this
+for you.
+
+A net cost of `0` means the operation is effectively **free**: the baseline
+already accounts for everything the benchmark does, so the subtraction lands on
+the measurement floor. (The raw subtraction can even come out slightly negative
+due to tiny asymmetries; the runner clamps such values to `0`.) This is the
+expected result for no-op passthroughs (e.g. an encoder that just returns its
+`b256` argument).
+
+## Project layout
+
+Each standard's benchmarks are a separate Forc library package under
+`benchmarks/`. Within a package, the source is split into one module per
+benchmarked type, plus shared scaffolding:
+
+```text
+benchmarks/
+├── benchmarking/              # shared library: keep, keep_ref_type, keep_copy_type
+│   └── src/benchmarking.sw
+└── src16/
+    ├── Forc.toml              # depends on `benchmarking` and the standard (`src16`)
+    └── src/
+        ├── src16.sw           # root entry: only `pub mod ...;` lines
+        ├── common.sw          # global `baseline` + cross-cutting fixtures
+        ├── src16_domain.sw    # one module per benchmarked type ...
+        ├── eip712_domain.sw
+        ├── src16_payload.sw
+        └── data_encoder.sw
+```
+
+A module's name matches the benchmark `<group>` it contains. The group is still
+repeated in every test name because `forc test` reports only the bare function
+name, not its module path — without the group, identically-named tests in
+different modules would collide.
+
+The `keep` helpers live in the shared `benchmarking` library and are reused by
+every benchmark package through a path dependency in `Forc.toml`:
+
+```toml
+[dependencies]
+benchmarking = { path = "../benchmarking" }
+src16 = { path = "../../standards/src16" }
+```
+
+Each module imports them with `use benchmarking::*;`.
+
+A few Sway module rules worth noting:
+
+- The root entry contains only `pub mod <module>;` lines. Modules must be `pub`
+  so that sibling modules can import from them.
+- A module imports an item from a sibling using an absolute path from the package
+  root: `use ::common::fixture_create_buffer;`. Items shared across modules
+  (fixtures, etc.) are therefore marked `pub`.
+- The global fallback `baseline` **cannot** be shared via the `benchmarking`
+  library: `forc test` does not run tests defined in dependency packages. It
+  lives in each package's `common` module instead.
+
+## Naming conventions
+
+Every benchmark and baseline is a `#[test]`. The test name encodes everything,
+using `__` (double underscore) as the segment separator:
+
+- A **benchmark** is named `bench__<group>__<name>`, where both `<group>` and
+  `<name>` are mandatory. `<group>` and `<name>` may each contain `_` for further
+  qualification (e.g. `bench__some_group__some_name_a_b_c`).
+- A **baseline** measures the overhead (fixtures + keep) of one or more
+  benchmarks. It is named `baseline`, `baseline__<group>`,
+  `baseline__<group>__<name>`, etc.
+
+### Baseline resolution
+
+A benchmark's baseline is chosen by **most-specific prefix match**. Given a
+benchmark, walk its name segments from the most specific to the least specific
+and pick the first baseline that exists. The bare `baseline` is the final
+fallback.
+
+For example, given the benchmark `bench__group__name_a_b_c` and the baselines
+`baseline`, `baseline__group`, and `baseline__group__name_a`:
+
+| Benchmark                       | Chosen baseline             |
+| ------------------------------- | --------------------------- |
+| `bench__group__name_a_b_c`      | `baseline__group__name_a`   |
+| `bench__group__name_d`          | `baseline__group`           |
+| `bench__other_group__name`      | `baseline`                  |
+
+This lets several benchmarks that share the same fixtures share a single
+baseline, while still allowing a more specific baseline when one benchmark needs
+different fixtures.
+
+## Fixtures
+
+Inputs are built by helper functions prefixed with `fixture_`. Fixtures **must**
+be marked `#[inline(never)]`. This guarantees the input-building cost is a real,
+non-eliminable function call that appears identically in both the benchmark and
+its baseline, and therefore cancels out in the subtraction.
+
+```sway
+#[inline(never)]
+fn fixture_create_src16_domain() -> SRC16Domain { /* ... */ }
+```
+
+A baseline runs exactly the same fixtures as its benchmark(s), but does **not**
+run the operation under measurement.
+
+A fixture used by more than one module is marked `pub` and imported via an
+absolute path (see [Project layout](#project-layout)). Cross-cutting fixtures
+that belong to no single type (e.g. an empty `Buffer`) live in `common`.
+
+## Keeping results
+
+The compiler will optimize away ("dead-code eliminate") any computation whose
+result is unused. If that happens, the benchmark measures nothing. We therefore
+always **keep** the result so it cannot be eliminated, using the `keep` helper
+from the shared `benchmarking` library:
+
+```sway
+#[inline(never)]
+pub fn keep<T>(_t: T) {}
+```
+
+`keep` is `#[inline(never)]`, so passing a value to it forces the value — and the
+computation that produced it — to be materialized.
+
+Do **not** rely on `let _ = ...` to keep a result. It happens to prevent
+elimination today, but that is an implementation detail of the current compiler;
+it may change, and it may already be wrong in some cases. **Always `keep`.**
+
+### `keep_ref_type` and `keep_copy_type` in baselines
+
+The baseline must mirror the benchmark's `keep` so that the keep cost cancels.
+Since `keep` is empty, its only cost is *passing the argument*, and there are
+exactly two cases:
+
+- **Reference types** — `b256`, `u256`, `String`, arrays, tuples, and any
+  struct — are passed as a pointer. Their keep cost is identical regardless of
+  the concrete type.
+- **Copy types** — `bool`, `u8` … `u64` — are passed as a `u64`. Their keep cost
+  is identical regardless of the concrete type.
+
+So the baseline never needs to construct a value of the benchmark's exact result
+type. It uses one of two helpers (also from the `benchmarking` library) matching
+the result's *category*:
+
+```sway
+#[inline(always)]
+pub fn keep_ref_type() { keep::<u256>(0u256); }   // for b256, String, structs, arrays, tuples, ...
+
+#[inline(always)]
+pub fn keep_copy_type() { keep::<u64>(0u64); }     // for bool, u8 ..= u64
+```
+
+To keep the pairing obvious, annotate each `keep_*_type()` call in a baseline
+with a comment naming the benchmark value it stands in for:
+
+```sway
+#[test]
+fn baseline__src16_domain__domain_hash() {
+    let _ = fixture_create_src16_domain();
+    keep_ref_type(); // hash
+}
+
+#[test]
+fn bench__src16_domain__domain_hash() {
+    let domain = fixture_create_src16_domain();
+
+    let hash = domain.domain_hash();
+    keep(hash);
+}
+```
+
+Here `domain_hash` returns a `b256` (a reference type), so the baseline uses
+`keep_ref_type()` annotated `// hash`.
+
+## Worked example
+
+Each benchmark/baseline pair differs only by the operation under measurement;
+everything else (fixtures, keep) is identical, so it cancels:
+
+```sway
+#[test]
+fn baseline__eip712_domain__new() {
+    let _ = fixture_create_eip712_domain_args();
+    keep_ref_type(); // domain
+}
+
+#[test]
+fn bench__eip712_domain__new() {
+    let (name, version, chain_id, verifying_contract) = fixture_create_eip712_domain_args();
+
+    let domain = EIP712Domain::new(name, version, chain_id, verifying_contract);
+    keep(domain);
+}
+```
+
+`EIP712Domain::new` returns a struct (a reference type), so the baseline keeps a
+`keep_ref_type()` placeholder. The cost of `new` is
+`gas(bench__eip712_domain__new) - gas(baseline__eip712_domain__new)`.
+
+## Length-dependent benchmarks
+
+When an operation's cost depends on the size of its input (e.g. encoding a
+dynamic array), a single net cost is only valid for one size. Instead, bench the
+operation at **two lengths** and report the input length as the final name
+segment (`__len_<n>`):
+
+```sway
+fn bench__data_encoder__dynamic_u8_array__len_1() { /* encode a 1-element Vec  */ }
+fn bench__data_encoder__dynamic_u8_array__len_8() { /* encode an 8-element Vec */ }
+```
+
+Each length has its own baseline that builds a `Vec` of that length, so each
+`net(len)` already excludes the `Vec`-building cost. From the two nets we recover
+both the per-element cost and the fixed overhead:
+
+```
+per_element    = (net(8) - net(1)) / (8 - 1)
+fixed_overhead =  net(1) - per_element
+```
+
+To make the per-length cost cancel exactly, the array fixture is **parameterized
+by length** (a single `#[inline(never)]` function called with `1` and `8`),
+rather than a separate fixture per length:
+
+```sway
+#[inline(never)]
+fn fixture_create_vec_u8(len: u64) -> Vec<u8> {
+    let mut v = Vec::new();
+    let mut i = 0;
+    while i < len {
+        v.push(0x42u8);
+        i += 1;
+    }
+    v
+}
+```

--- a/benchmarks/benchmarking/Forc.toml
+++ b/benchmarks/benchmarking/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "benchmarking.sw"
+license = "Apache-2.0"
+name = "benchmarking"
+
+[dependencies]

--- a/benchmarks/benchmarking/src/benchmarking.sw
+++ b/benchmarks/benchmarking/src/benchmarking.sw
@@ -1,0 +1,23 @@
+library;
+
+/// Forces a value — and the computation that produced it — to be materialized,
+/// so the optimizer cannot eliminate the code under measurement. `keep` is
+/// `#[inline(never)]`, so its only cost is passing the argument.
+#[inline(never)]
+pub fn keep<T>(_t: T) {}
+
+/// Stands in, in a baseline, for a benchmark's `keep` of a reference type
+/// (`b256`, `u256`, `String`, arrays, tuples, and any struct — all passed as a
+/// pointer). Its keep cost is identical regardless of the concrete type.
+#[inline(always)]
+pub fn keep_ref_type() {
+    keep::<u256>(0u256);
+}
+
+/// Stands in, in a baseline, for a benchmark's `keep` of a copy type
+/// (`bool`, `u8` ..= `u64` — all passed as a `u64`). Its keep cost is identical
+/// regardless of the concrete type.
+#[inline(always)]
+pub fn keep_copy_type() {
+    keep::<u64>(0u64);
+}

--- a/benchmarks/src16/Forc.toml
+++ b/benchmarks/src16/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "src16.sw"
+license = "Apache-2.0"
+name = "src16_benchmarks"
+
+[dependencies]
+benchmarking = { path = "../benchmarking" }
+src16 = { path = "../../standards/src16" }

--- a/benchmarks/src16/src/common.sw
+++ b/benchmarks/src16/src/common.sw
@@ -1,0 +1,18 @@
+library;
+
+use src16::*;
+
+/// The global fallback baseline (see the baseline-resolution rules in the
+/// benchmarks `README.md`). Measures the bare overhead common to every benchmark
+/// project. `forc test` does not run tests from dependency libraries, so this
+/// fallback must live in each benchmark project (it cannot be shared via the
+/// `benchmarking` library).
+#[test]
+fn baseline() {}
+
+/// Shared fixture for benchmarks that encode into a `Buffer` (e.g. the
+/// `abi_encode` benchmarks of the domain types).
+#[inline(never)]
+pub fn fixture_create_buffer() -> Buffer {
+    Buffer::new()
+}

--- a/benchmarks/src16/src/eip712_domain.sw
+++ b/benchmarks/src16/src/eip712_domain.sw
@@ -1,0 +1,71 @@
+library;
+
+use benchmarking::*;
+use src16::*;
+use std::string::*;
+
+use ::common::fixture_create_buffer;
+
+#[inline(never)]
+pub fn fixture_create_eip712_domain() -> EIP712Domain {
+    EIP712Domain::new(
+        String::from_ascii_str("SampleDomain"),
+        String::from_ascii_str("1"),
+        0,
+        ContractId::zero(),
+    )
+}
+
+#[inline(never)]
+pub fn fixture_create_eip712_domain_args() -> (String, String, u256, ContractId) {
+    (
+        String::from_ascii_str("SampleDomain"),
+        String::from_ascii_str("1"),
+        0,
+        ContractId::zero(),
+    )
+}
+
+#[test]
+fn baseline__eip712_domain__new() {
+    let _ = fixture_create_eip712_domain_args();
+    keep_ref_type(); // domain
+}
+
+#[test]
+fn bench__eip712_domain__new() {
+    let (name, version, chain_id, verifying_contract) = fixture_create_eip712_domain_args();
+
+    let domain = EIP712Domain::new(name, version, chain_id, verifying_contract);
+    keep(domain);
+}
+
+#[test]
+fn baseline__eip712_domain__abi_encode() {
+    let _ = fixture_create_eip712_domain();
+    let _ = fixture_create_buffer();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__eip712_domain__abi_encode() {
+    let domain = fixture_create_eip712_domain();
+    let buffer = fixture_create_buffer();
+
+    let encoded = domain.abi_encode(buffer);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__eip712_domain__domain_hash() {
+    let _ = fixture_create_eip712_domain();
+    keep_ref_type(); // hash
+}
+
+#[test]
+fn bench__eip712_domain__domain_hash() {
+    let domain = fixture_create_eip712_domain();
+
+    let hash = domain.domain_hash();
+    keep(hash);
+}

--- a/benchmarks/src16/src/src16.sw
+++ b/benchmarks/src16/src/src16.sw
@@ -1,0 +1,7 @@
+library;
+
+pub mod common;
+pub mod src16_domain;
+pub mod eip712_domain;
+pub mod src16_payload;
+pub mod typed_data_encoder;

--- a/benchmarks/src16/src/src16_domain.sw
+++ b/benchmarks/src16/src/src16_domain.sw
@@ -1,0 +1,47 @@
+library;
+
+use benchmarking::*;
+use src16::*;
+use std::string::*;
+
+use ::common::fixture_create_buffer;
+
+#[inline(never)]
+pub fn fixture_create_src16_domain() -> SRC16Domain {
+    SRC16Domain::new(
+        String::from_ascii_str("SampleDomain"),
+        String::from_ascii_str("1"),
+        0,
+        ContractId::zero(),
+    )
+}
+
+#[test]
+fn baseline__src16_domain__abi_encode() {
+    let _ = fixture_create_src16_domain();
+    let _ = fixture_create_buffer();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__src16_domain__abi_encode() {
+    let domain = fixture_create_src16_domain();
+    let buffer = fixture_create_buffer();
+
+    let encoded = domain.abi_encode(buffer);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__src16_domain__domain_hash() {
+    let _ = fixture_create_src16_domain();
+    keep_ref_type(); // hash
+}
+
+#[test]
+fn bench__src16_domain__domain_hash() {
+    let domain = fixture_create_src16_domain();
+
+    let hash = domain.domain_hash();
+    keep(hash);
+}

--- a/benchmarks/src16/src/src16_payload.sw
+++ b/benchmarks/src16/src/src16_payload.sw
@@ -1,0 +1,51 @@
+library;
+
+use benchmarking::*;
+use src16::*;
+
+use ::src16_domain::fixture_create_src16_domain;
+use ::eip712_domain::fixture_create_eip712_domain;
+
+#[inline(never)]
+fn fixture_create_src16_payload_with_src16_domain() -> SRC16Payload<SRC16Domain> {
+    SRC16Payload {
+        domain: fixture_create_src16_domain(),
+        data_hash: 0x1616161616161616161616161616161616161616161616161616161616161616,
+    }
+}
+
+#[inline(never)]
+fn fixture_create_src16_payload_with_eip712_domain() -> SRC16Payload<EIP712Domain> {
+    SRC16Payload {
+        domain: fixture_create_eip712_domain(),
+        data_hash: 0x1616161616161616161616161616161616161616161616161616161616161616,
+    }
+}
+
+#[test]
+fn baseline__src16_payload__encode_hash__src16_domain() {
+    let _ = fixture_create_src16_payload_with_src16_domain();
+    keep_ref_type(); // hash
+}
+
+#[test]
+fn bench__src16_payload__encode_hash__src16_domain() {
+    let payload = fixture_create_src16_payload_with_src16_domain();
+
+    let hash = payload.encode_hash();
+    keep(hash);
+}
+
+#[test]
+fn baseline__src16_payload__encode_hash__eip712_domain() {
+    let _ = fixture_create_src16_payload_with_eip712_domain();
+    keep_ref_type(); // hash
+}
+
+#[test]
+fn bench__src16_payload__encode_hash__eip712_domain() {
+    let payload = fixture_create_src16_payload_with_eip712_domain();
+
+    let hash = payload.encode_hash();
+    keep(hash);
+}

--- a/benchmarks/src16/src/typed_data_encoder.sw
+++ b/benchmarks/src16/src/typed_data_encoder.sw
@@ -1,0 +1,653 @@
+library;
+
+use benchmarking::*;
+use src16::*;
+use std::string::*;
+
+// Fixtures for `DataEncoder` (the `TypedDataEncoder` implementation).
+
+#[inline(never)]
+fn fixture_create_string() -> String {
+    String::from_ascii_str("SampleStringValueForEncoding")
+}
+
+#[inline(never)]
+fn fixture_create_u8() -> u8 {
+    0x42u8
+}
+
+#[inline(never)]
+fn fixture_create_u16() -> u16 {
+    0x4242u16
+}
+
+#[inline(never)]
+fn fixture_create_u32() -> u32 {
+    0x42424242u32
+}
+
+#[inline(never)]
+fn fixture_create_u64() -> u64 {
+    0x4242424242424242u64
+}
+
+#[inline(never)]
+fn fixture_create_u256() -> u256 {
+    0x4242424242424242424242424242424242424242424242424242424242424242u256
+}
+
+#[inline(never)]
+fn fixture_create_b256() -> b256 {
+    0x4242424242424242424242424242424242424242424242424242424242424242
+}
+
+#[inline(never)]
+fn fixture_create_bool() -> bool {
+    true
+}
+
+#[inline(never)]
+fn fixture_create_address() -> Address {
+    Address::zero()
+}
+
+#[inline(never)]
+fn fixture_create_contract_id() -> ContractId {
+    ContractId::zero()
+}
+
+#[inline(never)]
+fn fixture_create_identity() -> Identity {
+    Identity::Address(Address::zero())
+}
+
+// Dynamic-array fixtures are parameterized by length so that the same
+// (`#[inline(never)]`) build cost cancels between a benchmark and its baseline
+// at each length. Benching at two lengths lets us derive the per-element cost
+// (slope) and the fixed overhead (intercept) of the `dynamic_*_array` encoders.
+
+#[inline(never)]
+fn fixture_create_vec_u8(len: u64) -> Vec<u8> {
+    let mut v = Vec::new();
+    let mut i = 0;
+    while i < len {
+        v.push(0x42u8);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn fixture_create_vec_u16(len: u64) -> Vec<u16> {
+    let mut v = Vec::new();
+    let mut i = 0;
+    while i < len {
+        v.push(0x4242u16);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn fixture_create_vec_u32(len: u64) -> Vec<u32> {
+    let mut v = Vec::new();
+    let mut i = 0;
+    while i < len {
+        v.push(0x42424242u32);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn fixture_create_vec_u64(len: u64) -> Vec<u64> {
+    let mut v = Vec::new();
+    let mut i = 0;
+    while i < len {
+        v.push(0x4242424242424242u64);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn fixture_create_vec_u256(len: u64) -> Vec<u256> {
+    let mut v = Vec::new();
+    let mut i = 0;
+    while i < len {
+        v.push(0x4242424242424242424242424242424242424242424242424242424242424242u256);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn fixture_create_vec_b256(len: u64) -> Vec<b256> {
+    let mut v = Vec::new();
+    let mut i = 0;
+    while i < len {
+        v.push(0x4242424242424242424242424242424242424242424242424242424242424242);
+        i += 1;
+    }
+    v
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_string() {
+    let _ = fixture_create_string();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_string() {
+    let value = fixture_create_string();
+
+    let encoded = DataEncoder::encode_string(value);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_u8() {
+    let _ = fixture_create_u8();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_u8() {
+    let value = fixture_create_u8();
+
+    let encoded = DataEncoder::encode_u8(value);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_u16() {
+    let _ = fixture_create_u16();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_u16() {
+    let value = fixture_create_u16();
+
+    let encoded = DataEncoder::encode_u16(value);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_u32() {
+    let _ = fixture_create_u32();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_u32() {
+    let value = fixture_create_u32();
+
+    let encoded = DataEncoder::encode_u32(value);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_u64() {
+    let _ = fixture_create_u64();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_u64() {
+    let value = fixture_create_u64();
+
+    let encoded = DataEncoder::encode_u64(value);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_u256() {
+    let _ = fixture_create_u256();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_u256() {
+    let value = fixture_create_u256();
+
+    let encoded = DataEncoder::encode_u256(value);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_b256() {
+    let _ = fixture_create_b256();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_b256() {
+    let value = fixture_create_b256();
+
+    let encoded = DataEncoder::encode_b256(value);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_bool() {
+    let _ = fixture_create_bool();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_bool() {
+    let value = fixture_create_bool();
+
+    let encoded = DataEncoder::encode_bool(value);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_address() {
+    let _ = fixture_create_address();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_address() {
+    let value = fixture_create_address();
+
+    let encoded = DataEncoder::encode_address(value);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_contract_id() {
+    let _ = fixture_create_contract_id();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_contract_id() {
+    let value = fixture_create_contract_id();
+
+    let encoded = DataEncoder::encode_contract_id(value);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__encode_identity() {
+    let _ = fixture_create_identity();
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__encode_identity() {
+    let value = fixture_create_identity();
+
+    let encoded = DataEncoder::encode_identity(value);
+    keep(encoded);
+}
+
+// The `dynamic_*_array` encoders are length-dependent. Each is benched at two
+// lengths (1 and 8). Per-element cost = (net(8) - net(1)) / (8 - 1), and the
+// fixed overhead = net(1) - per-element cost, where net(len) is
+// `gas(bench __len) - gas(baseline __len)`.
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_u8_array__len_1() {
+    let _ = fixture_create_vec_u8(1);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_u8_array__len_1() {
+    let array = fixture_create_vec_u8(1);
+
+    let encoded = DataEncoder::dynamic_u8_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_u8_array__len_8() {
+    let _ = fixture_create_vec_u8(8);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_u8_array__len_8() {
+    let array = fixture_create_vec_u8(8);
+
+    let encoded = DataEncoder::dynamic_u8_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_u16_array__len_1() {
+    let _ = fixture_create_vec_u16(1);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_u16_array__len_1() {
+    let array = fixture_create_vec_u16(1);
+
+    let encoded = DataEncoder::dynamic_u16_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_u16_array__len_8() {
+    let _ = fixture_create_vec_u16(8);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_u16_array__len_8() {
+    let array = fixture_create_vec_u16(8);
+
+    let encoded = DataEncoder::dynamic_u16_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_u32_array__len_1() {
+    let _ = fixture_create_vec_u32(1);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_u32_array__len_1() {
+    let array = fixture_create_vec_u32(1);
+
+    let encoded = DataEncoder::dynamic_u32_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_u32_array__len_8() {
+    let _ = fixture_create_vec_u32(8);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_u32_array__len_8() {
+    let array = fixture_create_vec_u32(8);
+
+    let encoded = DataEncoder::dynamic_u32_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_u64_array__len_1() {
+    let _ = fixture_create_vec_u64(1);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_u64_array__len_1() {
+    let array = fixture_create_vec_u64(1);
+
+    let encoded = DataEncoder::dynamic_u64_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_u64_array__len_8() {
+    let _ = fixture_create_vec_u64(8);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_u64_array__len_8() {
+    let array = fixture_create_vec_u64(8);
+
+    let encoded = DataEncoder::dynamic_u64_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_u256_array__len_1() {
+    let _ = fixture_create_vec_u256(1);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_u256_array__len_1() {
+    let array = fixture_create_vec_u256(1);
+
+    let encoded = DataEncoder::dynamic_u256_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_u256_array__len_8() {
+    let _ = fixture_create_vec_u256(8);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_u256_array__len_8() {
+    let array = fixture_create_vec_u256(8);
+
+    let encoded = DataEncoder::dynamic_u256_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_b256_array__len_1() {
+    let _ = fixture_create_vec_b256(1);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_b256_array__len_1() {
+    let array = fixture_create_vec_b256(1);
+
+    let encoded = DataEncoder::dynamic_b256_array(array);
+    keep(encoded);
+}
+
+#[test]
+fn baseline__typed_data_encoder__dynamic_b256_array__len_8() {
+    let _ = fixture_create_vec_b256(8);
+    keep_ref_type(); // encoded
+}
+
+#[test]
+fn bench__typed_data_encoder__dynamic_b256_array__len_8() {
+    let array = fixture_create_vec_b256(8);
+
+    let encoded = DataEncoder::dynamic_b256_array(array);
+    keep(encoded);
+}
+
+// Aggregate benchmarks: call every `TypedDataEncoder` method in a single test.
+//
+// `__all` calls each encoder once. A function called from exactly one site is
+// always inlined, so this measures the encoders as inlined into one body, where
+// the compiler may both optimize across them and have `asm` blocks interfere
+// with optimizations.
+//
+// `__all_twice` calls each encoder twice (two call sites). Two call sites can
+// stop the inliner from inlining, keeping each encoder (and its `asm` block) as
+// an out-of-line call. Comparing `net(all_twice)` against `2 * net(all)` exposes
+// how much inlining the `asm`-heavy encoders helps or hurts.
+//
+// Dynamic arrays are exercised at length 1 here; their length scaling is already
+// characterized by the dedicated `__len_*` benchmarks above.
+
+#[test]
+fn baseline__typed_data_encoder__all() {
+    let _ = fixture_create_string();
+    let _ = fixture_create_u8();
+    let _ = fixture_create_u16();
+    let _ = fixture_create_u32();
+    let _ = fixture_create_u64();
+    let _ = fixture_create_u256();
+    let _ = fixture_create_b256();
+    let _ = fixture_create_bool();
+    let _ = fixture_create_address();
+    let _ = fixture_create_contract_id();
+    let _ = fixture_create_identity();
+    let _ = fixture_create_vec_u8(1);
+    let _ = fixture_create_vec_u16(1);
+    let _ = fixture_create_vec_u32(1);
+    let _ = fixture_create_vec_u64(1);
+    let _ = fixture_create_vec_u256(1);
+    let _ = fixture_create_vec_b256(1);
+
+    keep_ref_type(); // encode_string
+    keep_ref_type(); // encode_u8
+    keep_ref_type(); // encode_u16
+    keep_ref_type(); // encode_u32
+    keep_ref_type(); // encode_u64
+    keep_ref_type(); // encode_u256
+    keep_ref_type(); // encode_b256
+    keep_ref_type(); // encode_bool
+    keep_ref_type(); // encode_address
+    keep_ref_type(); // encode_contract_id
+    keep_ref_type(); // encode_identity
+    keep_ref_type(); // dynamic_u8_array
+    keep_ref_type(); // dynamic_u16_array
+    keep_ref_type(); // dynamic_u32_array
+    keep_ref_type(); // dynamic_u64_array
+    keep_ref_type(); // dynamic_u256_array
+    keep_ref_type(); // dynamic_b256_array
+}
+
+#[test]
+fn bench__typed_data_encoder__all() {
+    keep(DataEncoder::encode_string(fixture_create_string()));
+    keep(DataEncoder::encode_u8(fixture_create_u8()));
+    keep(DataEncoder::encode_u16(fixture_create_u16()));
+    keep(DataEncoder::encode_u32(fixture_create_u32()));
+    keep(DataEncoder::encode_u64(fixture_create_u64()));
+    keep(DataEncoder::encode_u256(fixture_create_u256()));
+    keep(DataEncoder::encode_b256(fixture_create_b256()));
+    keep(DataEncoder::encode_bool(fixture_create_bool()));
+    keep(DataEncoder::encode_address(fixture_create_address()));
+    keep(DataEncoder::encode_contract_id(fixture_create_contract_id()));
+    keep(DataEncoder::encode_identity(fixture_create_identity()));
+    keep(DataEncoder::dynamic_u8_array(fixture_create_vec_u8(1)));
+    keep(DataEncoder::dynamic_u16_array(fixture_create_vec_u16(1)));
+    keep(DataEncoder::dynamic_u32_array(fixture_create_vec_u32(1)));
+    keep(DataEncoder::dynamic_u64_array(fixture_create_vec_u64(1)));
+    keep(DataEncoder::dynamic_u256_array(fixture_create_vec_u256(1)));
+    keep(DataEncoder::dynamic_b256_array(fixture_create_vec_b256(1)));
+}
+
+#[test]
+fn baseline__typed_data_encoder__all_twice() {
+    // Call 1
+    let _ = fixture_create_string();
+    let _ = fixture_create_u8();
+    let _ = fixture_create_u16();
+    let _ = fixture_create_u32();
+    let _ = fixture_create_u64();
+    let _ = fixture_create_u256();
+    let _ = fixture_create_b256();
+    let _ = fixture_create_bool();
+    let _ = fixture_create_address();
+    let _ = fixture_create_contract_id();
+    let _ = fixture_create_identity();
+    let _ = fixture_create_vec_u8(1);
+    let _ = fixture_create_vec_u16(1);
+    let _ = fixture_create_vec_u32(1);
+    let _ = fixture_create_vec_u64(1);
+    let _ = fixture_create_vec_u256(1);
+    let _ = fixture_create_vec_b256(1);
+
+    keep_ref_type(); // encode_string
+    keep_ref_type(); // encode_u8
+    keep_ref_type(); // encode_u16
+    keep_ref_type(); // encode_u32
+    keep_ref_type(); // encode_u64
+    keep_ref_type(); // encode_u256
+    keep_ref_type(); // encode_b256
+    keep_ref_type(); // encode_bool
+    keep_ref_type(); // encode_address
+    keep_ref_type(); // encode_contract_id
+    keep_ref_type(); // encode_identity
+    keep_ref_type(); // dynamic_u8_array
+    keep_ref_type(); // dynamic_u16_array
+    keep_ref_type(); // dynamic_u32_array
+    keep_ref_type(); // dynamic_u64_array
+    keep_ref_type(); // dynamic_u256_array
+    keep_ref_type(); // dynamic_b256_array
+
+    // Call 2
+    let _ = fixture_create_string();
+    let _ = fixture_create_u8();
+    let _ = fixture_create_u16();
+    let _ = fixture_create_u32();
+    let _ = fixture_create_u64();
+    let _ = fixture_create_u256();
+    let _ = fixture_create_b256();
+    let _ = fixture_create_bool();
+    let _ = fixture_create_address();
+    let _ = fixture_create_contract_id();
+    let _ = fixture_create_identity();
+    let _ = fixture_create_vec_u8(1);
+    let _ = fixture_create_vec_u16(1);
+    let _ = fixture_create_vec_u32(1);
+    let _ = fixture_create_vec_u64(1);
+    let _ = fixture_create_vec_u256(1);
+    let _ = fixture_create_vec_b256(1);
+
+    keep_ref_type(); // encode_string
+    keep_ref_type(); // encode_u8
+    keep_ref_type(); // encode_u16
+    keep_ref_type(); // encode_u32
+    keep_ref_type(); // encode_u64
+    keep_ref_type(); // encode_u256
+    keep_ref_type(); // encode_b256
+    keep_ref_type(); // encode_bool
+    keep_ref_type(); // encode_address
+    keep_ref_type(); // encode_contract_id
+    keep_ref_type(); // encode_identity
+    keep_ref_type(); // dynamic_u8_array
+    keep_ref_type(); // dynamic_u16_array
+    keep_ref_type(); // dynamic_u32_array
+    keep_ref_type(); // dynamic_u64_array
+    keep_ref_type(); // dynamic_u256_array
+    keep_ref_type(); // dynamic_b256_array
+}
+
+#[test]
+fn bench__typed_data_encoder__all_twice() {
+    // Call 1
+    keep(DataEncoder::encode_string(fixture_create_string()));
+    keep(DataEncoder::encode_u8(fixture_create_u8()));
+    keep(DataEncoder::encode_u16(fixture_create_u16()));
+    keep(DataEncoder::encode_u32(fixture_create_u32()));
+    keep(DataEncoder::encode_u64(fixture_create_u64()));
+    keep(DataEncoder::encode_u256(fixture_create_u256()));
+    keep(DataEncoder::encode_b256(fixture_create_b256()));
+    keep(DataEncoder::encode_bool(fixture_create_bool()));
+    keep(DataEncoder::encode_address(fixture_create_address()));
+    keep(DataEncoder::encode_contract_id(fixture_create_contract_id()));
+    keep(DataEncoder::encode_identity(fixture_create_identity()));
+    keep(DataEncoder::dynamic_u8_array(fixture_create_vec_u8(1)));
+    keep(DataEncoder::dynamic_u16_array(fixture_create_vec_u16(1)));
+    keep(DataEncoder::dynamic_u32_array(fixture_create_vec_u32(1)));
+    keep(DataEncoder::dynamic_u64_array(fixture_create_vec_u64(1)));
+    keep(DataEncoder::dynamic_u256_array(fixture_create_vec_u256(1)));
+    keep(DataEncoder::dynamic_b256_array(fixture_create_vec_b256(1)));
+
+    // Call 2
+    keep(DataEncoder::encode_string(fixture_create_string()));
+    keep(DataEncoder::encode_u8(fixture_create_u8()));
+    keep(DataEncoder::encode_u16(fixture_create_u16()));
+    keep(DataEncoder::encode_u32(fixture_create_u32()));
+    keep(DataEncoder::encode_u64(fixture_create_u64()));
+    keep(DataEncoder::encode_u256(fixture_create_u256()));
+    keep(DataEncoder::encode_b256(fixture_create_b256()));
+    keep(DataEncoder::encode_bool(fixture_create_bool()));
+    keep(DataEncoder::encode_address(fixture_create_address()));
+    keep(DataEncoder::encode_contract_id(fixture_create_contract_id()));
+    keep(DataEncoder::encode_identity(fixture_create_identity()));
+    keep(DataEncoder::dynamic_u8_array(fixture_create_vec_u8(1)));
+    keep(DataEncoder::dynamic_u16_array(fixture_create_vec_u16(1)));
+    keep(DataEncoder::dynamic_u32_array(fixture_create_vec_u32(1)));
+    keep(DataEncoder::dynamic_u64_array(fixture_create_vec_u64(1)));
+    keep(DataEncoder::dynamic_u256_array(fixture_create_vec_u256(1)));
+    keep(DataEncoder::dynamic_b256_array(fixture_create_vec_b256(1)));
+}

--- a/justfile
+++ b/justfile
@@ -15,3 +15,8 @@ build-examples *args:
 alias ba := build-all
 # builds the standards and the examples; e.g.: `just ba --release`
 build-all *args: (build-standards args) (build-examples args)
+
+alias b := bench
+# runs a benchmark project and prints the results; e.g.: `just b -p benchmarks/src16 -f ascii`
+bench *args:
+    ./scripts/forc-bench.sh {{ args }}

--- a/scripts/forc-bench.sh
+++ b/scripts/forc-bench.sh
@@ -1,0 +1,443 @@
+#!/usr/bin/env bash
+
+# Benchmark runner for the lightweight, convention-based Sway benchmarks (see
+# `benchmarks/README.md`).
+#
+# Sway has no native benchmarking (`forc bench`), so benchmarks are encoded as
+# `forc test` unit tests following a naming convention:
+#
+#     bench__<group>__<name>       a benchmark
+#     baseline[__<group>[__<name>]] its baseline (fixture + keep overhead)
+#
+# The real cost of a benchmark is `gas(bench) - gas(<matching baseline>)`, where
+# the matching baseline is found by most-specific-prefix match (walking the name
+# from the most specific segment down to the bare `baseline` fallback). This
+# script runs the tests, computes those net costs, and prints them in one or
+# more formats.
+#
+# Usage:
+#
+#     ./scripts/forc-bench.sh -p <project> [options]
+#
+# Options:
+#
+#     -p, --path <project>          Path to the benchmark project (required),
+#                                   e.g. `benchmarks/src16`.
+#         --experimental <flags>    Forwarded to `forc test` as
+#                                   `--experimental <flags>` (optional).
+#         --no-experimental <flags> Forwarded to `forc test` as
+#                                   `--no-experimental <flags>` (optional).
+#     -f, --format <fmt>...         One or more of: raw csv ascii md json
+#                                   (default: raw). May be repeated or given as
+#                                   a space-separated list, e.g. `-f ascii json`.
+#     -h, --help                    Show this help.
+#
+# Formats (the benchmark is pretty-printed as `<group>::<name>` everywhere):
+#
+#     raw    The raw `forc test` output, verbatim.
+#     csv    `bench,gas` CSV (with header), gas being the net cost.
+#     ascii  A `Bench | Gas` ASCII table.
+#     md     A `Bench | Gas` Markdown table.
+#     json   `[{"bench": "<group>::<name>", "gas": <gas>}, ...]`.
+#
+# Diagnostics (version warnings, progress) go to stderr, so stdout carries only
+# the requested format(s) and stays pipe-clean for a single machine-readable
+# format. When more than one format is requested, each is preceded by a
+# `===== <FORMAT> =====` header.
+#
+# Before reporting, the runner enforces the benchmark conventions: every
+# `bench`/`baseline` test name must be well-formed, every benchmark must resolve
+# to a baseline, and every `fixture_*` function must be marked `#[inline(never)]`.
+# On any violation it prints the offenders to stderr and exits with code 3.
+#
+# In the end this invokes:
+#
+#     forc test --release --terse --path <project> \
+#         [--experimental <flags>] [--no-experimental <flags>]
+
+set -u
+
+# The expected `forc` version. If the installed `forc` differs, a warning is
+# printed (to stderr) before running the benchmarks.
+FORC_VERSION="0.71.2"
+
+VALID_FORMATS="raw csv ascii md json"
+
+usage() {
+    # Print the leading comment block (the usage text) without the shebang.
+    sed -n '3,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+err() {
+    echo "ERROR: $*" >&2
+}
+
+require_value() {
+    # require_value <flag> <count-of-remaining-args>
+    if [[ "$2" -lt 2 ]]; then
+        err "missing value for $1"
+        exit 2
+    fi
+}
+
+PATH_ARG=""
+EXPERIMENTAL=""
+NO_EXPERIMENTAL=""
+FORMATS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--path)
+            require_value "$1" "$#"
+            PATH_ARG="$2"
+            shift 2
+            ;;
+        --experimental)
+            require_value "$1" "$#"
+            EXPERIMENTAL="$2"
+            shift 2
+            ;;
+        --no-experimental)
+            require_value "$1" "$#"
+            NO_EXPERIMENTAL="$2"
+            shift 2
+            ;;
+        -f|--format)
+            shift
+            # Consume following tokens until the next flag (so `-f ascii json`
+            # works), while also supporting repeated `-f` flags.
+            if [[ $# -eq 0 || "$1" == -* ]]; then
+                err "missing value for --format"
+                exit 2
+            fi
+            while [[ $# -gt 0 && "$1" != -* ]]; do
+                FORMATS+=("$1")
+                shift
+            done
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown argument: $1"
+            echo >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "${PATH_ARG}" ]]; then
+    err "missing required --path <project>"
+    echo >&2
+    usage >&2
+    exit 2
+fi
+
+# Default to `raw` when no format is requested.
+if [[ ${#FORMATS[@]} -eq 0 ]]; then
+    FORMATS=("raw")
+fi
+
+# Validate formats and drop duplicates while preserving first-seen order.
+unique_formats=()
+for fmt in "${FORMATS[@]}"; do
+    case " ${VALID_FORMATS} " in
+        *" ${fmt} "*) ;;
+        *)
+            err "invalid format '${fmt}'. Valid formats: ${VALID_FORMATS}."
+            exit 2
+            ;;
+    esac
+    seen=false
+    for u in "${unique_formats[@]:-}"; do
+        [[ "${u}" == "${fmt}" ]] && seen=true && break
+    done
+    [[ "${seen}" == false ]] && unique_formats+=("${fmt}")
+done
+FORMATS=("${unique_formats[@]}")
+
+if ! command -v forc >/dev/null 2>&1; then
+    err "'forc' was not found in PATH. Please install forc ${FORC_VERSION}."
+    exit 1
+fi
+
+installed_forc="$(forc --version 2>/dev/null | awk '{print $NF}')"
+if [[ "${installed_forc}" != "${FORC_VERSION}" ]]; then
+    echo "WARNING: Expected forc version ${FORC_VERSION}, but found '${installed_forc}'." >&2
+    echo "         Benchmarks are measured with forc ${FORC_VERSION}; results might differ." >&2
+    echo >&2
+fi
+
+FORC_ARGS=(test --release --terse --path "${PATH_ARG}")
+[[ -n "${EXPERIMENTAL}" ]] && FORC_ARGS+=(--experimental "${EXPERIMENTAL}")
+[[ -n "${NO_EXPERIMENTAL}" ]] && FORC_ARGS+=(--no-experimental "${NO_EXPERIMENTAL}")
+
+out_file="$(mktemp)"
+trap 'rm -f "${out_file}"' EXIT
+
+echo "Running: forc ${FORC_ARGS[*]}" >&2
+forc "${FORC_ARGS[@]}" > "${out_file}" 2>&1
+status=$?
+
+if [[ ${status} -ne 0 ]]; then
+    err "'forc test' failed (exit ${status}). Output:"
+    cat "${out_file}" >&2
+    exit "${status}"
+fi
+
+# awk program that parses the captured `forc test` output, computes the net gas
+# per benchmark (bench minus its most-specific baseline), and prints one format.
+read -r -d '' AWK_PROG <<'AWK'
+function chop(s,   i, last) {
+    # Drop the last `_`-delimited token (and the `_`). Used to walk a baseline
+    # name from most specific to least specific.
+    last = 0
+    for (i = 1; i <= length(s); i++)
+        if (substr(s, i, 1) == "_") last = i
+    if (last == 0) return s
+    return substr(s, 1, last - 1)
+}
+
+function resolve(bench,   cand) {
+    # Most-specific-prefix match against the known baselines.
+    cand = bench
+    sub(/^bench__/, "baseline__", cand)
+    while (index(cand, "_") > 0) {
+        if (cand in basegas) return basegas[cand]
+        cand = chop(cand)
+    }
+    if (cand in basegas) return basegas[cand]   # the bare `baseline`
+    return "NONE"
+}
+
+function prettify(bench,   s) {
+    # `bench__<group>__<name>` -> `<group>::<name>`.
+    s = bench
+    sub(/^bench__/, "", s)
+    sub(/__/, "::", s)
+    return s
+}
+
+function rep(n, ch,   i, s) {
+    s = ""
+    for (i = 0; i < n; i++) s = s ch
+    return s
+}
+
+{
+    line = $0
+    gsub(/\033\[[0-9;]*m/, "", line)   # strip ANSI color codes
+    $0 = line                          # re-split into fields
+}
+
+$1 == "test" && $4 == "ok" && $NF == "gas)" {
+    name = $2
+    gas = $(NF - 1) + 0
+    if (name ~ /^bench__/) {
+        order[++n] = name
+        benchgas[name] = gas
+    } else if (name == "baseline" || name ~ /^baseline__/) {
+        basegas[name] = gas
+    }
+}
+
+END {
+    # Compute net costs. A negative net means the operation is effectively free
+    # (the subtraction landed on the measurement floor), so report it as 0.
+    maxbench = length("Bench")
+    maxgas = length("Gas")
+    for (i = 1; i <= n; i++) {
+        b = order[i]
+        base = resolve(b)
+        if (base == "NONE") {
+            print "WARNING: no baseline found for " b "; using raw gas." > "/dev/stderr"
+            net = benchgas[b]
+        } else {
+            net = benchgas[b] - base
+        }
+        if (net < 0) net = 0
+        pretty[i] = prettify(b)
+        value[i] = net
+        if (length(pretty[i]) > maxbench) maxbench = length(pretty[i])
+        if (length(net "") > maxgas) maxgas = length(net "")
+    }
+
+    # Sort indices by pretty name (insertion sort; n is small). `raw` is printed
+    # verbatim elsewhere and keeps source order; every other format is sorted.
+    for (i = 1; i <= n; i++) ord[i] = i
+    for (i = 2; i <= n; i++) {
+        key = ord[i]
+        j = i - 1
+        while (j >= 1 && pretty[ord[j]] > pretty[key]) {
+            ord[j + 1] = ord[j]
+            j--
+        }
+        ord[j + 1] = key
+    }
+
+    if (fmt == "csv") {
+        print "bench,gas"
+        for (k = 1; k <= n; k++) print pretty[ord[k]] "," value[ord[k]]
+    } else if (fmt == "md") {
+        print "| Bench | Gas |"
+        print "| --- | --: |"
+        for (k = 1; k <= n; k++) printf("| %s | %d |\n", pretty[ord[k]], value[ord[k]])
+    } else if (fmt == "json") {
+        printf("[")
+        for (k = 1; k <= n; k++) {
+            printf("%s\n  {\"bench\": \"%s\", \"gas\": %d}", (k == 1 ? "" : ","), pretty[ord[k]], value[ord[k]])
+        }
+        printf("%s]\n", (n == 0 ? "" : "\n"))
+    } else if (fmt == "ascii") {
+        border = "+" rep(maxbench + 2, "-") "+" rep(maxgas + 2, "-") "+"
+        print border
+        printf("| %-*s | %*s |\n", maxbench, "Bench", maxgas, "Gas")
+        print border
+        for (k = 1; k <= n; k++)
+            printf("| %-*s | %*d |\n", maxbench, pretty[ord[k]], maxgas, value[ord[k]])
+        print border
+    }
+}
+AWK
+
+# awk program that validates benchmark/baseline test names. Prints one offending
+# name per line (to stdout); a benchmark must be `bench__<group>__<name>` and a
+# baseline `baseline`, `baseline__<group>`, or `baseline__<group>__<name>`.
+read -r -d '' NAME_CHECK_AWK <<'AWK'
+function valid_bench(n,   rest, p, g, nm) {
+    if (n !~ /^bench__/) return 0
+    rest = substr(n, 8)            # drop the leading "bench__"
+    p = index(rest, "__")
+    if (p == 0) return 0           # no <group>__<name> separator
+    g = substr(rest, 1, p - 1)
+    nm = substr(rest, p + 2)
+    return (length(g) > 0 && length(nm) > 0)
+}
+{ line = $0; gsub(/\033\[[0-9;]*m/, "", line); $0 = line }
+$1 == "test" && $4 == "ok" && $NF == "gas)" {
+    name = $2
+    if (name ~ /^bench/) {
+        if (!valid_bench(name)) print name "  (expected bench__<group>__<name>)"
+    } else if (name ~ /^baseline/) {
+        if (name != "baseline" && name !~ /^baseline__.+/)
+            print name "  (expected baseline, baseline__<group>, or baseline__<group>__<name>)"
+    }
+}
+AWK
+
+# awk program that checks every benchmark resolves to a baseline (by the same
+# most-specific-prefix walk the formatter uses, down to the bare `baseline`
+# fallback). Prints each benchmark with no matching baseline (to stdout).
+read -r -d '' BASELINE_CHECK_AWK <<'AWK'
+function valid_bench(n,   rest, p, g, nm) {
+    if (n !~ /^bench__/) return 0
+    rest = substr(n, 8)
+    p = index(rest, "__")
+    if (p == 0) return 0
+    g = substr(rest, 1, p - 1)
+    nm = substr(rest, p + 2)
+    return (length(g) > 0 && length(nm) > 0)
+}
+function chop(s,   i, last) {
+    last = 0
+    for (i = 1; i <= length(s); i++)
+        if (substr(s, i, 1) == "_") last = i
+    if (last == 0) return s
+    return substr(s, 1, last - 1)
+}
+function has_baseline(bench,   cand) {
+    cand = bench
+    sub(/^bench__/, "baseline__", cand)
+    while (index(cand, "_") > 0) {
+        if (cand in base) return 1
+        cand = chop(cand)
+    }
+    return (cand in base)          # the bare `baseline`
+}
+{ line = $0; gsub(/\033\[[0-9;]*m/, "", line); $0 = line }
+$1 == "test" && $4 == "ok" && $NF == "gas)" {
+    name = $2
+    if (valid_bench(name)) benches[++nb] = name
+    else if (name == "baseline" || name ~ /^baseline__/) base[name] = 1
+}
+END {
+    for (i = 1; i <= nb; i++)
+        if (!has_baseline(benches[i])) print benches[i]
+}
+AWK
+
+# awk program that checks every `fixture_*` function is marked `#[inline(never)]`.
+# It accumulates the attribute lines (`#[...]`) directly above a definition and,
+# when it reaches a `fn fixture_...`, verifies one of them is `#[inline(never)]`.
+# Prints `<file>:<line>: <def>` for each offending fixture (to stdout).
+read -r -d '' FIXTURE_CHECK_AWK <<'AWK'
+/^[[:space:]]*#\[/ { attrs = attrs $0; next }   # attribute line: accumulate
+/^[[:space:]]*$/   { next }                     # blank line: keep accumulated attrs
+{
+    if ($0 ~ /^[[:space:]]*(pub[[:space:]]+)?fn[[:space:]]+fixture_/) {
+        if (attrs !~ /#\[inline\(never\)\]/) {
+            def = $0
+            sub(/^[[:space:]]+/, "", def)
+            printf("%s:%d: %s\n", FILENAME, FNR, def)
+        }
+    }
+    attrs = ""                                  # any code line resets the attrs
+}
+AWK
+
+# Enforce the benchmark conventions before reporting (see `benchmarks/README.md`).
+name_violations="$(awk "${NAME_CHECK_AWK}" "${out_file}")"
+baseline_violations="$(awk "${BASELINE_CHECK_AWK}" "${out_file}")"
+
+sw_files=()
+while IFS= read -r -d '' f; do
+    sw_files+=("${f}")
+done < <(find "${PATH_ARG%/}/src" -type f -name '*.sw' -print0 2>/dev/null)
+
+fixture_violations=""
+if [[ ${#sw_files[@]} -gt 0 ]]; then
+    fixture_violations="$(awk "${FIXTURE_CHECK_AWK}" "${sw_files[@]}")"
+fi
+
+if [[ -n "${name_violations}" || -n "${baseline_violations}" || -n "${fixture_violations}" ]]; then
+    err "benchmark convention violations found:"
+    if [[ -n "${name_violations}" ]]; then
+        echo >&2
+        echo "  Malformed benchmark/baseline test names:" >&2
+        while IFS= read -r v; do echo "    ${v}" >&2; done <<< "${name_violations}"
+    fi
+    if [[ -n "${baseline_violations}" ]]; then
+        echo >&2
+        echo "  Benchmarks with no matching baseline (need a baseline, e.g. the bare 'baseline'):" >&2
+        while IFS= read -r v; do echo "    ${v}" >&2; done <<< "${baseline_violations}"
+    fi
+    if [[ -n "${fixture_violations}" ]]; then
+        echo >&2
+        echo "  Fixtures ('fixture_*' functions) must be marked '#[inline(never)]':" >&2
+        while IFS= read -r v; do echo "    ${v}" >&2; done <<< "${fixture_violations}"
+    fi
+    echo >&2
+    exit 3
+fi
+
+multiple=false
+[[ ${#FORMATS[@]} -gt 1 ]] && multiple=true
+
+for fmt in "${FORMATS[@]}"; do
+    if [[ "${multiple}" == true ]]; then
+        echo "===== ${fmt} ====="
+    fi
+    if [[ "${fmt}" == "raw" ]]; then
+        cat "${out_file}"
+    else
+        awk -v fmt="${fmt}" "${AWK_PROG}" "${out_file}"
+    fi
+    [[ "${multiple}" == true ]] && echo
+done
+
+# The loop's last statement (`[[ ... ]] && echo`) can leave a non-zero exit code
+# when only a single format is requested. Exit explicitly so callers (e.g. `just`)
+# don't see a spurious failure.
+exit 0

--- a/standards/src16/src/src16.sw
+++ b/standards/src16/src/src16.sw
@@ -121,9 +121,9 @@ impl SRC16Domain {
     ) -> SRC16Domain {
         SRC16Domain {
             name: domain_name,
-            version: version,
-            chain_id: chain_id,
-            verifying_contract: verifying_contract,
+            version,
+            chain_id,
+            verifying_contract,
         }
     }
 


### PR DESCRIPTION
## Type of change

- Benchmarking infrastructure.

## Changes

`forc` does not have benchmarking support, e.g., `forc bench`. This PR uses `forc test` combined with test naming conventions and a `forc-bench.sh` script runner to provide a simple gas benchmarking infrastructure.

- Adds `forc-bench.sh` runner.
- Adds benchmarks for `src16`.

## Notes

Storing benchmark results on CI and warning on regressions will be done in a follow up PR.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.