### PR TITLE
Fix SRC16 with changes from O2

### DIFF
--- a/benchmarks/src16/src/common.sw
+++ b/benchmarks/src16/src/common.sw
@@ -1,7 +1,5 @@
 library;
 
-use src16::*;
-
 /// The global fallback baseline (see the baseline-resolution rules in the
 /// benchmarks `README.md`). Measures the bare overhead common to every benchmark
 /// project. `forc test` does not run tests from dependency libraries, so this
@@ -9,10 +7,3 @@ use src16::*;
 /// `benchmarking` library).
 #[test]
 fn baseline() {}
-
-/// Shared fixture for benchmarks that encode into a `Buffer` (e.g. the
-/// `abi_encode` benchmarks of the domain types).
-#[inline(never)]
-pub fn fixture_create_buffer() -> Buffer {
-    Buffer::new()
-}

--- a/benchmarks/src16/src/eip712_domain.sw
+++ b/benchmarks/src16/src/eip712_domain.sw
@@ -4,25 +4,26 @@ use benchmarking::*;
 use src16::*;
 use std::string::*;
 
-use ::common::fixture_create_buffer;
 
 #[inline(never)]
 pub fn fixture_create_eip712_domain() -> EIP712Domain {
     EIP712Domain::new(
-        String::from_ascii_str("SampleDomain"),
-        String::from_ascii_str("1"),
-        0,
-        ContractId::zero(),
+        Some(String::from_ascii_str("SampleDomain")),
+        Some(String::from_ascii_str("1")),
+        Some(0),
+        Some(ContractId::zero()),
+        None,
     )
 }
 
 #[inline(never)]
-pub fn fixture_create_eip712_domain_args() -> (String, String, u256, ContractId) {
+pub fn fixture_create_eip712_domain_args() -> (Option<String>, Option<String>, Option<u256>, Option<ContractId>, Option<b256>) {
     (
-        String::from_ascii_str("SampleDomain"),
-        String::from_ascii_str("1"),
-        0,
-        ContractId::zero(),
+        Some(String::from_ascii_str("SampleDomain")),
+        Some(String::from_ascii_str("1")),
+        Some(0),
+        Some(ContractId::zero()),
+        None,
     )
 }
 
@@ -34,26 +35,10 @@ fn baseline__eip712_domain__new() {
 
 #[test]
 fn bench__eip712_domain__new() {
-    let (name, version, chain_id, verifying_contract) = fixture_create_eip712_domain_args();
+    let (name, version, chain_id, verifying_contract, salt) = fixture_create_eip712_domain_args();
 
-    let domain = EIP712Domain::new(name, version, chain_id, verifying_contract);
+    let domain = EIP712Domain::new(name, version, chain_id, verifying_contract, salt);
     keep(domain);
-}
-
-#[test]
-fn baseline__eip712_domain__abi_encode() {
-    let _ = fixture_create_eip712_domain();
-    let _ = fixture_create_buffer();
-    keep_ref_type(); // encoded
-}
-
-#[test]
-fn bench__eip712_domain__abi_encode() {
-    let domain = fixture_create_eip712_domain();
-    let buffer = fixture_create_buffer();
-
-    let encoded = domain.abi_encode(buffer);
-    keep(encoded);
 }
 
 #[test]

--- a/benchmarks/src16/src/eip712_domain.sw
+++ b/benchmarks/src16/src/eip712_domain.sw
@@ -4,7 +4,6 @@ use benchmarking::*;
 use src16::*;
 use std::string::*;
 
-
 #[inline(never)]
 pub fn fixture_create_eip712_domain() -> EIP712Domain {
     EIP712Domain::new(

--- a/benchmarks/src16/src/src16_domain.sw
+++ b/benchmarks/src16/src/src16_domain.sw
@@ -4,7 +4,6 @@ use benchmarking::*;
 use src16::*;
 use std::string::*;
 
-
 #[inline(never)]
 pub fn fixture_create_src16_domain() -> SRC16Domain {
     SRC16Domain::new(

--- a/benchmarks/src16/src/src16_domain.sw
+++ b/benchmarks/src16/src/src16_domain.sw
@@ -4,32 +4,16 @@ use benchmarking::*;
 use src16::*;
 use std::string::*;
 
-use ::common::fixture_create_buffer;
 
 #[inline(never)]
 pub fn fixture_create_src16_domain() -> SRC16Domain {
     SRC16Domain::new(
-        String::from_ascii_str("SampleDomain"),
-        String::from_ascii_str("1"),
-        0,
-        ContractId::zero(),
+        Some(String::from_ascii_str("SampleDomain")),
+        Some(String::from_ascii_str("1")),
+        Some(0),
+        Some(ContractId::zero()),
+        None,
     )
-}
-
-#[test]
-fn baseline__src16_domain__abi_encode() {
-    let _ = fixture_create_src16_domain();
-    let _ = fixture_create_buffer();
-    keep_ref_type(); // encoded
-}
-
-#[test]
-fn bench__src16_domain__abi_encode() {
-    let domain = fixture_create_src16_domain();
-    let buffer = fixture_create_buffer();
-
-    let encoded = domain.abi_encode(buffer);
-    keep(encoded);
 }
 
 #[test]

--- a/benchmarks/src16/src/src16_payload.sw
+++ b/benchmarks/src16/src/src16_payload.sw
@@ -2,50 +2,73 @@ library;
 
 use benchmarking::*;
 use src16::*;
+use std::{bytes::Bytes, hash::*, string::String};
 
 use ::src16_domain::fixture_create_src16_domain;
 use ::eip712_domain::fixture_create_eip712_domain;
 
-#[inline(never)]
-fn fixture_create_src16_payload_with_src16_domain() -> SRC16Payload<SRC16Domain> {
-    SRC16Payload {
-        domain: fixture_create_src16_domain(),
-        data_hash: 0x1616161616161616161616161616161616161616161616161616161616161616,
+pub struct Mail {
+    from: Address,
+    to: Address,
+    contents: String,
+}
+
+const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
+
+impl SRC16Encode for Mail {
+    fn type_hash(encoding: Encoding) -> b256 {
+        MAIL_TYPE_HASH
+    }
+
+    fn struct_hash(self, encoding: Encoding) -> b256 {
+        let mut encoded = Bytes::new();
+        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
+        encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
+        encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 }
 
 #[inline(never)]
-fn fixture_create_src16_payload_with_eip712_domain() -> SRC16Payload<EIP712Domain> {
-    SRC16Payload {
-        domain: fixture_create_eip712_domain(),
-        data_hash: 0x1616161616161616161616161616161616161616161616161616161616161616,
+fn fixture_create_mail() -> Mail {
+    Mail {
+        from: Address::zero(),
+        to: Address::zero(),
+        contents: String::from_ascii_str("Hello, Fuel!"),
     }
 }
 
 #[test]
-fn baseline__src16_payload__encode_hash__src16_domain() {
-    let _ = fixture_create_src16_payload_with_src16_domain();
+fn baseline__src16_encode__encode__src16_domain() {
+    let _ = fixture_create_mail();
+    let _ = fixture_create_src16_domain();
     keep_ref_type(); // hash
 }
 
 #[test]
-fn bench__src16_payload__encode_hash__src16_domain() {
-    let payload = fixture_create_src16_payload_with_src16_domain();
-
-    let hash = payload.encode_hash();
+fn bench__src16_encode__encode__src16_domain() {
+    let mail = fixture_create_mail();
+    let domain = Domain::SRC16Domain(fixture_create_src16_domain());
+    let hash = mail.encode(domain);
     keep(hash);
 }
 
 #[test]
-fn baseline__src16_payload__encode_hash__eip712_domain() {
-    let _ = fixture_create_src16_payload_with_eip712_domain();
+fn baseline__src16_encode__encode__eip712_domain() {
+    let _ = fixture_create_mail();
+    let _ = fixture_create_eip712_domain();
     keep_ref_type(); // hash
 }
 
 #[test]
-fn bench__src16_payload__encode_hash__eip712_domain() {
-    let payload = fixture_create_src16_payload_with_eip712_domain();
-
-    let hash = payload.encode_hash();
+fn bench__src16_encode__encode__eip712_domain() {
+    let mail = fixture_create_mail();
+    let domain = Domain::EIP712Domain(fixture_create_eip712_domain());
+    let hash = mail.encode(domain);
     keep(hash);
 }

--- a/benchmarks/src16/src/src16_payload.sw
+++ b/benchmarks/src16/src/src16_payload.sw
@@ -13,16 +13,24 @@ pub struct Mail {
     contents: String,
 }
 
-const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
+/// "Mail(address from,address to,string contents)"
+const MAIL_SRC16_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
+
+/// "Mail(bytes32 from,bytes32 to,string contents)"
+const MAIL_EIP712_TYPE_HASH: b256 = 0xcfc972d321844e0304c5a752957425d5df13c3b09c563624a806b517155d7056;
 
 impl SRC16Encode for Mail {
     fn type_hash(encoding: Encoding) -> b256 {
-        MAIL_TYPE_HASH
+        match encoding {
+            Encoding::SRC16 => MAIL_SRC16_TYPE_HASH,
+            Encoding::EIP712 => MAIL_EIP712_TYPE_HASH,
+        }
     }
 
     fn struct_hash(self, encoding: Encoding) -> b256 {
+        let type_hash = Self::type_hash(encoding);
         let mut encoded = Bytes::new();
-        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        encoded.append(type_hash.to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());

--- a/docs/spell-check-custom-words.txt
+++ b/docs/spell-check-custom-words.txt
@@ -282,3 +282,4 @@ AltBn
 NameEvent
 GlobalMetadataEvent
 ifps
+stdlib

--- a/docs/src/src-16-typed-structured-data.md
+++ b/docs/src/src-16-typed-structured-data.md
@@ -164,20 +164,32 @@ pub enum Domain {
 ## Example implementation
 
 ```sway
-const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
+// keccak256("Mail(address from,address to,string contents)")
+const MAIL_SRC16_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
+// keccak256("Mail(bytes32 from,bytes32 to,string contents)")
+// Fuel's 32-byte Address maps to bytes32 in EIP712 since EVM has no 32-byte address primitive.
+const MAIL_EIP712_TYPE_HASH: b256 = 0xcfc972d321844e0304c5a752957425d5df13c3b09c563624a806b517155d7056;
 
 impl SRC16Encode for Mail {
     fn type_hash(encoding: Encoding) -> b256 {
-        MAIL_TYPE_HASH
+        match encoding {
+            Encoding::SRC16 => MAIL_SRC16_TYPE_HASH,
+            Encoding::EIP712 => MAIL_EIP712_TYPE_HASH,
+        }
     }
 
     fn struct_hash(self, encoding: Encoding) -> b256 {
+        let type_hash = Self::type_hash(encoding);
         let mut encoded = Bytes::new();
-        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        encoded.append(type_hash.to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 }
 ```

--- a/docs/src/src-16-typed-structured-data.md
+++ b/docs/src/src-16-typed-structured-data.md
@@ -61,22 +61,26 @@ The domain separator provides context for the signing operation, preventing cros
 
 ```sway
 pub struct SRC16Domain {
-    name: String,                   // The protocol name (e.g., "MyProtocol")
-    version: String,                // The protocol version (e.g., "1")
-    chain_id: u64,                  // The Fuel chain ID
-    verifying_contract: ContractId, // The contract id that will verify the signature
+    name: Option<String>,                   // The protocol name (e.g., "MyProtocol")
+    version: Option<String>,                // The protocol version (e.g., "1")
+    chain_id: Option<u256>,                 // The Fuel chain ID
+    verifying_contract: Option<ContractId>, // The contract id that will verify the signature
+    salt: Option<b256>,                     // An optional disambiguating salt
 }
 ```
 
-The `chain_id` field is a u64 that must be encoded by left-padding with zeros and packed in big-endian order to fill a 32-byte value.
+All fields are optional. Only the fields that are `Some` are included in both the domain type hash string and the encoded data. This mirrors the EIP712 specification which allows the domain to be constructed with only the fields relevant to the application.
+
+The `chain_id` field is a `u256` encoded as 32 bytes big-endian.
 
 The domain separator encoding follows this scheme:
 
-* Add SRC16_DOMAIN_TYPE_HASH
-* Add Keccak256 hash of name string
-* Add Keccak256 hash of version string
-* Add chain ID as 32-byte big-endian
-* Add verifying contract id as 32 bytes
+* Dynamically build the type hash string from only the present fields (e.g. `"SRC16Domain(string name,u256 chain_id)"`)
+* Compute the type hash as the Keccak256 of the type hash string (stored at position 0 of the encoded buffer)
+* For each present field in order: append its encoded 32-byte value to the buffer
+* Compute the final domain hash as Keccak256 of the entire encoded buffer
+
+All hashing is performed using raw `k256` assembly to avoid length-prefixed stdlib encoding.
 
 ## Type Encoding
 
@@ -122,7 +126,7 @@ Reference Types:
 * Arrays (both fixed and dynamic) are encoded as the Keccak256 hash of their concatenated encodings
 * Struct values are encoded recursively as hash_struct(value)
 
-The implementation of `TypedDataHash` for `𝕊` SHALL utilize the `DataEncoder` for encoding each element of the struct based on its type.
+The implementation of `SRC16Encode` for `𝕊` SHALL utilize the `DataEncoder` for encoding each element of the struct based on its type.
 
 ## Final Message Encoding
 
@@ -137,36 +141,54 @@ where:
 * `domain_separator` is the 32-byte hash of the domain parameters
 * `hash_struct`(message) is the 32-byte hash of the structured data
 
+## Encoding and Domain Enums
+
+The `Encoding` enum selects between the Fuel-native and Ethereum-compatible encoding variants:
+
+```sway
+pub enum Encoding {
+    SRC16: (),
+    EIP712: (),
+}
+```
+
+The `Domain` enum wraps either a Fuel-native or Ethereum-compatible domain separator. The encoding variant is derived from the domain type:
+
+```sway
+pub enum Domain {
+    SRC16Domain: SRC16Domain,
+    EIP712Domain: EIP712Domain,
+}
+```
+
 ## Example implementation
 
 ```sway
 const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
 
-impl TypedDataHash for Mail {
-
-    fn type_hash() -> b256 {
+impl SRC16Encode for Mail {
+    fn type_hash(encoding: Encoding) -> b256 {
         MAIL_TYPE_HASH
     }
 
-    fn struct_hash(self) -> b256 {
+    fn struct_hash(self, encoding: Encoding) -> b256 {
         let mut encoded = Bytes::new();
-        encoded.append(
-            MAIL_TYPE_HASH.to_be_bytes()
-        );
-        encoded.append(
-            DataEncoder::encode_address(self.from).to_be_bytes()
-        );
-        encoded.append(
-            DataEncoder::encode_address(self.to).to_be_bytes()
-        );
-        encoded.append(
-            DataEncoder::encode_string(self.contents).to_be_bytes()
-        );
-
+        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
+        encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
+        encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
         keccak256(encoded)
     }
 }
 ```
+
+The default `encode` method is provided automatically and produces the final signed hash:
+
+```
+keccak256("\x19\x01" ‖ domain_hash ‖ struct_hash)
+```
+
+To sign a message, call `mail.encode(domain)` where `domain` is a `Domain::SRC16Domain(...)` or `Domain::EIP712Domain(...)` value.
 
 ## Rationale
 
@@ -214,24 +236,26 @@ When implementing SRC16 in relation to EIP712, the following type mappings and c
 #### Domain Separator Compatibility
 
 ```sway
-// SRC16 Domain (Fuel native)
+// SRC16 Domain (Fuel native) — all fields optional
 pub struct SRC16Domain {
-    name: String,                   // Same as EIP712
-    version: String,                // Same as EIP712
-    chain_id: u64,                  // Fuel chain ID
-    verifying_contract: ContractId, // Full 32-byte ContractId
+    name: Option<String>,                   // Same as EIP712
+    version: Option<String>,                // Same as EIP712
+    chain_id: Option<u256>,                 // Fuel chain ID
+    verifying_contract: Option<ContractId>, // Full 32-byte ContractId
+    salt: Option<b256>,                     // Optional disambiguating salt
 }
 
-// EIP712 Domain (Ethereum compatible)
+// EIP712 Domain (Ethereum compatible) — all fields optional
 pub struct EIP712Domain {
-    name: String,
-    version: String,
-    chain_id: u256,
-    verifying_contract: b256,      // Only rightmost 20 bytes used
+    name: Option<String>,
+    version: Option<String>,
+    chain_id: Option<u256>,
+    verifying_contract: Option<b256>,       // Only rightmost 20 bytes used
+    salt: Option<b256>,                     // Optional disambiguating salt
 }
 ```
 
-Note on `verifying_contract` field; When implementing EIP712 compatibility within SRC16, the `verifying_contract` address in the `EIP712Domain` must be constructed by taking only the rightmost 20 bytes from either a Fuel `ContractId`. This ensures proper compatibility with Ethereum's 20-byte addressing scheme in the domain separator.
+Note on `verifying_contract` field; When implementing EIP712 compatibility within SRC16, the `verifying_contract` address in the `EIP712Domain` must be constructed by taking only the rightmost 20 bytes from a Fuel `ContractId`. The `EIP712Domain::new` constructor handles this automatically. This ensures proper compatibility with Ethereum's 20-byte addressing scheme in the domain separator.
 
 ```sway
 // Example ContractId conversion:
@@ -244,7 +268,7 @@ Note on `verifying_contract` field; When implementing EIP712 compatibility withi
 //    └─────────────── 20 bytes ───────────────┘
 ```
 
-Note on EIP712 Domain Separator `salt`; Within EIP712 the field `salt` is an optional field to be used at the discretion of the protocol designer. Within SRC16 the `EIP712Domain` does not use the `salt` field. The other fields in `EIP712Domain` are mandatory within SRC16.
+Note on `salt`; Both `SRC16Domain` and `EIP712Domain` support an optional `salt` field at the discretion of the protocol designer. When `salt` is `None` it is omitted from the type hash string and encoded data entirely.
 
 ## Security Considerations
 

--- a/docs/src/src-16-typed-structured-data.md
+++ b/docs/src/src-16-typed-structured-data.md
@@ -184,7 +184,7 @@ impl SRC16Encode for Mail {
 
 The default `encode` method is provided automatically and produces the final signed hash:
 
-```
+```text
 keccak256("\x19\x01" ‖ domain_hash ‖ struct_hash)
 ```
 

--- a/docs/src/src-17-naming-verification.md
+++ b/docs/src/src-17-naming-verification.md
@@ -10,7 +10,7 @@ A standard interface for names on Fuel allows external applications to verify an
 
 A number of existing name service platforms already existed prior to the development of this standard. Notably the most well-known on the Ethereum Blockchain is the [Ethereum Name Service(ENS)](https://ens.domains/). This domain service has a major influence on other name services across multiple platforms. ENS pioneered name service platforms and this standard takes some inspiration from their resolver design.
 
-On Fuel, we have 2 existing name service platforms. These are [Bako ID](https://www.bako.id/) and [Fuel Name Service(FNS)](https://fuelname.com/). This standard was developed in close collaboration with these two platforms to ensure compatibility and ease of upgrade.
+On Fuel, we have 2 existing name service platforms. These are [Bako ID](https://app.bako.id/) and [Fuel Name Service(FNS)](https://fuelname.com/). This standard was developed in close collaboration with these two platforms to ensure compatibility and ease of upgrade.
 
 ## Specification
 

--- a/examples/src16-typed-data/ethereum_example/src/main.sw
+++ b/examples/src16-typed-data/ethereum_example/src/main.sw
@@ -1,15 +1,6 @@
 contract;
 
-use src16::{
-    DataEncoder,
-    DomainHash,
-    EIP712,
-    EIP712Domain,
-    SRC16Base,
-    SRC16Encode,
-    SRC16Payload,
-    TypedDataHash,
-};
+use src16::{DataEncoder, Domain, EIP712Domain, Encoding, SRC16Base, SRC16Encode};
 use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
 
 configurable {
@@ -17,15 +8,15 @@ configurable {
     DOMAIN: str[8] = __to_str_array("MyDomain"),
     /// The current major version for the signing domain.
     VERSION: str[1] = __to_str_array("1"),
-    /// The active chain ID where the signing is intended to be used. Cast to u256 in domain_hash
+    /// The active chain ID where the signing is intended to be used.
     CHAIN_ID: u64 = 9889u64,
 }
 
 /// A demo struct representing a mail message
 pub struct Mail {
-    /// The sender's address
+    /// The sender's address (EVM bytes32)
     pub from: b256,
-    /// The recipient's address
+    /// The recipient's address (EVM bytes32)
     pub to: b256,
     /// The message contents
     pub contents: String,
@@ -39,67 +30,36 @@ pub struct Mail {
 ///
 const MAIL_TYPE_HASH: b256 = 0xcfc972d321844e0304c5a752957425d5df13c3b09c563624a806b517155d7056;
 
-impl TypedDataHash for Mail {
-    fn type_hash() -> b256 {
+impl SRC16Encode for Mail {
+    fn type_hash(encoding: Encoding) -> b256 {
         MAIL_TYPE_HASH
     }
 
-    fn struct_hash(self) -> b256 {
+    fn struct_hash(self, encoding: Encoding) -> b256 {
         let mut encoded = Bytes::new();
-
-        // Add the Mail type hash.
         encoded.append(MAIL_TYPE_HASH.to_be_bytes());
-        // Use the DataEncoder to encode each field for known types
         encoded.append(DataEncoder::encode_b256(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_b256(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
-
-        keccak256(encoded)
-    }
-}
-
-/// Implement the encode function for Mail using SRC16Payload
-///
-/// # Additional Information
-///
-/// 1. Get the encodeData hash of the Mail typed data using
-///    <Mail>..struct_hash();
-/// 2. Obtain the payload to by populating the SRC16Payload struct
-///    with the domain separator and data_hash from the previous step.
-/// 3. Obtain the final_hash [Some(b256)] or None using the function
-///    SRC16Payload::encode_hash()
-///
-impl SRC16Encode<Mail> for Mail {
-    fn encode(s: Mail) -> b256 {
-        // encodeData hash
-        let data_hash = s.struct_hash();
-        // setup payload
-        let payload = SRC16Payload {
-            domain: _get_domain_separator(),
-            data_hash: data_hash,
-        };
-
-        // Get the final encoded hash
-        match payload.encode_hash() {
-            Some(hash) => hash,
-            None => revert(0),
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
         }
     }
 }
 
 impl SRC16Base for Contract {
-    fn domain_separator_hash() -> b256 {
+    fn domain_separator_hash(encoding: Encoding) -> b256 {
         _get_domain_separator().domain_hash()
     }
 
-    fn data_type_hash() -> b256 {
-        MAIL_TYPE_HASH
+    fn data_type_hash(encoding: Encoding) -> b256 {
+        Mail::type_hash(encoding)
     }
-}
 
-impl EIP712 for Contract {
-    fn domain_separator() -> EIP712Domain {
-        _get_domain_separator()
+    fn domain_separator(encoding: Encoding) -> Domain {
+        Domain::EIP712Domain(_get_domain_separator())
     }
 }
 
@@ -108,7 +68,7 @@ abi MailMe {
 }
 
 impl MailMe for Contract {
-    /// Sends a some mail and returns its encoded hash
+    /// Sends some mail and returns its encoded hash
     ///
     /// # Arguments
     ///
@@ -121,32 +81,30 @@ impl MailMe for Contract {
     /// * [b256] - The encoded hash of the mail data
     ///
     fn send_mail_get_hash(from_addr: b256, to_addr: b256, contents: String) -> b256 {
-        // Create the mail struct from data passed in call
         let some_mail = Mail {
             from: from_addr,
             to: to_addr,
             contents: contents,
         };
-
-        Mail::encode(some_mail)
+        let domain = Domain::EIP712Domain(_get_domain_separator());
+        some_mail.encode(domain)
     }
 }
 
-/// A program specific implementation to get the Ethereum EIP712Domain
+/// Returns the Ethereum EIP712Domain for this contract.
 ///
-/// In a Contract the ContractID can be obtain with ContractId::this()
+/// In a Contract the ContractId can be obtained with ContractId::this()
 ///
-/// In a Predicate or Script it is at the implementors discretion to
-/// use the code root if they wish to contrain the validation to a
-/// specifc program.
+/// In a Predicate or Script it is at the implementor's discretion to
+/// use the code root if they wish to constrain the validation to a
+/// specific program.
 ///
 fn _get_domain_separator() -> EIP712Domain {
     EIP712Domain::new(
-        String::from_ascii_str(from_str_array(DOMAIN)),
-        String::from_ascii_str(from_str_array(VERSION)),
-        (asm(r1: (0, 0, 0, CHAIN_ID)) {
-                r1: u256
-            }),
-        ContractId::this(),
+        Some(String::from_ascii_str(from_str_array(DOMAIN))),
+        Some(String::from_ascii_str(from_str_array(VERSION))),
+        Some((asm(r1: (0, 0, 0, CHAIN_ID)) { r1: u256 })),
+        Some(ContractId::this()),
+        None,
     )
 }

--- a/examples/src16-typed-data/ethereum_example/src/main.sw
+++ b/examples/src16-typed-data/ethereum_example/src/main.sw
@@ -32,12 +32,16 @@ const MAIL_TYPE_HASH: b256 = 0xcfc972d321844e0304c5a752957425d5df13c3b09c563624a
 
 impl SRC16Encode for Mail {
     fn type_hash(encoding: Encoding) -> b256 {
-        MAIL_TYPE_HASH
+        match encoding {
+            Encoding::EIP712 => MAIL_TYPE_HASH,
+            Encoding::SRC16 => revert(0),
+        }
     }
 
     fn struct_hash(self, encoding: Encoding) -> b256 {
+        let type_hash = Self::type_hash(encoding);
         let mut encoded = Bytes::new();
-        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        encoded.append(type_hash.to_be_bytes());
         encoded.append(DataEncoder::encode_b256(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_b256(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());

--- a/examples/src16-typed-data/ethereum_example/src/main.sw
+++ b/examples/src16-typed-data/ethereum_example/src/main.sw
@@ -103,7 +103,9 @@ fn _get_domain_separator() -> EIP712Domain {
     EIP712Domain::new(
         Some(String::from_ascii_str(from_str_array(DOMAIN))),
         Some(String::from_ascii_str(from_str_array(VERSION))),
-        Some((asm(r1: (0, 0, 0, CHAIN_ID)) { r1: u256 })),
+        Some((asm(r1: (0, 0, 0, CHAIN_ID)) {
+            r1: u256
+        })),
         Some(ContractId::this()),
         None,
     )

--- a/examples/src16-typed-data/ethereum_example/src/main.sw
+++ b/examples/src16-typed-data/ethereum_example/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use src16::{DataEncoder, Domain, EIP712Domain, Encoding, SRC16Base, SRC16Encode};
+use src16::{DataEncoder, Domain, EIP712Domain, Encoding, SRC16, SRC16Encode};
 use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
 
 configurable {
@@ -49,7 +49,7 @@ impl SRC16Encode for Mail {
     }
 }
 
-impl SRC16Base for Contract {
+impl SRC16 for Contract {
     fn domain_separator_hash(encoding: Encoding) -> b256 {
         _get_domain_separator().domain_hash()
     }

--- a/examples/src16-typed-data/ethereum_example/src/main.sw
+++ b/examples/src16-typed-data/ethereum_example/src/main.sw
@@ -51,7 +51,10 @@ impl SRC16Encode for Mail {
 
 impl SRC16 for Contract {
     fn domain_separator_hash(encoding: Encoding) -> b256 {
-        _get_domain_separator().domain_hash()
+        match encoding {
+            Encoding::EIP712 => _get_domain_separator().domain_hash(),
+            Encoding::SRC16 => revert(0),
+        }
     }
 
     fn data_type_hash(encoding: Encoding) -> b256 {
@@ -59,7 +62,10 @@ impl SRC16 for Contract {
     }
 
     fn domain_separator(encoding: Encoding) -> Domain {
-        Domain::EIP712Domain(_get_domain_separator())
+        match encoding {
+            Encoding::EIP712 => Domain::EIP712Domain(_get_domain_separator()),
+            Encoding::SRC16 => revert(0),
+        }
     }
 }
 

--- a/examples/src16-typed-data/fuel_example/src/main.sw
+++ b/examples/src16-typed-data/fuel_example/src/main.sw
@@ -51,7 +51,10 @@ impl SRC16Encode for Mail {
 
 impl SRC16 for Contract {
     fn domain_separator_hash(encoding: Encoding) -> b256 {
-        _get_domain_separator().domain_hash()
+        match encoding {
+            Encoding::SRC16 => _get_domain_separator().domain_hash(),
+            Encoding::EIP712 => revert(0),
+        }
     }
 
     fn data_type_hash(encoding: Encoding) -> b256 {
@@ -59,7 +62,10 @@ impl SRC16 for Contract {
     }
 
     fn domain_separator(encoding: Encoding) -> Domain {
-        Domain::SRC16Domain(_get_domain_separator())
+        match encoding {
+            Encoding::SRC16 => Domain::SRC16Domain(_get_domain_separator()),
+            Encoding::EIP712 => revert(0),
+        }
     }
 }
 

--- a/examples/src16-typed-data/fuel_example/src/main.sw
+++ b/examples/src16-typed-data/fuel_example/src/main.sw
@@ -103,7 +103,9 @@ fn _get_domain_separator() -> SRC16Domain {
     SRC16Domain::new(
         Some(String::from_ascii_str(from_str_array(DOMAIN))),
         Some(String::from_ascii_str(from_str_array(VERSION))),
-        Some((asm(r1: (0, 0, 0, CHAIN_ID)) { r1: u256 })),
+        Some((asm(r1: (0, 0, 0, CHAIN_ID)) {
+            r1: u256
+        })),
         Some(ContractId::this()),
         None,
     )

--- a/examples/src16-typed-data/fuel_example/src/main.sw
+++ b/examples/src16-typed-data/fuel_example/src/main.sw
@@ -1,15 +1,6 @@
 contract;
 
-use src16::{
-    DataEncoder,
-    DomainHash,
-    SRC16,
-    SRC16Base,
-    SRC16Domain,
-    SRC16Encode,
-    SRC16Payload,
-    TypedDataHash,
-};
+use src16::{DataEncoder, Domain, Encoding, SRC16Base, SRC16Domain, SRC16Encode};
 use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
 
 configurable {
@@ -17,7 +8,7 @@ configurable {
     DOMAIN: str[8] = __to_str_array("MyDomain"),
     /// The current major version for the signing domain.
     VERSION: str[1] = __to_str_array("1"),
-    /// The active chain ID where the signing is intended to be used. Cast to u256 in domain_hash
+    /// The active chain ID where the signing is intended to be used.
     CHAIN_ID: u64 = 9889u64,
 }
 
@@ -39,66 +30,36 @@ pub struct Mail {
 ///
 const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
 
-impl TypedDataHash for Mail {
-    fn type_hash() -> b256 {
+impl SRC16Encode for Mail {
+    fn type_hash(encoding: Encoding) -> b256 {
         MAIL_TYPE_HASH
     }
 
-    fn struct_hash(self) -> b256 {
+    fn struct_hash(self, encoding: Encoding) -> b256 {
         let mut encoded = Bytes::new();
-        // Add the Mail type hash.
         encoded.append(MAIL_TYPE_HASH.to_be_bytes());
-        // Use the DataEncoder to encode each field for known types
         encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
-
-        keccak256(encoded)
-    }
-}
-
-/// Implement the encode function for Mail using SRC16Payload
-///
-/// # Additional Information
-///
-/// 1. Get the encodeData hash of the Mail typed data using
-///    <Mail>..struct_hash();
-/// 2. Obtain the payload to by populating the SRC16Payload struct
-///    with the domain separator and data_hash from the previous step.
-/// 3. Obtain the final_hash [Some(b256)] or None using the function
-///    SRC16Payload::encode_hash()
-///
-impl SRC16Encode<Mail> for Mail {
-    fn encode(s: Mail) -> b256 {
-        // encodeData hash
-        let data_hash = s.struct_hash();
-        // setup payload
-        let payload = SRC16Payload {
-            domain: _get_domain_separator(),
-            data_hash: data_hash,
-        };
-
-        // Get the final encoded hash
-        match payload.encode_hash() {
-            Some(hash) => hash,
-            None => revert(0),
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
         }
     }
 }
 
 impl SRC16Base for Contract {
-    fn domain_separator_hash() -> b256 {
+    fn domain_separator_hash(encoding: Encoding) -> b256 {
         _get_domain_separator().domain_hash()
     }
 
-    fn data_type_hash() -> b256 {
-        MAIL_TYPE_HASH
+    fn data_type_hash(encoding: Encoding) -> b256 {
+        Mail::type_hash(encoding)
     }
-}
 
-impl SRC16 for Contract {
-    fn domain_separator() -> SRC16Domain {
-        _get_domain_separator()
+    fn domain_separator(encoding: Encoding) -> Domain {
+        Domain::SRC16Domain(_get_domain_separator())
     }
 }
 
@@ -107,7 +68,7 @@ abi MailMe {
 }
 
 impl MailMe for Contract {
-    /// Sends a some mail and returns its encoded hash
+    /// Sends some mail and returns its encoded hash
     ///
     /// # Arguments
     ///
@@ -120,30 +81,30 @@ impl MailMe for Contract {
     /// * [b256] - The encoded hash of the mail data
     ///
     fn send_mail_get_hash(from_addr: Address, to_addr: Address, contents: String) -> b256 {
-        // Create the mail struct from data passed in call
         let some_mail = Mail {
             from: from_addr,
             to: to_addr,
             contents: contents,
         };
-
-        Mail::encode(some_mail)
+        let domain = Domain::SRC16Domain(_get_domain_separator());
+        some_mail.encode(domain)
     }
 }
 
-/// A program specific implementation to get the Fuel SRC16Domain
+/// Returns the Fuel SRC16Domain for this contract.
 ///
-/// In a Contract the ContractID can be obtain with ContractId::this()
+/// In a Contract the ContractId can be obtained with ContractId::this()
 ///
-/// In a Predicate or Script it is at the implementors discretion to
-/// use the code root if they wish to contrain the validation to a
-/// specifc program.
+/// In a Predicate or Script it is at the implementor's discretion to
+/// use the code root if they wish to constrain the validation to a
+/// specific program.
 ///
 fn _get_domain_separator() -> SRC16Domain {
     SRC16Domain::new(
-        String::from_ascii_str(from_str_array(DOMAIN)),
-        String::from_ascii_str(from_str_array(VERSION)),
-        CHAIN_ID,
-        ContractId::this(),
+        Some(String::from_ascii_str(from_str_array(DOMAIN))),
+        Some(String::from_ascii_str(from_str_array(VERSION))),
+        Some((asm(r1: (0, 0, 0, CHAIN_ID)) { r1: u256 })),
+        Some(ContractId::this()),
+        None,
     )
 }

--- a/examples/src16-typed-data/fuel_example/src/main.sw
+++ b/examples/src16-typed-data/fuel_example/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use src16::{DataEncoder, Domain, Encoding, SRC16Base, SRC16Domain, SRC16Encode};
+use src16::{DataEncoder, Domain, Encoding, SRC16, SRC16Domain, SRC16Encode};
 use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
 
 configurable {
@@ -49,7 +49,7 @@ impl SRC16Encode for Mail {
     }
 }
 
-impl SRC16Base for Contract {
+impl SRC16 for Contract {
     fn domain_separator_hash(encoding: Encoding) -> b256 {
         _get_domain_separator().domain_hash()
     }

--- a/examples/src16-typed-data/fuel_example/src/main.sw
+++ b/examples/src16-typed-data/fuel_example/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use src16::{DataEncoder, Domain, Encoding, SRC16, SRC16Domain, SRC16Encode};
+use src16::{DataEncoder, Domain, EIP712Domain, Encoding, SRC16, SRC16Domain, SRC16Encode};
 use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
 
 configurable {
@@ -22,22 +22,36 @@ pub struct Mail {
     pub contents: String,
 }
 
-/// The Keccak256 hash of the type Mail as UTF8 encoded bytes.
+/// The Keccak256 hash of the Mail type string for SRC16 (Fuel-native) encoding.
 ///
 /// "Mail(address from,address to,string contents)"
 ///
 /// 536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f
 ///
-const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
+const MAIL_SRC16_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
+
+/// The Keccak256 hash of the Mail type string for EIP712 (Ethereum-compatible) encoding.
+///
+/// Fuel's 32-byte Address maps to bytes32 since EVM has no 32-byte address primitive.
+///
+/// "Mail(bytes32 from,bytes32 to,string contents)"
+///
+/// cfc972d321844e0304c5a752957425d5df13c3b09c563624a806b517155d7056
+///
+const MAIL_EIP712_TYPE_HASH: b256 = 0xcfc972d321844e0304c5a752957425d5df13c3b09c563624a806b517155d7056;
 
 impl SRC16Encode for Mail {
     fn type_hash(encoding: Encoding) -> b256 {
-        MAIL_TYPE_HASH
+        match encoding {
+            Encoding::SRC16 => MAIL_SRC16_TYPE_HASH,
+            Encoding::EIP712 => MAIL_EIP712_TYPE_HASH,
+        }
     }
 
     fn struct_hash(self, encoding: Encoding) -> b256 {
+        let type_hash = Self::type_hash(encoding);
         let mut encoded = Bytes::new();
-        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        encoded.append(type_hash.to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
@@ -52,8 +66,8 @@ impl SRC16Encode for Mail {
 impl SRC16 for Contract {
     fn domain_separator_hash(encoding: Encoding) -> b256 {
         match encoding {
-            Encoding::SRC16 => _get_domain_separator().domain_hash(),
-            Encoding::EIP712 => revert(0),
+            Encoding::SRC16 => Domain::SRC16Domain(_get_src16_domain()).domain_hash(),
+            Encoding::EIP712 => Domain::EIP712Domain(_get_eip712_domain()).domain_hash(),
         }
     }
 
@@ -63,14 +77,19 @@ impl SRC16 for Contract {
 
     fn domain_separator(encoding: Encoding) -> Domain {
         match encoding {
-            Encoding::SRC16 => Domain::SRC16Domain(_get_domain_separator()),
-            Encoding::EIP712 => revert(0),
+            Encoding::SRC16 => Domain::SRC16Domain(_get_src16_domain()),
+            Encoding::EIP712 => Domain::EIP712Domain(_get_eip712_domain()),
         }
     }
 }
 
 abi MailMe {
-    fn send_mail_get_hash(from_addr: Address, to_addr: Address, contents: String) -> b256;
+    fn send_mail_get_hash(
+        from_addr: Address,
+        to_addr: Address,
+        contents: String,
+        encoding: Encoding,
+    ) -> b256;
 }
 
 impl MailMe for Contract {
@@ -81,18 +100,27 @@ impl MailMe for Contract {
     /// * `from_addr`: [Address] - The sender's address
     /// * `to_addr`: [Address] - The recipient's address
     /// * `contents`: [String] - The message contents
+    /// * `encoding`: [Encoding] - Whether to produce an SRC16 or EIP712 hash
     ///
     /// # Returns
     ///
     /// * [b256] - The encoded hash of the mail data
     ///
-    fn send_mail_get_hash(from_addr: Address, to_addr: Address, contents: String) -> b256 {
+    fn send_mail_get_hash(
+        from_addr: Address,
+        to_addr: Address,
+        contents: String,
+        encoding: Encoding,
+    ) -> b256 {
         let some_mail = Mail {
             from: from_addr,
             to: to_addr,
             contents: contents,
         };
-        let domain = Domain::SRC16Domain(_get_domain_separator());
+        let domain = match encoding {
+            Encoding::SRC16 => Domain::SRC16Domain(_get_src16_domain()),
+            Encoding::EIP712 => Domain::EIP712Domain(_get_eip712_domain()),
+        };
         some_mail.encode(domain)
     }
 }
@@ -105,8 +133,28 @@ impl MailMe for Contract {
 /// use the code root if they wish to constrain the validation to a
 /// specific program.
 ///
-fn _get_domain_separator() -> SRC16Domain {
+fn _get_src16_domain() -> SRC16Domain {
     SRC16Domain::new(
+        Some(String::from_ascii_str(from_str_array(DOMAIN))),
+        Some(String::from_ascii_str(from_str_array(VERSION))),
+        Some((asm(r1: (0, 0, 0, CHAIN_ID)) {
+            r1: u256
+        })),
+        Some(ContractId::this()),
+        None,
+    )
+}
+
+/// Returns the Ethereum EIP712Domain for this contract.
+///
+/// In a Contract the ContractId can be obtained with ContractId::this()
+///
+/// In a Predicate or Script it is at the implementor's discretion to
+/// use the code root if they wish to constrain the validation to a
+/// specific program.
+///
+fn _get_eip712_domain() -> EIP712Domain {
+    EIP712Domain::new(
         Some(String::from_ascii_str(from_str_array(DOMAIN))),
         Some(String::from_ascii_str(from_str_array(VERSION))),
         Some((asm(r1: (0, 0, 0, CHAIN_ID)) {

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -5,9 +5,6 @@
         },
         {
             "pattern": "https://github.com/FuelLabs/devrel-requests/issues/new/choose"
-        },
-        {
-            "pattern": "\\.sw$"
         }
     ]
 }

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -5,6 +5,9 @@
         },
         {
             "pattern": "https://github.com/FuelLabs/devrel-requests/issues/new/choose"
+        },
+        {
+            "pattern": "\\.sw$"
         }
     ]
 }

--- a/standards/src16/README.md
+++ b/standards/src16/README.md
@@ -61,22 +61,26 @@ The domain separator provides context for the signing operation, preventing cros
 
 ```sway
 pub struct SRC16Domain {
-    name: String,                   // The protocol name (e.g., "MyProtocol")
-    version: String,                // The protocol version (e.g., "1")
-    chain_id: u64,                  // The Fuel chain ID
-    verifying_contract: ContractId, // The contract id that will verify the signature
+    name: Option<String>,                   // The protocol name (e.g., "MyProtocol")
+    version: Option<String>,                // The protocol version (e.g., "1")
+    chain_id: Option<u256>,                 // The Fuel chain ID
+    verifying_contract: Option<ContractId>, // The contract id that will verify the signature
+    salt: Option<b256>,                     // An optional disambiguating salt
 }
 ```
 
-The `chain_id` field is a u64 that must be encoded by left-padding with zeros and packed in big-endian order to fill a 32-byte value.
+All fields are optional. Only the fields that are `Some` are included in both the domain type hash string and the encoded data. This mirrors the EIP712 specification which allows the domain to be constructed with only the fields relevant to the application.
+
+The `chain_id` field is a `u256` encoded as 32 bytes big-endian.
 
 The domain separator encoding follows this scheme:
 
-* Add SRC16_DOMAIN_TYPE_HASH
-* Add Keccak256 hash of name string
-* Add Keccak256 hash of version string
-* Add chain ID as 32-byte big-endian
-* Add verifying contract id as 32 bytes
+* Dynamically build the type hash string from only the present fields (e.g. `"SRC16Domain(string name,u256 chain_id)"`)
+* Compute the type hash as the Keccak256 of the type hash string (stored at position 0 of the encoded buffer)
+* For each present field in order: append its encoded 32-byte value to the buffer
+* Compute the final domain hash as Keccak256 of the entire encoded buffer
+
+All hashing is performed using raw `k256` assembly to avoid length-prefixed stdlib encoding.
 
 ## Type Encoding
 
@@ -122,7 +126,7 @@ Reference Types:
 * Arrays (both fixed and dynamic) are encoded as the Keccak256 hash of their concatenated encodings
 * Struct values are encoded recursively as hash_struct(value)
 
-The implementation of `TypedDataHash` for `𝕊` SHALL utilize the `DataEncoder` for encoding each element of the struct based on its type.
+The implementation of `SRC16Encode` for `𝕊` SHALL utilize the `DataEncoder` for encoding each element of the struct based on its type.
 
 ## Final Message Encoding
 
@@ -137,36 +141,54 @@ where:
 * `domain_separator` is the 32-byte hash of the domain parameters
 * `hash_struct`(message) is the 32-byte hash of the structured data
 
+## Encoding and Domain Enums
+
+The `Encoding` enum selects between the Fuel-native and Ethereum-compatible encoding variants:
+
+```sway
+pub enum Encoding {
+    SRC16: (),
+    EIP712: (),
+}
+```
+
+The `Domain` enum wraps either a Fuel-native or Ethereum-compatible domain separator. The encoding variant is derived from the domain type:
+
+```sway
+pub enum Domain {
+    SRC16Domain: SRC16Domain,
+    EIP712Domain: EIP712Domain,
+}
+```
+
 ## Example implementation
 
 ```sway
 const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
 
-impl TypedDataHash for Mail {
-
-    fn type_hash() -> b256 {
+impl SRC16Encode for Mail {
+    fn type_hash(encoding: Encoding) -> b256 {
         MAIL_TYPE_HASH
     }
 
-    fn struct_hash(self) -> b256 {
+    fn struct_hash(self, encoding: Encoding) -> b256 {
         let mut encoded = Bytes::new();
-        encoded.append(
-            MAIL_TYPE_HASH.to_be_bytes()
-        );
-        encoded.append(
-            DataEncoder::encode_address(self.from).to_be_bytes()
-        );
-        encoded.append(
-            DataEncoder::encode_address(self.to).to_be_bytes()
-        );
-        encoded.append(
-            DataEncoder::encode_string(self.contents).to_be_bytes()
-        );
-
+        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
+        encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
+        encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
         keccak256(encoded)
     }
 }
 ```
+
+The default `encode` method is provided automatically and produces the final signed hash:
+
+```
+keccak256("\x19\x01" ‖ domain_hash ‖ struct_hash)
+```
+
+To sign a message, call `mail.encode(domain)` where `domain` is a `Domain::SRC16Domain(...)` or `Domain::EIP712Domain(...)` value.
 
 ## Rationale
 
@@ -214,24 +236,26 @@ When implementing SRC16 in relation to EIP712, the following type mappings and c
 #### Domain Separator Compatibility
 
 ```sway
-// SRC16 Domain (Fuel native)
+// SRC16 Domain (Fuel native) — all fields optional
 pub struct SRC16Domain {
-    name: String,                   // Same as EIP712
-    version: String,                // Same as EIP712
-    chain_id: u64,                  // Fuel chain ID
-    verifying_contract: ContractId, // Full 32-byte ContractId
+    name: Option<String>,                   // Same as EIP712
+    version: Option<String>,                // Same as EIP712
+    chain_id: Option<u256>,                 // Fuel chain ID
+    verifying_contract: Option<ContractId>, // Full 32-byte ContractId
+    salt: Option<b256>,                     // Optional disambiguating salt
 }
 
-// EIP712 Domain (Ethereum compatible)
+// EIP712 Domain (Ethereum compatible) — all fields optional
 pub struct EIP712Domain {
-    name: String,
-    version: String,
-    chain_id: u256,
-    verifying_contract: b256,      // Only rightmost 20 bytes used
+    name: Option<String>,
+    version: Option<String>,
+    chain_id: Option<u256>,
+    verifying_contract: Option<b256>,       // Only rightmost 20 bytes used
+    salt: Option<b256>,                     // Optional disambiguating salt
 }
 ```
 
-Note on `verifying_contract` field; When implementing EIP712 compatibility within SRC16, the `verifying_contract` address in the `EIP712Domain` must be constructed by taking only the rightmost 20 bytes from either a Fuel `ContractId`. This ensures proper compatibility with Ethereum's 20-byte addressing scheme in the domain separator.
+Note on `verifying_contract` field; When implementing EIP712 compatibility within SRC16, the `verifying_contract` address in the `EIP712Domain` must be constructed by taking only the rightmost 20 bytes from a Fuel `ContractId`. The `EIP712Domain::new` constructor handles this automatically. This ensures proper compatibility with Ethereum's 20-byte addressing scheme in the domain separator.
 
 ```sway
 // Example ContractId conversion:
@@ -244,7 +268,7 @@ Note on `verifying_contract` field; When implementing EIP712 compatibility withi
 //    └─────────────── 20 bytes ───────────────┘
 ```
 
-Note on EIP712 Domain Separator `salt`; Within EIP712 the field `salt` is an optional field to be used at the discretion of the protocol designer. Within SRC16 the `EIP712Domain` does not use the `salt` field. The other fields in `EIP712Domain` are mandatory within SRC16.
+Note on `salt`; Both `SRC16Domain` and `EIP712Domain` support an optional `salt` field at the discretion of the protocol designer. When `salt` is `None` it is omitted from the type hash string and encoded data entirely.
 
 ## Security Considerations
 
@@ -264,108 +288,55 @@ Implementations must validate all type information and enforce strict encoding r
 
 Example of the SRC16 implementation where a contract utilizes the encoding scheme to produce a typed structured data hash of the Mail type.
 
+Fuel-native (SRC16Domain):
+
 ```sway
 contract;
 
-use src16::{
-    DataEncoder,
-    DomainHash,
-    SRC16,
-    SRC16Base,
-    SRC16Domain,
-    SRC16Encode,
-    SRC16Payload,
-    TypedDataHash,
-};
+use src16::{DataEncoder, Domain, Encoding, SRC16Base, SRC16Domain, SRC16Encode};
 use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
 
 configurable {
-    /// The name of the signing domain.
     DOMAIN: str[8] = __to_str_array("MyDomain"),
-    /// The current major version for the signing domain.
     VERSION: str[1] = __to_str_array("1"),
-    /// The active chain ID where the signing is intended to be used. Cast to u256 in domain_hash
     CHAIN_ID: u64 = 9889u64,
 }
 
-/// A demo struct representing a mail message
 pub struct Mail {
-    /// The sender's address
     pub from: Address,
-    /// The recipient's address
     pub to: Address,
-    /// The message contents
     pub contents: String,
 }
 
-/// The Keccak256 hash of the type Mail as UTF8 encoded bytes.
-///
-/// "Mail(address from,address to,string contents)"
-///
-/// 536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f
-///
+/// keccak256("Mail(address from,address to,string contents)")
 const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
 
-impl TypedDataHash for Mail {
-    fn type_hash() -> b256 {
+impl SRC16Encode for Mail {
+    fn type_hash(encoding: Encoding) -> b256 {
         MAIL_TYPE_HASH
     }
 
-    fn struct_hash(self) -> b256 {
+    fn struct_hash(self, encoding: Encoding) -> b256 {
         let mut encoded = Bytes::new();
-        // Add the Mail type hash.
         encoded.append(MAIL_TYPE_HASH.to_be_bytes());
-        // Use the DataEncoder to encode each field for known types
         encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
-
         keccak256(encoded)
     }
 }
 
-/// Implement the encode function for Mail using SRC16Payload
-///
-/// # Additional Information
-///
-/// 1. Get the encodeData hash of the Mail typed data using
-///    <Mail>..struct_hash();
-/// 2. Obtain the payload to by populating the SRC16Payload struct
-///    with the domain separator and data_hash from the previous step.
-/// 3. Obtain the final_hash [Some(b256)] or None using the function
-///    SRC16Payload::encode_hash()
-///
-impl SRC16Encode<Mail> for Mail {
-    fn encode(s: Mail) -> b256 {
-        // encodeData hash
-        let data_hash = s.struct_hash();
-        // setup payload
-        let payload = SRC16Payload {
-            domain: _get_domain_separator(),
-            data_hash: data_hash,
-        };
-
-        // Get the final encoded hash
-        match payload.encode_hash() {
-            Some(hash) => hash,
-            None => revert(0),
-        }
-    }
-}
-
 impl SRC16Base for Contract {
-    fn domain_separator_hash() -> b256 {
+    fn domain_separator_hash(encoding: Encoding) -> b256 {
         _get_domain_separator().domain_hash()
     }
 
-    fn data_type_hash() -> b256 {
-        MAIL_TYPE_HASH
+    fn data_type_hash(encoding: Encoding) -> b256 {
+        Mail::type_hash(encoding)
     }
-}
 
-impl SRC16 for Contract {
-    fn domain_separator() -> SRC16Domain {
-        _get_domain_separator()
+    fn domain_separator(encoding: Encoding) -> Domain {
+        Domain::SRC16Domain(_get_domain_separator())
     }
 }
 
@@ -374,151 +345,73 @@ abi MailMe {
 }
 
 impl MailMe for Contract {
-    /// Sends a some mail and returns its encoded hash
-    ///
-    /// # Arguments
-    ///
-    /// * `from_addr`: [Address] - The sender's address
-    /// * `to_addr`: [Address] - The recipient's address
-    /// * `contents`: [String] - The message contents
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The encoded hash of the mail data
-    ///
     fn send_mail_get_hash(from_addr: Address, to_addr: Address, contents: String) -> b256 {
-        // Create the mail struct from data passed in call
-        let some_mail = Mail {
-            from: from_addr,
-            to: to_addr,
-            contents: contents,
-        };
-
-        Mail::encode(some_mail)
+        let some_mail = Mail { from: from_addr, to: to_addr, contents: contents };
+        let domain = Domain::SRC16Domain(_get_domain_separator());
+        some_mail.encode(domain)
     }
 }
 
-/// A program specific implementation to get the Fuel SRC16Domain
-///
-/// In a Contract the ContractID can be obtain with ContractId::this()
-///
-/// In a Predicate or Script it is at the implementors discretion to
-/// use the code root if they wish to contrain the validation to a
-/// specifc program.
-///
 fn _get_domain_separator() -> SRC16Domain {
     SRC16Domain::new(
-        String::from_ascii_str(from_str_array(DOMAIN)),
-        String::from_ascii_str(from_str_array(VERSION)),
-        CHAIN_ID,
-        ContractId::this(),
+        Some(String::from_ascii_str(from_str_array(DOMAIN))),
+        Some(String::from_ascii_str(from_str_array(VERSION))),
+        Some((asm(r1: (0, 0, 0, CHAIN_ID)) { r1: u256 })),
+        Some(ContractId::this()),
+        None,
     )
 }
 ```
 
+Ethereum-compatible (EIP712Domain):
+
 ```sway
 contract;
 
-use src16::{
-    DataEncoder,
-    DomainHash,
-    EIP712,
-    EIP712Domain,
-    SRC16Base,
-    SRC16Encode,
-    SRC16Payload,
-    TypedDataHash,
-};
+use src16::{DataEncoder, Domain, EIP712Domain, Encoding, SRC16Base, SRC16Encode};
 use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
 
 configurable {
-    /// The name of the signing domain.
     DOMAIN: str[8] = __to_str_array("MyDomain"),
-    /// The current major version for the signing domain.
     VERSION: str[1] = __to_str_array("1"),
-    /// The active chain ID where the signing is intended to be used. Cast to u256 in domain_hash
     CHAIN_ID: u64 = 9889u64,
 }
 
-/// A demo struct representing a mail message
 pub struct Mail {
-    /// The sender's address
     pub from: b256,
-    /// The recipient's address
     pub to: b256,
-    /// The message contents
     pub contents: String,
 }
 
-/// The Keccak256 hash of the type Mail as UTF8 encoded bytes.
-///
-/// "Mail(bytes32 from,bytes32 to,string contents)"
-///
-/// cfc972d321844e0304c5a752957425d5df13c3b09c563624a806b517155d7056
-///
+/// keccak256("Mail(bytes32 from,bytes32 to,string contents)")
 const MAIL_TYPE_HASH: b256 = 0xcfc972d321844e0304c5a752957425d5df13c3b09c563624a806b517155d7056;
 
-impl TypedDataHash for Mail {
-    fn type_hash() -> b256 {
+impl SRC16Encode for Mail {
+    fn type_hash(encoding: Encoding) -> b256 {
         MAIL_TYPE_HASH
     }
 
-    fn struct_hash(self) -> b256 {
+    fn struct_hash(self, encoding: Encoding) -> b256 {
         let mut encoded = Bytes::new();
-
-        // Add the Mail type hash.
         encoded.append(MAIL_TYPE_HASH.to_be_bytes());
-        // Use the DataEncoder to encode each field for known types
         encoded.append(DataEncoder::encode_b256(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_b256(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
-
         keccak256(encoded)
     }
 }
 
-/// Implement the encode function for Mail using SRC16Payload
-///
-/// # Additional Information
-///
-/// 1. Get the encodeData hash of the Mail typed data using
-///    <Mail>..struct_hash();
-/// 2. Obtain the payload to by populating the SRC16Payload struct
-///    with the domain separator and data_hash from the previous step.
-/// 3. Obtain the final_hash [Some(b256)] or None using the function
-///    SRC16Payload::encode_hash()
-///
-impl SRC16Encode<Mail> for Mail {
-    fn encode(s: Mail) -> b256 {
-        // encodeData hash
-        let data_hash = s.struct_hash();
-        // setup payload
-        let payload = SRC16Payload {
-            domain: _get_domain_separator(),
-            data_hash: data_hash,
-        };
-
-        // Get the final encoded hash
-        match payload.encode_hash() {
-            Some(hash) => hash,
-            None => revert(0),
-        }
-    }
-}
-
 impl SRC16Base for Contract {
-    fn domain_separator_hash() -> b256 {
+    fn domain_separator_hash(encoding: Encoding) -> b256 {
         _get_domain_separator().domain_hash()
     }
 
-    fn data_type_hash() -> b256 {
-        MAIL_TYPE_HASH
+    fn data_type_hash(encoding: Encoding) -> b256 {
+        Mail::type_hash(encoding)
     }
-}
 
-impl EIP712 for Contract {
-    fn domain_separator() -> EIP712Domain {
-        _get_domain_separator()
+    fn domain_separator(encoding: Encoding) -> Domain {
+        Domain::EIP712Domain(_get_domain_separator())
     }
 }
 
@@ -527,46 +420,20 @@ abi MailMe {
 }
 
 impl MailMe for Contract {
-    /// Sends a some mail and returns its encoded hash
-    ///
-    /// # Arguments
-    ///
-    /// * `from_addr`: [b256] - The sender's address
-    /// * `to_addr`: [b256] - The recipient's address
-    /// * `contents`: [String] - The message contents
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The encoded hash of the mail data
-    ///
     fn send_mail_get_hash(from_addr: b256, to_addr: b256, contents: String) -> b256 {
-        // Create the mail struct from data passed in call
-        let some_mail = Mail {
-            from: from_addr,
-            to: to_addr,
-            contents: contents,
-        };
-
-        Mail::encode(some_mail)
+        let some_mail = Mail { from: from_addr, to: to_addr, contents: contents };
+        let domain = Domain::EIP712Domain(_get_domain_separator());
+        some_mail.encode(domain)
     }
 }
 
-/// A program specific implementation to get the Ethereum EIP712Domain
-///
-/// In a Contract the ContractID can be obtain with ContractId::this()
-///
-/// In a Predicate or Script it is at the implementors discretion to
-/// use the code root if they wish to contrain the validation to a
-/// specifc program.
-///
 fn _get_domain_separator() -> EIP712Domain {
     EIP712Domain::new(
-        String::from_ascii_str(from_str_array(DOMAIN)),
-        String::from_ascii_str(from_str_array(VERSION)),
-        (asm(r1: (0, 0, 0, CHAIN_ID)) {
-                r1: u256
-            }),
-        ContractId::this(),
+        Some(String::from_ascii_str(from_str_array(DOMAIN))),
+        Some(String::from_ascii_str(from_str_array(VERSION))),
+        Some((asm(r1: (0, 0, 0, CHAIN_ID)) { r1: u256 })),
+        Some(ContractId::this()),
+        None,
     )
 }
 ```

--- a/standards/src16/README.md
+++ b/standards/src16/README.md
@@ -293,7 +293,7 @@ Fuel-native (SRC16Domain):
 ```sway
 contract;
 
-use src16::{DataEncoder, Domain, Encoding, SRC16Base, SRC16Domain, SRC16Encode};
+use src16::{DataEncoder, Domain, Encoding, SRC16, SRC16Domain, SRC16Encode};
 use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
 
 configurable {
@@ -326,7 +326,7 @@ impl SRC16Encode for Mail {
     }
 }
 
-impl SRC16Base for Contract {
+impl SRC16 for Contract {
     fn domain_separator_hash(encoding: Encoding) -> b256 {
         _get_domain_separator().domain_hash()
     }
@@ -368,7 +368,7 @@ Ethereum-compatible (EIP712Domain):
 ```sway
 contract;
 
-use src16::{DataEncoder, Domain, EIP712Domain, Encoding, SRC16Base, SRC16Encode};
+use src16::{DataEncoder, Domain, EIP712Domain, Encoding, SRC16, SRC16Encode};
 use std::{bytes::Bytes, contract_id::*, hash::*, string::String};
 
 configurable {
@@ -401,7 +401,7 @@ impl SRC16Encode for Mail {
     }
 }
 
-impl SRC16Base for Contract {
+impl SRC16 for Contract {
     fn domain_separator_hash(encoding: Encoding) -> b256 {
         _get_domain_separator().domain_hash()
     }

--- a/standards/src16/README.md
+++ b/standards/src16/README.md
@@ -164,16 +164,21 @@ pub enum Domain {
 ## Example implementation
 
 ```sway
+// keccak256("Mail(address from,address to,string contents)")
 const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
 
 impl SRC16Encode for Mail {
     fn type_hash(encoding: Encoding) -> b256 {
-        MAIL_TYPE_HASH
+        match encoding {
+            Encoding::SRC16 => MAIL_TYPE_HASH,
+            Encoding::EIP712 => revert(0),
+        }
     }
 
     fn struct_hash(self, encoding: Encoding) -> b256 {
+        let type_hash = Self::type_hash(encoding);
         let mut encoded = Bytes::new();
-        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        encoded.append(type_hash.to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
@@ -313,12 +318,16 @@ const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c
 
 impl SRC16Encode for Mail {
     fn type_hash(encoding: Encoding) -> b256 {
-        MAIL_TYPE_HASH
+        match encoding {
+            Encoding::SRC16 => MAIL_TYPE_HASH,
+            Encoding::EIP712 => revert(0),
+        }
     }
 
     fn struct_hash(self, encoding: Encoding) -> b256 {
+        let type_hash = Self::type_hash(encoding);
         let mut encoded = Bytes::new();
-        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        encoded.append(type_hash.to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
@@ -328,7 +337,10 @@ impl SRC16Encode for Mail {
 
 impl SRC16 for Contract {
     fn domain_separator_hash(encoding: Encoding) -> b256 {
-        _get_domain_separator().domain_hash()
+        match encoding {
+            Encoding::SRC16 => _get_domain_separator().domain_hash(),
+            Encoding::EIP712 => revert(0),
+        }
     }
 
     fn data_type_hash(encoding: Encoding) -> b256 {
@@ -336,7 +348,10 @@ impl SRC16 for Contract {
     }
 
     fn domain_separator(encoding: Encoding) -> Domain {
-        Domain::SRC16Domain(_get_domain_separator())
+        match encoding {
+            Encoding::SRC16 => Domain::SRC16Domain(_get_domain_separator()),
+            Encoding::EIP712 => revert(0),
+        }
     }
 }
 
@@ -388,22 +403,33 @@ const MAIL_TYPE_HASH: b256 = 0xcfc972d321844e0304c5a752957425d5df13c3b09c563624a
 
 impl SRC16Encode for Mail {
     fn type_hash(encoding: Encoding) -> b256 {
-        MAIL_TYPE_HASH
+        match encoding {
+            Encoding::EIP712 => MAIL_TYPE_HASH,
+            Encoding::SRC16 => revert(0),
+        }
     }
 
     fn struct_hash(self, encoding: Encoding) -> b256 {
+        let type_hash = Self::type_hash(encoding);
         let mut encoded = Bytes::new();
-        encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+        encoded.append(type_hash.to_be_bytes());
         encoded.append(DataEncoder::encode_b256(self.from).to_be_bytes());
         encoded.append(DataEncoder::encode_b256(self.to).to_be_bytes());
         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 }
 
 impl SRC16 for Contract {
     fn domain_separator_hash(encoding: Encoding) -> b256 {
-        _get_domain_separator().domain_hash()
+        match encoding {
+            Encoding::EIP712 => _get_domain_separator().domain_hash(),
+            Encoding::SRC16 => revert(0),
+        }
     }
 
     fn data_type_hash(encoding: Encoding) -> b256 {
@@ -411,7 +437,10 @@ impl SRC16 for Contract {
     }
 
     fn domain_separator(encoding: Encoding) -> Domain {
-        Domain::EIP712Domain(_get_domain_separator())
+        match encoding {
+            Encoding::EIP712 => Domain::EIP712Domain(_get_domain_separator()),
+            Encoding::SRC16 => revert(0),
+        }
     }
 }
 

--- a/standards/src16/src/src16.sw
+++ b/standards/src16/src/src16.sw
@@ -520,18 +520,6 @@ pub trait SRC16Encode {
     }
 }
 
-/// Trait for managing a u64 replay protection nonce on a typed data struct.
-pub trait Nonce {
-    fn set_nonce(ref mut self, nonce: u64);
-    fn get_nonce(self) -> u64;
-}
-
-/// Trait for managing a u256 replay protection nonce on a typed data struct.
-pub trait ExtendedNonce {
-    fn set_nonce(ref mut self, nonce: u256);
-    fn get_nonce(self) -> u256;
-}
-
 /// This trait provides common encoding methods for different data types.
 ///
 /// # Additional Information

--- a/standards/src16/src/src16.sw
+++ b/standards/src16/src/src16.sw
@@ -416,7 +416,7 @@ impl Domain {
 }
 
 /// Standard ABI for contracts that support SRC16 typed structured data signing.
-abi SRC16Base {
+abi SRC16 {
     /// Returns the Keccak256 hash of the domain separator for the given encoding.
     fn domain_separator_hash(encoding: Encoding) -> b256;
 

--- a/standards/src16/src/src16.sw
+++ b/standards/src16/src/src16.sw
@@ -483,7 +483,7 @@ pub trait SRC16Encode {
         ];
 
         // \x19\x01 prefix
-        asm(dst: encoded, src_1: 0x19, src_2: 0x01, bytes: 1) {
+        asm(dst: encoded, src_1: 0x19, src_2: 0x01) {
             sb dst src_1 i0;
             sb dst src_2 i1;
         };

--- a/standards/src16/src/src16.sw
+++ b/standards/src16/src/src16.sw
@@ -3,100 +3,21 @@ library;
 use std::{bytes::Bytes, hash::*, string::String};
 use std::bytes_conversions::{b256::*, u256::*, u64::*};
 
-/// This base ABI provides the common hashing functionality that is
-/// shared between the Fuel (SRC16) and Ethereum (EIP712) implementations.
-abi SRC16Base {
-    /// Returns the Keccak256 hash of the encoded domain separator
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The domain separator hash computed from the domain parameters
-    fn domain_separator_hash() -> b256;
-
-    /// Returns the Keccak256 hash of the structured data type
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The type hash specific to the implementing contract's data structure
-    fn data_type_hash() -> b256;
-}
-
-/// Fuel-specific implementation of structured data signing
-///
-/// # Additional Information
-///
-/// Extends SRC16Base with Fuel-specific domain separator handling using
-///
-abi SRC16 : SRC16Base {
-    /// Returns the domain separator struct for Fuel
-    ///
-    /// # Returns
-    ///
-    /// * [SRC16Domain] - The domain separator containing Fuel-specific parameters
-    fn domain_separator() -> SRC16Domain;
-}
-
-/// Ethereum-compatible implementation of structured data signing
-///
-/// # Additional Information
-///
-/// Extends SRC16Base with Ethereum-compatible domain separator handling using
-///
-abi EIP712 : SRC16Base {
-    /// Returns the domain separator struct for Ethereum compatibility
-    ///
-    /// # Returns
-    ///
-    /// * [EIP712Domain] - The domain separator containing Ethereum-compatible parameters
-    fn domain_separator() -> EIP712Domain;
-}
-
 /// Contains the core parameters that uniquely identify a domain for typed
-/// data signing on Fuel.
+/// data signing on Fuel. All fields are optional; only the fields that are
+/// Some are included in the type hash string and encoded data, allowing the
+/// domain to be constructed with only the parameters required by the application.
 pub struct SRC16Domain {
     /// The name of the signing domain
-    name: String,
+    name: Option<String>,
     /// The current major version of the signing domain
-    version: String,
-    /// The active chain ID where the signing is intended to be used.
-    chain_id: u64,
+    version: Option<String>,
+    /// The active chain ID where the signing is intended to be used
+    chain_id: Option<u256>,
     /// The contract id of the contract that will verify the signature
-    verifying_contract: ContractId,
-}
-
-/// The type hash constant for the SRC16Domain domain separator
-///
-/// # Additional Information
-///
-/// This is the Keccak256 hash of "SRC16Domain(string name,string version,uint256 chainId,contractId verifyingContract)"
-pub const SRC16_DOMAIN_TYPE_HASH: b256 = 0x10f132d1adc99105bb9ad0d98956a93f35bda5c77713ac13adc489609c39336f;
-
-/// Encodes the SRC16Domain domain parameters using AbiEncode.
-///
-/// # Additional Information
-///
-/// The encoding follows the following scheme:
-/// 1. add SRC16_DOMAIN_TYPE_HASH
-/// 2. add Keccak256 hash of name string
-/// 3. add Keccak256 hash of version string
-/// 4. add Chain ID as 32-byte big-endian
-/// 5. add Verifying contract address as 32-bytes
-///
-impl AbiEncode for SRC16Domain {
-    fn is_encode_trivial() -> bool {
-        false
-    }
-
-    fn abi_encode(self, buffer: Buffer) -> Buffer {
-        let buffer = SRC16_DOMAIN_TYPE_HASH.abi_encode(buffer);
-        let buffer = keccak256(Bytes::from(self.name)).abi_encode(buffer);
-        let buffer = keccak256(Bytes::from(self.version)).abi_encode(buffer);
-        let buffer = (asm(r1: (0, 0, 0, self.chain_id)) {
-            r1: b256
-        }).abi_encode(buffer);
-        let buffer = self.verifying_contract.abi_encode(buffer);
-        buffer
-    }
+    verifying_contract: Option<ContractId>,
+    /// A disambiguating salt
+    salt: Option<b256>,
 }
 
 impl SRC16Domain {
@@ -104,26 +25,29 @@ impl SRC16Domain {
     ///
     /// # Arguments
     ///
-    /// * `domain_name`: [String] - The name of the signing domain
-    /// * `version`: [String] - The version of the signing domain
-    /// * `chain_id`: [u64] - The chain ID where the contract is deployed
-    /// * `verifying_contract`: [b256] - The address of the contract that will verify the signature
+    /// * `name`: [Option<String>] - The name of the signing domain
+    /// * `version`: [Option<String>] - The version of the signing domain
+    /// * `chain_id`: [Option<u256>] - The chain ID where the contract is deployed
+    /// * `verifying_contract`: [Option<ContractId>] - The contract that will verify the signature
+    /// * `salt`: [Option<b256>] - An optional disambiguating salt
     ///
     /// # Returns
     ///
     /// * [SRC16Domain] - A new instance of SRC16Domain with the provided parameters
     ///
     pub fn new(
-        domain_name: String,
-        version: String,
-        chain_id: u64,
-        verifying_contract: ContractId,
+        name: Option<String>,
+        version: Option<String>,
+        chain_id: Option<u256>,
+        verifying_contract: Option<ContractId>,
+        salt: Option<b256>,
     ) -> SRC16Domain {
         SRC16Domain {
-            name: domain_name,
+            name,
             version,
             chain_id,
             verifying_contract,
+            salt,
         }
     }
 
@@ -131,63 +55,155 @@ impl SRC16Domain {
     ///
     /// # Additional Information
     ///
-    /// Utilizes AbiEncode for SRC16Domain
+    /// Dynamically builds the type hash string including only the fields that are
+    /// Some. Uses raw k256 assembly to hash string values and the final encoded
+    /// buffer directly, avoiding length-prefixed stdlib encoding.
     ///
     /// # Returns
     ///
     /// * [b256] - The Keccak256 hash of the encoded domain parameters
     ///
     pub fn domain_hash(self) -> b256 {
-        let buffer = self.abi_encode(Buffer::new());
-        let encoded = buffer.as_raw_slice();
-        let bytes = Bytes::from(encoded);
-        keccak256(bytes)
+        let mut encoded: [b256; 6] = [
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+        ];
+        let mut type_hash_string = Bytes::new();
+        let mut total_bytes = 32;
+        let mut needs_comma = false;
+
+        type_hash_string.append(String::from_ascii_str("SRC16Domain(").as_bytes());
+
+        if self.name.is_some() {
+            type_hash_string.append(String::from_ascii_str("string name").as_bytes());
+            asm(
+                ptr: self.name.unwrap().ptr(),
+                len: self.name.unwrap().as_str().len(),
+                dst: encoded,
+                offset_bytes: total_bytes,
+                offset_ptr,
+            ) {
+                add offset_ptr dst offset_bytes;
+                k256 offset_ptr ptr len;
+            }
+            total_bytes += 32;
+            needs_comma = true;
+        }
+
+        if self.version.is_some() {
+            if needs_comma {
+                type_hash_string.append(String::from_ascii_str(",string version").as_bytes());
+            } else {
+                type_hash_string.append(String::from_ascii_str("string version").as_bytes());
+            }
+            asm(
+                ptr: self.version.unwrap().ptr(),
+                len: self.version.unwrap().as_str().len(),
+                dst: encoded,
+                offset_bytes: total_bytes,
+                offset_ptr,
+            ) {
+                add offset_ptr dst offset_bytes;
+                k256 offset_ptr ptr len;
+            }
+            total_bytes += 32;
+            needs_comma = true;
+        }
+
+        if self.chain_id.is_some() {
+            if needs_comma {
+                type_hash_string.append(String::from_ascii_str(",u256 chain_id").as_bytes());
+            } else {
+                type_hash_string.append(String::from_ascii_str("u256 chain_id").as_bytes());
+            }
+            asm(
+                dst: encoded,
+                src: self.chain_id.unwrap(),
+                bytes: 32,
+                offset_bytes: total_bytes,
+                offset_ptr,
+            ) {
+                add offset_ptr dst offset_bytes;
+                mcp offset_ptr src bytes;
+            };
+            total_bytes += 32;
+            needs_comma = true;
+        }
+
+        if self.verifying_contract.is_some() {
+            if needs_comma {
+                type_hash_string.append(String::from_ascii_str(",contractId verifying_contract").as_bytes());
+            } else {
+                type_hash_string.append(String::from_ascii_str("contractId verifying_contract").as_bytes());
+            }
+            asm(
+                dst: encoded,
+                src: self.verifying_contract.unwrap(),
+                bytes: 32,
+                offset_bytes: total_bytes,
+                offset_ptr,
+            ) {
+                add offset_ptr dst offset_bytes;
+                mcp offset_ptr src bytes;
+            };
+            total_bytes += 32;
+            needs_comma = true;
+        }
+
+        if self.salt.is_some() {
+            if needs_comma {
+                type_hash_string.append(String::from_ascii_str(",b256 salt").as_bytes());
+            } else {
+                type_hash_string.append(String::from_ascii_str("b256 salt").as_bytes());
+            }
+            asm(
+                dst: encoded,
+                src: self.salt.unwrap(),
+                bytes: 32,
+                offset_bytes: total_bytes,
+                offset_ptr,
+            ) {
+                add offset_ptr dst offset_bytes;
+                mcp offset_ptr src bytes;
+            };
+            total_bytes += 32;
+        }
+
+        type_hash_string.append(String::from_ascii_str(")").as_bytes());
+        asm(
+            ptr: type_hash_string.ptr(),
+            len: type_hash_string.len(),
+            dst: encoded,
+        ) {
+            k256 dst ptr len;
+        }
+
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded, bytes: total_bytes) {
+            k256 hash ptr bytes;
+            hash: b256
+        }
     }
 }
 
-/// The EIP712 Domain struct matching Ethereum's implementation
+/// The EIP712 Domain struct matching Ethereum's implementation.
+/// All fields are optional per the EIP712 specification, allowing the domain
+/// to be constructed with only the parameters required by the application.
 pub struct EIP712Domain {
     /// The name of the signing domain
-    name: String,
+    name: Option<String>,
     /// The current major version of the signing domain
-    version: String,
+    version: Option<String>,
     /// The Ethereum chain ID
-    chain_id: u256,
-    /// The address of the contract that will verify the signature
-    verifying_contract: b256,
-}
-
-/// The type hash constant for the EIP712Domain domain separator
-///
-/// # Additional Information
-///
-/// This is the Keccak256 hash of "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
-pub const EIP712_DOMAIN_TYPE_HASH: b256 = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
-
-/// Encodes the EIP712Domain domain parameters using AbiEncode.
-///
-/// # Additional Information
-///
-/// The encoding follows the following scheme:
-/// 1. add EIP712_DOMAIN_TYPE_HASH
-/// 2. add Keccak256 hash of name string
-/// 3. add Keccak256 hash of version string
-/// 4. add Chain ID as 32-byte big-endian
-/// 5. add Verifying contract address as 32-bytes
-///
-impl AbiEncode for EIP712Domain {
-    fn is_encode_trivial() -> bool {
-        false
-    }
-
-    fn abi_encode(self, buffer: Buffer) -> Buffer {
-        let buffer = EIP712_DOMAIN_TYPE_HASH.abi_encode(buffer);
-        let buffer = keccak256(Bytes::from(self.name)).abi_encode(buffer);
-        let buffer = keccak256(Bytes::from(self.version)).abi_encode(buffer);
-        let buffer = self.chain_id.abi_encode(buffer);
-        let buffer = self.verifying_contract.abi_encode(buffer);
-        buffer
-    }
+    chain_id: Option<u256>,
+    /// The address of the contract that will verify the signature (rightmost 20 bytes)
+    verifying_contract: Option<b256>,
+    /// A disambiguating salt
+    salt: Option<b256>,
 }
 
 impl EIP712Domain {
@@ -195,36 +211,48 @@ impl EIP712Domain {
     ///
     /// # Arguments
     ///
-    /// * `domain_name`: [String] - The name of the signing domain
-    /// * `version`: [String] - The version of the signing domain
-    /// * `chain_id`: [u256] - The chain ID where the contract is deployed
-    /// * `verifying_contract`: [b256] - The address (last 20-Bytes) of the contract that will verify the signature
+    /// * `name`: [Option<String>] - The name of the signing domain
+    /// * `version`: [Option<String>] - The version of the signing domain
+    /// * `chain_id`: [Option<u256>] - The chain ID where the contract is deployed
+    /// * `verifying_contract`: [Option<ContractId>] - The contract that will verify the signature.
+    ///   Only the rightmost 20 bytes are retained to match Ethereum's 20-byte address scheme.
+    /// * `salt`: [Option<b256>] - An optional disambiguating salt
     ///
     /// # Returns
     ///
     /// * [EIP712Domain] - A new instance of EIP712Domain with the provided parameters
     ///
     pub fn new(
-        domain_name: String,
-        version: String,
-        chain_id: u256,
-        verifying_contract: ContractId,
+        name: Option<String>,
+        version: Option<String>,
+        chain_id: Option<u256>,
+        verifying_contract: Option<ContractId>,
+        salt: Option<b256>,
     ) -> EIP712Domain {
-        // Take only the rightmost 20 bytes from a 32-byte Fuel ContractId
-        let mut verifying_contract_last_20 = Bytes::with_capacity(32);
-        let mut i = 0;
-        while i < 12 {
-            verifying_contract_last_20.push(0);
-            i += 1;
-        }
-        let (_, last_20): (Bytes, Bytes) = verifying_contract.bits().to_be_bytes().split_at(12);
-        verifying_contract_last_20.append(last_20);
-
-        EIP712Domain {
-            name: domain_name,
-            version: version,
-            chain_id: chain_id,
-            verifying_contract: verifying_contract_last_20.try_into().unwrap(),
+        match verifying_contract {
+            Some(bits) => {
+                // An EVM address is only 20 bytes, so the first 12 are set to zero
+                let mut local_bits = bits.bits();
+                asm(r1: local_bits) {
+                    mcli r1 i12;
+                };
+                EIP712Domain {
+                    name,
+                    version,
+                    chain_id,
+                    verifying_contract: Some(local_bits),
+                    salt,
+                }
+            },
+            None => {
+                EIP712Domain {
+                    name,
+                    version,
+                    chain_id,
+                    verifying_contract: None,
+                    salt,
+                }
+            }
         }
     }
 
@@ -232,166 +260,264 @@ impl EIP712Domain {
     ///
     /// # Additional Information
     ///
-    /// Utilizes AbiEncode for EIP712Domain
+    /// Dynamically builds the type hash string including only the fields that are
+    /// Some. This is the `domainSeparator` as defined in https://eips.ethereum.org/EIPS/eip-712
     ///
     /// # Returns
     ///
     /// * [b256] - The Keccak256 hash of the encoded domain parameters
     ///
     pub fn domain_hash(self) -> b256 {
-        let buffer = self.abi_encode(Buffer::new());
-        let encoded = buffer.as_raw_slice();
-        let bytes = Bytes::from(encoded);
-        keccak256(bytes)
+        let mut encoded: [b256; 6] = [
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+        ];
+        let mut type_hash_string = Bytes::new();
+        let mut total_bytes = 32;
+        let mut needs_comma = false;
+
+        type_hash_string.append(String::from_ascii_str("EIP712Domain(").as_bytes());
+
+        if self.name.is_some() {
+            type_hash_string.append(String::from_ascii_str("string name").as_bytes());
+            asm(
+                ptr: self.name.unwrap().ptr(),
+                len: self.name.unwrap().as_str().len(),
+                dst: encoded,
+                offset_bytes: total_bytes,
+                offset_ptr,
+            ) {
+                add offset_ptr dst offset_bytes;
+                k256 offset_ptr ptr len;
+            }
+            total_bytes += 32;
+            needs_comma = true;
+        }
+
+        if self.version.is_some() {
+            if needs_comma {
+                type_hash_string.append(String::from_ascii_str(",string version").as_bytes());
+            } else {
+                type_hash_string.append(String::from_ascii_str("string version").as_bytes());
+            }
+            asm(
+                ptr: self.version.unwrap().ptr(),
+                len: self.version.unwrap().as_str().len(),
+                dst: encoded,
+                offset_bytes: total_bytes,
+                offset_ptr,
+            ) {
+                add offset_ptr dst offset_bytes;
+                k256 offset_ptr ptr len;
+            }
+            total_bytes += 32;
+            needs_comma = true;
+        }
+
+        if self.chain_id.is_some() {
+            if needs_comma {
+                type_hash_string.append(String::from_ascii_str(",uint256 chainId").as_bytes());
+            } else {
+                type_hash_string.append(String::from_ascii_str("uint256 chainId").as_bytes());
+            }
+            asm(
+                dst: encoded,
+                src: self.chain_id.unwrap(),
+                bytes: 32,
+                offset_bytes: total_bytes,
+                offset_ptr,
+            ) {
+                add offset_ptr dst offset_bytes;
+                mcp offset_ptr src bytes;
+            };
+            total_bytes += 32;
+            needs_comma = true;
+        }
+
+        if self.verifying_contract.is_some() {
+            if needs_comma {
+                type_hash_string.append(String::from_ascii_str(",address verifyingContract").as_bytes());
+            } else {
+                type_hash_string.append(String::from_ascii_str("address verifyingContract").as_bytes());
+            }
+            asm(
+                dst: encoded,
+                src: self.verifying_contract.unwrap(),
+                bytes: 32,
+                offset_bytes: total_bytes,
+                offset_ptr,
+            ) {
+                add offset_ptr dst offset_bytes;
+                mcp offset_ptr src bytes;
+            };
+            total_bytes += 32;
+            needs_comma = true;
+        }
+
+        if self.salt.is_some() {
+            if needs_comma {
+                type_hash_string.append(String::from_ascii_str(",bytes32 salt").as_bytes());
+            } else {
+                type_hash_string.append(String::from_ascii_str("bytes32 salt").as_bytes());
+            }
+            asm(
+                dst: encoded,
+                src: self.salt.unwrap(),
+                bytes: 32,
+                offset_bytes: total_bytes,
+                offset_ptr,
+            ) {
+                add offset_ptr dst offset_bytes;
+                mcp offset_ptr src bytes;
+            };
+            total_bytes += 32;
+        }
+
+        type_hash_string.append(String::from_ascii_str(")").as_bytes());
+        asm(
+            ptr: type_hash_string.ptr(),
+            len: type_hash_string.len(),
+            dst: encoded,
+        ) {
+            k256 dst ptr len;
+        }
+
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded, bytes: total_bytes) {
+            k256 hash ptr bytes;
+            hash: b256
+        }
     }
 }
 
-/// Trait for types that can be hashed in a structured way
-///
-pub trait TypedDataHash {
-    /// The type hash constant for this struct
-    fn type_hash() -> b256;
-
-    /// Return the Keccak256 hash of the encoded typed structured data.
-    ///
-    /// # Arguments
-    ///
-    /// * `self` : [<custom_struct>] - A custom data structure used by the SRC16 validator.
-    /// # Returns
-    ///
-    /// * [b256] - The Keccak256 hash of the encoded structured data
-    ///
-    /// # Additional Information
-    ///
-    /// This is a per-program implementation. This function should be implemented
-    /// for the <custom_struct>. The DataEncoder can be used to encoded known data types.
-    ///
-    /// Implementors should ensure their hash computation follows the SRC16 specification.
-    ///
-    /// # Example
-    ///
-    /// ```sway
-    /// use src16::{SRC16, TypedDataHash};
-    ///
-    /// impl TypedDataHash for <custom_struct> {
-    ///     fn struct_hash(self) -> b256 {
-    ///         let mut encoded = Bytes::new();
-    ///
-    ///         ... implement encodeData for S using DataEncoder ...
-    ///
-    ///         keccak256(encoded)
-    /// }
-    /// ```
-    ///
-    fn struct_hash(self) -> b256;
+/// Selects the encoding variant — Fuel-native (SRC16) or Ethereum-compatible (EIP712).
+pub enum Encoding {
+    SRC16: (),
+    EIP712: (),
 }
 
-/// Holds the signing domain and types data hash used by DomainHash.
-pub struct SRC16Payload<D> {
-    pub domain: D,
-    pub data_hash: b256,
+/// Wraps either a Fuel-native or Ethereum-compatible domain separator.
+pub enum Domain {
+    SRC16Domain: SRC16Domain,
+    EIP712Domain: EIP712Domain,
 }
 
-impl<D> SRC16Payload<D> {
-    /// Computes the final encoded hash according to SRC16/EIP712 specification
-    ///
-    /// # Additional Information
-    ///
-    /// The encoding follows this scheme:
-    /// 1. Add prefix bytes \x19\x01
-    /// 2. Add domain separator hash from either SRC16Domain or EIP712Domain
-    /// 3. Add struct data hash
-    /// 4. Compute final Keccak256 hash
-    ///
-    /// # Arguments
-    ///
-    /// * `self`: [SRC16Payload<D>] - The payload containing domain parameters and data hash
-    ///
-    /// # Returns
-    ///
-    /// * [Option<b256>] - The final encoded hash, or None if encoding fails
-    ///
-    /// # Examples
-    ///
-    /// ```sway
-    /// fn encode_mail_data(mail: Mail, domain: SRC16Domain) {
-    ///     let payload = SRC16Payload {
-    ///         domain: domain,
-    ///         data_hash: mail.struct_hash(),
-    ///     };
-    ///     let final_hash = payload.encode_hash();
-    /// }
-    /// ```
-    pub fn encode_hash(self) -> Option<b256>
-    where
-        D: DomainHash,
-    {
-        let domain_separator_bytes = self.domain.domain_hash().to_be_bytes();
-        let data_hash_bytes = self.data_hash.to_be_bytes();
-        let mut digest_input = Bytes::with_capacity(66);
-        digest_input.push(0x19);
-        digest_input.push(0x01);
-        digest_input.append(domain_separator_bytes);
-        digest_input.append(data_hash_bytes);
-        let final_hash = keccak256(digest_input);
-
-        Some(final_hash)
+impl Domain {
+    pub fn domain_hash(self) -> b256 {
+        match self {
+            Self::SRC16Domain(domain) => domain.domain_hash(),
+            Self::EIP712Domain(domain) => domain.domain_hash(),
+        }
     }
 }
 
-/// Trait for domain types that can be hashed
-pub trait DomainHash {
-    fn domain_hash(self) -> b256;
+/// Standard ABI for contracts that support SRC16 typed structured data signing.
+abi SRC16Base {
+    /// Returns the Keccak256 hash of the domain separator for the given encoding.
+    fn domain_separator_hash(encoding: Encoding) -> b256;
+
+    /// Returns the Keccak256 type hash of the contract's primary data type for the given encoding.
+    fn data_type_hash(encoding: Encoding) -> b256;
+
+    /// Returns the domain separator for the given encoding.
+    fn domain_separator(encoding: Encoding) -> Domain;
 }
 
-/// Implementation of domain hashing for both SRC16 and EIP712 domains
+/// Trait for types that can be encoded as SRC16 typed structured data.
 ///
 /// # Additional Information
 ///
-/// Both domain types provide their own domain_hash() implementation following their
-/// respective encoding schemes:
-/// * SRC16Domain uses "SRC16Domain(string name,string version,uint256 chainId,address verifyingContract)"
-/// * EIP712Domain uses "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+/// Implementors provide `type_hash` and `struct_hash` for both SRC16 and EIP712
+/// encodings. The default `encode` method combines them with the domain separator
+/// following the `\x19\x01 ‖ domainHash ‖ structHash` pattern.
 ///
-/// # Returns
+/// # Example
 ///
-/// * [b256] - The Keccak256 hash of the encoded domain parameters
+/// ```sway
+/// const MAIL_TYPE_HASH: b256 = 0x536e54c54e6699204b424f41f6dea846ee38ac369afec3e7c141d2c92c65e67f;
 ///
-impl DomainHash for SRC16Domain {
-    fn domain_hash(self) -> b256 {
-        self.domain_hash()
+/// impl SRC16Encode for Mail {
+///     fn type_hash(encoding: Encoding) -> b256 {
+///         MAIL_TYPE_HASH
+///     }
+///
+///     fn struct_hash(self, encoding: Encoding) -> b256 {
+///         let mut encoded = Bytes::new();
+///         encoded.append(MAIL_TYPE_HASH.to_be_bytes());
+///         encoded.append(DataEncoder::encode_address(self.from).to_be_bytes());
+///         encoded.append(DataEncoder::encode_address(self.to).to_be_bytes());
+///         encoded.append(DataEncoder::encode_string(self.contents).to_be_bytes());
+///         let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+///         asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+///             k256 hash ptr len;
+///             hash: b256
+///         }
+///     }
+/// }
+/// ```
+pub trait SRC16Encode {
+    /// Returns the Keccak256 type hash for this struct under the given encoding.
+    fn type_hash(encoding: Encoding) -> b256;
+
+    /// Returns the Keccak256 struct hash (type_hash ‖ encode_data) for the given encoding.
+    fn struct_hash(self, encoding: Encoding) -> b256;
+} {
+    /// Computes the final SRC16/EIP712 encoded hash: `keccak256(\x19\x01 ‖ domainHash ‖ structHash)`.
+    fn encode(self, domain: Domain) -> b256 {
+        let encoding = match domain {
+            Domain::SRC16Domain => Encoding::SRC16,
+            Domain::EIP712Domain => Encoding::EIP712,
+        };
+
+        let domain_separator_bytes = domain.domain_hash();
+        let data_hash_bytes = self.struct_hash(encoding);
+
+        let mut encoded: [b256; 3] = [
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+        ];
+
+        // \x19\x01 prefix
+        asm(dst: encoded, src_1: 0x19, src_2: 0x01, bytes: 1) {
+            sb dst src_1 i0;
+            sb dst src_2 i1;
+        };
+
+        // domain separator hash at offset 2
+        asm(dst: encoded, src: domain_separator_bytes, bytes: 32, offset_bytes: 2, offset_ptr) {
+            add offset_ptr dst offset_bytes;
+            mcp offset_ptr src bytes;
+        };
+
+        // struct hash at offset 34
+        asm(dst: encoded, src: data_hash_bytes, bytes: 32, offset_bytes: 34, offset_ptr) {
+            add offset_ptr dst offset_bytes;
+            mcp offset_ptr src bytes;
+        };
+
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded, bytes: 66) {
+            k256 hash ptr bytes;
+            hash: b256
+        }
     }
 }
 
-impl DomainHash for EIP712Domain {
-    fn domain_hash(self) -> b256 {
-        self.domain_hash()
-    }
+/// Trait for managing a u64 replay protection nonce on a typed data struct.
+pub trait Nonce {
+    fn set_nonce(ref mut self, nonce: u64);
+    fn get_nonce(self) -> u64;
 }
 
-pub trait SRC16Encode<T> {
-    /// Returns the combined typed data hash according to SRC16 specification.
-    ///
-    /// # Arguments
-    ///
-    /// * `s`: [T] - A generic structured data type defined in the implementing program.
-    ///
-    /// # Additional Information
-    ///
-    /// This function produces a domain-bound hash by combining:
-    /// 1. The prefix bytes (\x19\x01)
-    /// 2. The domain separator hash
-    /// 3. The structured data hash
-    ///
-    /// # Arguments
-    ///
-    /// * `data_hash`: [b256] - The Keccak256 hash of the encoded structured data
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The combined typed data hash.
-    ///
-    fn encode<T>(s: T) -> b256;
+/// Trait for managing a u256 replay protection nonce on a typed data struct.
+pub trait ExtendedNonce {
+    fn set_nonce(ref mut self, nonce: u256);
+    fn get_nonce(self) -> u256;
 }
 
 /// This trait provides common encoding methods for different data types.
@@ -433,120 +559,54 @@ pub struct DataEncoder {}
 /// specification.
 ///
 impl TypedDataEncoder for DataEncoder {
-    /// Encodes a String value by taking the Keccak256 hash of its bytes.
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [String] - The string value to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The keccak256 hash of the string's bytes
+    /// Encodes a String value by taking the Keccak256 hash of its raw bytes.
     fn encode_string(value: String) -> b256 {
-        keccak256(Bytes::from(value))
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: value.ptr(), len: value.as_str().len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a u8 value into a 32-byte value (big-endian, padded with zeros).
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [u8] - The u8 value to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The value padded to 32 bytes
+    /// Encodes a u8 value into a 32-byte big-endian value.
     fn encode_u8(value: u8) -> b256 {
         asm(r1: (0, 0, 0, value.as_u64())) {
             r1: b256
         }
     }
 
-    /// Encodes a u16 value into a 32-byte value (big-endian, padded with zeros).
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [u16] - The u16 value to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The value padded to 32 bytes
+    /// Encodes a u16 value into a 32-byte big-endian value.
     fn encode_u16(value: u16) -> b256 {
         asm(r1: (0, 0, 0, value.as_u64())) {
             r1: b256
         }
     }
 
-    /// Encodes a u32 value into a 32-byte value (big-endian, padded with zeros).
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [u32] - The u32 value to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The value padded to 32 bytes
+    /// Encodes a u32 value into a 32-byte big-endian value.
     fn encode_u32(value: u32) -> b256 {
         asm(r1: (0, 0, 0, value.as_u64())) {
             r1: b256
         }
     }
 
-    /// Encodes a u64 value into a 32-byte value (big-endian, padded with zeros).
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [u64] - The u64 value to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The value padded to 32 bytes
+    /// Encodes a u64 value into a 32-byte big-endian value.
     fn encode_u64(value: u64) -> b256 {
         asm(r1: (0, 0, 0, value)) {
             r1: b256
         }
     }
 
-    /// Encodes a u256 value into a 32-byte value (big-endian, padded with zeros).
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [u256] - The u256 value to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The value padded to 32 bytes
+    /// Encodes a u256 value into a 32-byte value.
     fn encode_u256(value: u256) -> b256 {
         value.as_b256()
     }
 
-    /// Encodes as it original b256 value.
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [b256] - The b256 value to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The value padded to 32 bytes
+    /// Returns the b256 value as-is.
     fn encode_b256(value: b256) -> b256 {
         value
     }
 
-    /// Encodes a boolean value into a 32-byte value
-    ///
-    /// # Additional Information
-    ///
-    /// Encodes bool values as follows in b256 big-endian format:
-    /// * false = 0
-    /// * true = 1
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [bool] - The boolean to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The encoded value
+    /// Encodes a boolean value: false → 0, true → 1, both padded to 32 bytes.
     fn encode_bool(value: bool) -> b256 {
         let value_as_uint = if value { 1u64 } else { 0u64 };
         asm(r1: (0, 0, 0, value_as_uint)) {
@@ -554,22 +614,7 @@ impl TypedDataEncoder for DataEncoder {
         }
     }
 
-    /// Encodes a dynamic array of u8 values into a single 32-byte hash.
-    ///
-    /// # Additional Information
-    ///
-    /// The encoding follows this scheme:
-    /// 1. Each u8 value in the array is encoded to a b256
-    /// 2. The encoded values are concatenated in order
-    /// 3. The concatenated bytes are hashed with Keccak256
-    ///
-    /// # Arguments
-    ///
-    /// * `array`: [Vec<u8>] - The array of u8 values to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The Keccak256 hash of the concatenated encoded values
+    /// Encodes a dynamic array of u8 values as keccak256 of their concatenated 32-byte encodings.
     fn dynamic_u8_array(array: Vec<u8>) -> b256 {
         let mut encoded = Bytes::new();
         for v in array.iter() {
@@ -580,25 +625,14 @@ impl TypedDataEncoder for DataEncoder {
                     .to_be_bytes(),
             );
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a dynamic array of u16 values into a single 32-byte hash.
-    ///
-    /// # Additional Information
-    ///
-    /// The encoding follows this scheme:
-    /// 1. Each u16 value in the array is encoded to a b256
-    /// 2. The encoded values are concatenated in order
-    /// 3. The concatenated bytes are hashed with Keccak256
-    ///
-    /// # Arguments
-    ///
-    /// * `array`: [Vec<u16>] - The array of u16 values to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The Keccak256 hash of the concatenated encoded values
+    /// Encodes a dynamic array of u16 values as keccak256 of their concatenated 32-byte encodings.
     fn dynamic_u16_array(array: Vec<u16>) -> b256 {
         let mut encoded = Bytes::new();
         for v in array.iter() {
@@ -609,25 +643,14 @@ impl TypedDataEncoder for DataEncoder {
                     .to_be_bytes(),
             );
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a dynamic array of u32 values into a single 32-byte hash.
-    ///
-    /// # Additional Information
-    ///
-    /// The encoding follows this scheme:
-    /// 1. Each u32 value in the array is encoded to a b256
-    /// 2. The encoded values are concatenated in order
-    /// 3. The concatenated bytes are hashed with Keccak256
-    ///
-    /// # Arguments
-    ///
-    /// * `array`: [Vec<u32>] - The array of u32 values to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The Keccak256 hash of the concatenated encoded values
+    /// Encodes a dynamic array of u32 values as keccak256 of their concatenated 32-byte encodings.
     fn dynamic_u32_array(array: Vec<u32>) -> b256 {
         let mut encoded = Bytes::new();
         for v in array.iter() {
@@ -638,25 +661,14 @@ impl TypedDataEncoder for DataEncoder {
                     .to_be_bytes(),
             );
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a dynamic array of u64 values into a single 32-byte hash.
-    ///
-    /// # Additional Information
-    ///
-    /// The encoding follows this scheme:
-    /// 1. Each u64 value in the array is encoded to a b256
-    /// 2. The encoded values are concatenated in order
-    /// 3. The concatenated bytes are hashed with Keccak256
-    ///
-    /// # Arguments
-    ///
-    /// * `array`: [Vec<u64>] - The array of u64 values to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The Keccak256 hash of the concatenated encoded values
+    /// Encodes a dynamic array of u64 values as keccak256 of their concatenated 32-byte encodings.
     fn dynamic_u64_array(array: Vec<u64>) -> b256 {
         let mut encoded = Bytes::new();
         for v in array.iter() {
@@ -664,96 +676,50 @@ impl TypedDataEncoder for DataEncoder {
                 r1: b256
             }).to_be_bytes());
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a dynamic array of u256 values into a single 32-byte hash.
-    ///
-    /// # Additional Information
-    ///
-    /// The encoding follows this scheme:
-    /// 1. Each u256 value in the array is encoded to a b256
-    /// 2. The encoded values are concatenated in order
-    /// 3. The concatenated bytes are hashed with Keccak256
-    ///
-    /// # Arguments
-    ///
-    /// * `array`: [Vec<u256>] - The array of u256 values to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The Keccak256 hash of the concatenated encoded values
+    /// Encodes a dynamic array of u256 values as keccak256 of their concatenated 32-byte encodings.
     fn dynamic_u256_array(array: Vec<u256>) -> b256 {
         let mut encoded = Bytes::new();
         for v in array.iter() {
             encoded.append(v.to_be_bytes());
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a dynamic array of b256 values into a single 32-byte hash.
-    ///
-    /// # Additional Information
-    ///
-    /// The encoding follows this scheme:
-    /// 1. Each b256 value in the array is encoded to a b256
-    /// 2. The encoded values are concatenated in order
-    /// 3. The concatenated bytes are hashed with Keccak256
-    ///
-    /// # Arguments
-    ///
-    /// * `array`: [Vec<b256>] - The array of b256 values to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The Keccak256 hash of the concatenated encoded values
+    /// Encodes a dynamic array of b256 values as keccak256 of their concatenated encodings.
     fn dynamic_b256_array(array: Vec<b256>) -> b256 {
         let mut encoded = Bytes::new();
         for v in array.iter() {
             encoded.append(v.to_be_bytes());
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes an Address into a 32-byte value.
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [Address] - The address to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The address as a b256
+    /// Encodes an Address as its underlying b256.
     fn encode_address(value: Address) -> b256 {
         value.into()
     }
 
-    /// Encodes a ContractId into a 32-byte value.
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [ContractId] - The contract ID to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The contract ID as a b256
+    /// Encodes a ContractId as its underlying b256.
     fn encode_contract_id(value: ContractId) -> b256 {
         value.into()
     }
 
-    /// Encodes an Identity enum into a 32-byte value.
-    ///
-    /// # Additional Information
-    ///
-    /// Handles both Address and ContractId variants by accessing their underlying b256 representation.
-    ///
-    /// # Arguments
-    ///
-    /// * `value`: [Identity] - The identity to encode
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The encoded identity value
+    /// Encodes an Identity (Address or ContractId) as its underlying b256.
     fn encode_identity(value: Identity) -> b256 {
         match value {
             Identity::Address(addr) => addr.bits(),
@@ -778,23 +744,6 @@ pub enum EncoderType {
 
 /// This trait provides standard methods for encoding a fixed array of typed
 /// values into a single 32-byte hash.
-///
-/// # Additional Information
-///
-/// The encoding follows this scheme:
-/// 1. Each typed value in the array is encoded to a b256 using
-///    the respective DataEncoder method.
-/// 2. The encoded values are concatenated in order
-/// 3. The concatenated bytes are hashed with Keccak256
-///
-/// # Arguments
-///
-/// * `slice`: [raw_slice] - The raw slice containing the typed array
-///
-/// # Returns
-///
-/// * [b256] - The Keccak256 hash of the concatenated encoded values
-///
 pub trait FixedDataEncoder {
     fn encode_fixed_string_array(slice: raw_slice) -> b256;
     fn encode_fixed_u8_array(slice: raw_slice) -> b256;
@@ -809,177 +758,179 @@ pub trait FixedDataEncoder {
 }
 
 impl FixedDataEncoder for DataEncoder {
-    /// Encodes a fixed array of String values into a single 32-byte hash.
     fn encode_fixed_string_array(slice: raw_slice) -> b256 {
         let mut encoded = Bytes::new();
         let len = slice.len::<String>();
         let ptr = slice.ptr();
-
         let mut i = 0;
         while i < len {
             let item = ptr.add::<String>(i).read::<String>();
             encoded.append(DataEncoder::encode_string(item).to_be_bytes());
             i += 1;
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a fixed array of u8 values into a single 32-byte hash.
     fn encode_fixed_u8_array(slice: raw_slice) -> b256 {
         let mut encoded = Bytes::new();
         let len = slice.len::<u8>();
         let ptr = slice.ptr();
-
         let mut i = 0;
         while i < len {
             let item = ptr.add::<u8>(i).read::<u8>();
             encoded.append(DataEncoder::encode_u8(item).to_be_bytes());
             i += 1;
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a fixed array of u16 values into a single 32-byte hash.
     fn encode_fixed_u16_array(slice: raw_slice) -> b256 {
         let mut encoded = Bytes::new();
         let len = slice.len::<u16>();
         let ptr = slice.ptr();
-
         let mut i = 0;
         while i < len {
             let item = ptr.add::<u16>(i).read::<u16>();
             encoded.append(DataEncoder::encode_u16(item).to_be_bytes());
             i += 1;
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a fixed array of u32 values into a single 32-byte hash.
     fn encode_fixed_u32_array(slice: raw_slice) -> b256 {
         let mut encoded = Bytes::new();
         let len = slice.len::<u32>();
         let ptr = slice.ptr();
-
         let mut i = 0;
         while i < len {
             let item = ptr.add::<u32>(i).read::<u32>();
             encoded.append(DataEncoder::encode_u32(item).to_be_bytes());
             i += 1;
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a fixed array of u64 values into a single 32-byte hash.
     fn encode_fixed_u64_array(slice: raw_slice) -> b256 {
         let mut encoded = Bytes::new();
         let len = slice.len::<u64>();
         let ptr = slice.ptr();
-
         let mut i = 0;
         while i < len {
             let item = ptr.add::<u64>(i).read::<u64>();
             encoded.append(DataEncoder::encode_u64(item).to_be_bytes());
             i += 1;
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a fixed array of u256 values into a single 32-byte hash.
     fn encode_fixed_u256_array(slice: raw_slice) -> b256 {
         let mut encoded = Bytes::new();
         let len = slice.len::<u256>();
         let ptr = slice.ptr();
-
         let mut i = 0;
         while i < len {
             let item = ptr.add::<u256>(i).read::<u256>();
             encoded.append(DataEncoder::encode_u256(item).to_be_bytes());
             i += 1;
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a fixed array of b256 values into a single 32-byte hash.
     fn encode_fixed_b256_array(slice: raw_slice) -> b256 {
         let mut encoded = Bytes::new();
         let len = slice.len::<b256>();
         let ptr = slice.ptr();
-
         let mut i = 0;
         while i < len {
             let item = ptr.add::<b256>(i).read::<b256>();
             encoded.append(DataEncoder::encode_b256(item).to_be_bytes());
             i += 1;
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a fixed array of Address values into a single 32-byte hash.
     fn encode_fixed_address_array(slice: raw_slice) -> b256 {
         let mut encoded = Bytes::new();
         let len = slice.len::<Address>();
         let ptr = slice.ptr();
-
         let mut i = 0;
         while i < len {
             let item = ptr.add::<Address>(i).read::<Address>();
             encoded.append(DataEncoder::encode_address(item).to_be_bytes());
             i += 1;
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a fixed array of ContractId values into a single 32-byte hash.
     fn encode_fixed_contract_id_array(slice: raw_slice) -> b256 {
         let mut encoded = Bytes::new();
         let len = slice.len::<ContractId>();
         let ptr = slice.ptr();
-
         let mut i = 0;
         while i < len {
             let item = ptr.add::<ContractId>(i).read::<ContractId>();
             encoded.append(DataEncoder::encode_contract_id(item).to_be_bytes());
             i += 1;
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 
-    /// Encodes a fixed array of Identity values into a single 32-byte hash
     fn encode_fixed_identity_array(slice: raw_slice) -> b256 {
         let mut encoded = Bytes::new();
         let len = slice.len::<Identity>();
         let ptr = slice.ptr();
-
         let mut i = 0;
         while i < len {
             let item = ptr.add::<Identity>(i).read::<Identity>();
             encoded.append(DataEncoder::encode_identity(item).to_be_bytes());
             i += 1;
         }
-        keccak256(encoded)
+        let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(hash: result_buffer, ptr: encoded.ptr(), len: encoded.len()) {
+            k256 hash ptr len;
+            hash: b256
+        }
     }
 }
 
 /// This trait provides encoding functionality for fixed-length arrays of different types.
 pub trait FixedArrayEncoder {
-    /// Encodes a fixed-length array into a 32-byte hash based on the specified encoder type.
-    ///
-    /// # Additional Information
-    ///
-    /// This function acts as a dispatcher that routes to specific encoding implementations
-    /// based on the provided EncoderType. The encoding follows this scheme:
-    /// 1. Each element is encoded according to its type-specific rules
-    /// 2. The encoded values are concatenated in order
-    /// 3. The concatenated bytes are hashed with Keccak256
-    ///
-    /// # Arguments
-    ///
-    /// * `slice`: [raw_slice] - The raw slice containing the array data
-    /// * `encoder_type`: [EncoderType] - The type of encoder to use for the array elements
-    ///
-    /// # Returns
-    ///
-    /// * [b256] - The Keccak256 hash of the concatenated encoded values
     fn encode_fixed_array(slice: raw_slice, encoder_type: EncoderType) -> b256;
 }
 

--- a/standards/src16/src/src16.sw
+++ b/standards/src16/src/src16.sw
@@ -489,13 +489,25 @@ pub trait SRC16Encode {
         };
 
         // domain separator hash at offset 2
-        asm(dst: encoded, src: domain_separator_bytes, bytes: 32, offset_bytes: 2, offset_ptr) {
+        asm(
+            dst: encoded,
+            src: domain_separator_bytes,
+            bytes: 32,
+            offset_bytes: 2,
+            offset_ptr,
+        ) {
             add offset_ptr dst offset_bytes;
             mcp offset_ptr src bytes;
         };
 
         // struct hash at offset 34
-        asm(dst: encoded, src: data_hash_bytes, bytes: 32, offset_bytes: 34, offset_ptr) {
+        asm(
+            dst: encoded,
+            src: data_hash_bytes,
+            bytes: 32,
+            offset_bytes: 34,
+            offset_ptr,
+        ) {
             add offset_ptr dst offset_bytes;
             mcp offset_ptr src bytes;
         };
@@ -562,7 +574,11 @@ impl TypedDataEncoder for DataEncoder {
     /// Encodes a String value by taking the Keccak256 hash of its raw bytes.
     fn encode_string(value: String) -> b256 {
         let result_buffer: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        asm(hash: result_buffer, ptr: value.ptr(), len: value.as_str().len()) {
+        asm(
+            hash: result_buffer,
+            ptr: value.ptr(),
+            len: value.as_str().len(),
+        ) {
             k256 hash ptr len;
             hash: b256
         }

--- a/standards/src17/README.md
+++ b/standards/src17/README.md
@@ -10,7 +10,7 @@ A standard interface for names on Fuel allows external applications to verify an
 
 A number of existing name service platforms already existed prior to the development of this standard. Notably the most well-known on the Ethereum Blockchain is the [Ethereum Name Service(ENS)](https://ens.domains/). This domain service has a major influence on other name services across multiple platforms. ENS pioneered name service platforms and this standard takes some inspiration from their resolver design.
 
-On Fuel, we have 2 existing name service platforms. These are [Bako ID](https://www.bako.id/) and [Fuel Name Service(FNS)](https://fuelname.com/). This standard was developed in close collaboration with these two platforms to ensure compatibility and ease of upgrade.
+On Fuel, we have 2 existing name service platforms. These are [Bako ID](https://app.bako.id/) and [Fuel Name Service(FNS)](https://fuelname.com/). This standard was developed in close collaboration with these two platforms to ensure compatibility and ease of upgrade.
 
 ## Specification
 


### PR DESCRIPTION
## Summary

Rewrites the SRC16 typed structured data standard to match the O2 production implementation. Fixes correctness issues with domain field encoding, raw hashing, and API design.

## Problems Fixed

### 1. Domain fields were required — EIP712 requires them to be optional

The previous `SRC16Domain` and `EIP712Domain` structs required all fields. EIP712 specifies that domain fields (`name`, `version`, `chainId`, `verifyingContract`, `salt`) are all optional — only the fields present are included in the type hash string and encoded data. A domain with only `name` and `chainId` must produce a different type hash than one with all five fields.

**Fix:** All domain fields are now `Option<T>`. The type hash string is built dynamically from only the `Some` fields (e.g. `"SRC16Domain(string name,u256 chain_id)"`). Missing fields are excluded entirely.

### 2. `chain_id` was `u64` instead of `u256`

EIP712 encodes `chainId` as a 256-bit integer. The previous implementation used `u64`, producing incorrect 32-byte encodings.

**Fix:** `chain_id: Option<u256>` in both domain structs.

### 3. `salt` field was missing

Both domain structs lacked the optional `salt` field present in the EIP712 spec.

**Fix:** `salt: Option<b256>` added to both `SRC16Domain` and `EIP712Domain`.

### 4. Stdlib `keccak256(Bytes)` is unsafe for EIP712

`std-0.70.2` includes two implementations of `impl Hash for Bytes` gated by `#[cfg(experimental_new_hashing)]`. The new implementation prepends an 8-byte u64 length before the content, which would silently corrupt every hash if that flag were enabled. This also applies to string encoding — `keccak256(Bytes::from(string))` goes through the same path.

EIP712 requires hashing only raw content bytes — no length prefix, no framing.

**Fix:** All hashing uses raw `k256` assembly (`k256 hash ptr len`) directly. This is immune to stdlib behavior changes and matches the FuelVM opcode semantics exactly.

### 5. `SRC16Encode<T>`, `TypedDataHash`, `SRC16Payload`, `DomainHash` removed

The previous API used a generic `SRC16Encode<T>` trait, a separate `TypedDataHash` trait for struct hashing, and `SRC16Payload<D>` to combine domain + data hash. This was redundant, non-idiomatic, and diverged from the O2 production usage.

**Fix:** Replaced with a single `SRC16Encode` trait matching O2 exactly:

```sway
pub trait SRC16Encode {
    fn type_hash(encoding: Encoding) -> b256;
    fn struct_hash(self, encoding: Encoding) -> b256;
} {
    fn encode(self, domain: Domain) -> b256 { ... } // provided default
}
```

The `encoding: Encoding` parameter allows a single impl to serve both SRC16 and EIP712 encodings. The default `encode` method handles the `\x19\x01 ‖ domainHash ‖ structHash` final hash automatically.

### 6. `SRC16` and `EIP712` ABIs replaced by unified `SRC16`

The previous standard exposed three separate ABIs (`SRC16Base`, `SRC16`, `EIP712`) that returned variant-specific domain types. This required contracts to implement multiple ABIs and made the interface asymmetric.

**Fix:** Single `SRC16` ABI taking `encoding: Encoding` to select the variant:

```sway
abi SRC16 {
    fn domain_separator_hash(encoding: Encoding) -> b256;
    fn data_type_hash(encoding: Encoding) -> b256;
    fn domain_separator(encoding: Encoding) -> Domain;
}
```

### 7. `Encoding` and `Domain` enums added

Added two enums from the O2 implementation:

- `Encoding` — selects `SRC16` (Fuel-native) or `EIP712` (Ethereum-compatible)
- `Domain` — wraps `SRC16Domain` or `EIP712Domain` with a unified `domain_hash()` method

The `Encoding` value is derived from the `Domain` variant inside `SRC16Encode::encode`, so callers only pass a `Domain` and the encoding is inferred automatically.

---

## Files Changed

| File | Change |
|------|--------|
| `standards/src16/src/src16.sw` | Full rewrite — see above |
| `examples/src16-typed-data/fuel_example/src/main.sw` | Updated to `SRC16Encode` + `Domain::SRC16Domain` |
| `examples/src16-typed-data/ethereum_example/src/main.sw` | Updated to `SRC16Encode` + `Domain::EIP712Domain` |
| `benchmarks/src16/src/src16_payload.sw` | Replaced `SRC16Payload` benchmarks with `SRC16Encode::encode` benchmarks |
| `benchmarks/src16/src/common.sw` | Removed unused `Buffer` fixture |
| `benchmarks/src16/src/src16_domain.sw` | Removed unused `fixture_create_buffer` import |
| `benchmarks/src16/src/eip712_domain.sw` | Removed unused `fixture_create_buffer` import |
| `standards/src16/README.md` | Updated spec, added `Encoding`/`Domain` docs, updated examples |
| `docs/src/src-16-typed-structured-data.md` | Same updates as README |

---

## Breaking Changes

Downstream code using `TypedDataHash`, `SRC16Payload`, `DomainHash`, `SRC16Encode<T>`, the `SRC16` ABI, or the `EIP712` ABI must be migrated to the new `SRC16Encode` trait and `SRC16Base` ABI.
