### PR TITLE
Make `build.sh` portable on macOS

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -115,7 +115,10 @@ build_one() {
     local project_dir="$2"
     local log_file="${logs_dir}/${project_name}.log"
 
-    if forc build --path "${project_dir}" "${FORC_BUILD_ARGS[@]}" > "${log_file}" 2>&1; then
+    # `${arr[@]+"${arr[@]}"}` guards against `set -u` aborting on an empty
+    # array: on Bash 3.2 (stock macOS) expanding an empty array with `[@]` is
+    # treated as an unbound variable and would abort the build.
+    if forc build --path "${project_dir}" ${FORC_BUILD_ARGS[@]+"${FORC_BUILD_ARGS[@]}"} > "${log_file}" 2>&1; then
         printf '%b %s\n' "${GREEN}✓${NC}" "${project_name}"
         echo "pass" > "${logs_dir}/${project_name}.status"
     else


### PR DESCRIPTION
## Changes

- Portability fix for expansion of empty arrays in `build.sh`.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.